### PR TITLE
Spring-clean the conf-mingw-w64- packages

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -58,7 +58,14 @@ jobs:
           opam-pin: false
           windows-environment: ${{ matrix.windows_environment }}
 
+      - name: Remove the compiler
+        run: |
+          opam switch set-invariant -n ${{ matrix.windows_environment == 'msys2' && 'msys2-mingw64' || 'host-system-mingw' }}
+          opam remove ocaml-compiler ocaml -y
+          opam switch set-invariant -n host-system-mingw
+
       - name: Install packages
+        if: always()
         run: |
           $failed = $false
           Foreach ($pkg in '${{ matrix.packages }}' -split ' ') {

--- a/packages/conf-mingw-w64-allegro5-i686/conf-mingw-w64-allegro5-i686.1/opam
+++ b/packages/conf-mingw-w64-allegro5-i686/conf-mingw-w64-allegro5-i686.1/opam
@@ -11,9 +11,9 @@ depends: [
   "msys2-mingw32" {os = "win32" & os-distribution = "msys2"}
   "conf-pkg-config" {build}
 ]
-synopsis: "allegro5 for i686 mingw-w64"
+synopsis: "Virtual package for allegro5 on i686 mingw-w64 (32-bit x86)"
 description:
-  "Ensure the i686 version of allegro5 for the mingw-w64 project is available"
+  "Ensures the i686 version of allegro5 for the mingw-w64 project is available"
 maintainer: "Sylvain Chiron <chironsylvain@orange.fr>"
 depexts: [
   ["mingw-w64-i686-allegro5"] {os = "win32" & os-distribution = "msys2"}

--- a/packages/conf-mingw-w64-allegro5-i686/conf-mingw-w64-allegro5-i686.1/opam
+++ b/packages/conf-mingw-w64-allegro5-i686/conf-mingw-w64-allegro5-i686.1/opam
@@ -15,7 +15,7 @@ depends: [
 synopsis: "Virtual package for allegro5 on i686 mingw-w64 (32-bit x86)"
 description:
   "Ensures the i686 version of allegro5 for the mingw-w64 project is available"
-maintainer: "Sylvain Chiron <chironsylvain@orange.fr>"
+maintainer: "David Allsopp <dra27@dra27.uk>"
 depexts: [
   ["mingw-w64-i686-allegro"] {os = "win32" & os-distribution = "msys2"}
 ]

--- a/packages/conf-mingw-w64-allegro5-i686/conf-mingw-w64-allegro5-i686.1/opam
+++ b/packages/conf-mingw-w64-allegro5-i686/conf-mingw-w64-allegro5-i686.1/opam
@@ -4,8 +4,8 @@ homepage: "https://liballeg.org"
 bug-reports: "https://github.com/ocaml/opam-repository/issues"
 license: "Giftware"
 flags: conf
-available: os = "win32"
-build: ["pkgconf" "--personality=i686-w64-mingw32" "allegro5"]
+available: os = "win32" & os-distribution = "msys2"
+build: ["pkgconf" "allegro-5"]
 depends: [
   "msys2" {build & os = "win32" & os-distribution = "msys2"}
   "msys2-mingw32" {os = "win32" & os-distribution = "msys2"}
@@ -17,5 +17,5 @@ description:
   "Ensures the i686 version of allegro5 for the mingw-w64 project is available"
 maintainer: "Sylvain Chiron <chironsylvain@orange.fr>"
 depexts: [
-  ["mingw-w64-i686-allegro5"] {os = "win32" & os-distribution = "msys2"}
+  ["mingw-w64-i686-allegro"] {os = "win32" & os-distribution = "msys2"}
 ]

--- a/packages/conf-mingw-w64-allegro5-i686/conf-mingw-w64-allegro5-i686.1/opam
+++ b/packages/conf-mingw-w64-allegro5-i686/conf-mingw-w64-allegro5-i686.1/opam
@@ -7,6 +7,8 @@ flags: conf
 available: os = "win32"
 build: ["pkgconf" "--personality=i686-w64-mingw32" "allegro5"]
 depends: [
+  "msys2" {build & os = "win32" & os-distribution = "msys2"}
+  "msys2-mingw32" {os = "win32" & os-distribution = "msys2"}
   "conf-pkg-config" {build}
 ]
 synopsis: "allegro5 for i686 mingw-w64"

--- a/packages/conf-mingw-w64-allegro5-i686/conf-mingw-w64-allegro5-i686.1/opam
+++ b/packages/conf-mingw-w64-allegro5-i686/conf-mingw-w64-allegro5-i686.1/opam
@@ -10,6 +10,7 @@ depends: [
   "msys2" {build & os = "win32" & os-distribution = "msys2"}
   "msys2-mingw32" {os = "win32" & os-distribution = "msys2"}
   "conf-pkg-config" {build}
+  "conf-mingw-w64-gcc-i686" {build}
 ]
 synopsis: "Virtual package for allegro5 on i686 mingw-w64 (32-bit x86)"
 description:

--- a/packages/conf-mingw-w64-allegro5-x86_64/conf-mingw-w64-allegro5-x86_64.1/opam
+++ b/packages/conf-mingw-w64-allegro5-x86_64/conf-mingw-w64-allegro5-x86_64.1/opam
@@ -11,9 +11,9 @@ depends: [
   "msys2-mingw64" {os = "win32" & os-distribution = "msys2"}
   "conf-pkg-config" {build}
 ]
-synopsis: "allegro5 for x86_64 mingw-w64"
+synopsis: "Virtual package for allegro5 on x86_64 mingw-w64 (64-bit x86_64)"
 description:
-  "Ensure the x86_64 version of allegro5 for the mingw-w64 project is available"
+  "Ensures the x86_64 version of allegro5 for the mingw-w64 project is available"
 maintainer: "Sylvain Chiron <chironsylvain@orange.fr>"
 depexts: [
   ["mingw-w64-x86_64-allegro5"] {os = "win32" & os-distribution = "msys2"}

--- a/packages/conf-mingw-w64-allegro5-x86_64/conf-mingw-w64-allegro5-x86_64.1/opam
+++ b/packages/conf-mingw-w64-allegro5-x86_64/conf-mingw-w64-allegro5-x86_64.1/opam
@@ -7,6 +7,8 @@ flags: conf
 available: os = "win32"
 build: ["pkgconf" "--personality=x86_64-w64-mingw32" "allegro5"]
 depends: [
+  "msys2" {build & os = "win32" & os-distribution = "msys2"}
+  "msys2-mingw64" {os = "win32" & os-distribution = "msys2"}
   "conf-pkg-config" {build}
 ]
 synopsis: "allegro5 for x86_64 mingw-w64"

--- a/packages/conf-mingw-w64-allegro5-x86_64/conf-mingw-w64-allegro5-x86_64.1/opam
+++ b/packages/conf-mingw-w64-allegro5-x86_64/conf-mingw-w64-allegro5-x86_64.1/opam
@@ -10,6 +10,7 @@ depends: [
   "msys2" {build & os = "win32" & os-distribution = "msys2"}
   "msys2-mingw64" {os = "win32" & os-distribution = "msys2"}
   "conf-pkg-config" {build}
+  "conf-mingw-w64-gcc-x86_64" {build}
 ]
 synopsis: "Virtual package for allegro5 on x86_64 mingw-w64 (64-bit x86_64)"
 description:

--- a/packages/conf-mingw-w64-allegro5-x86_64/conf-mingw-w64-allegro5-x86_64.1/opam
+++ b/packages/conf-mingw-w64-allegro5-x86_64/conf-mingw-w64-allegro5-x86_64.1/opam
@@ -15,7 +15,7 @@ depends: [
 synopsis: "Virtual package for allegro5 on x86_64 mingw-w64 (64-bit x86_64)"
 description:
   "Ensures the x86_64 version of allegro5 for the mingw-w64 project is available"
-maintainer: "Sylvain Chiron <chironsylvain@orange.fr>"
+maintainer: "David Allsopp <dra27@dra27.uk>"
 depexts: [
   ["mingw-w64-x86_64-allegro"] {os = "win32" & os-distribution = "msys2"}
 ]

--- a/packages/conf-mingw-w64-allegro5-x86_64/conf-mingw-w64-allegro5-x86_64.1/opam
+++ b/packages/conf-mingw-w64-allegro5-x86_64/conf-mingw-w64-allegro5-x86_64.1/opam
@@ -4,8 +4,8 @@ homepage: "https://liballeg.org"
 bug-reports: "https://github.com/ocaml/opam-repository/issues"
 license: "Giftware"
 flags: conf
-available: os = "win32"
-build: ["pkgconf" "--personality=x86_64-w64-mingw32" "allegro5"]
+available: os = "win32" & os-distribution = "msys2"
+build: ["pkgconf" "allegro-5"]
 depends: [
   "msys2" {build & os = "win32" & os-distribution = "msys2"}
   "msys2-mingw64" {os = "win32" & os-distribution = "msys2"}
@@ -17,5 +17,5 @@ description:
   "Ensures the x86_64 version of allegro5 for the mingw-w64 project is available"
 maintainer: "Sylvain Chiron <chironsylvain@orange.fr>"
 depexts: [
-  ["mingw-w64-x86_64-allegro5"] {os = "win32" & os-distribution = "msys2"}
+  ["mingw-w64-x86_64-allegro"] {os = "win32" & os-distribution = "msys2"}
 ]

--- a/packages/conf-mingw-w64-ao-i686/conf-mingw-w64-ao-i686.1/opam
+++ b/packages/conf-mingw-w64-ao-i686/conf-mingw-w64-ao-i686.1/opam
@@ -8,7 +8,7 @@ homepage: "https://www.xiph.org/ao/"
 bug-reports: "https://github.com/ocaml/opam-repository/issues"
 flags: conf
 available: os = "win32"
-build: ["pkgconf" "--personality=i686-w64-mingw32" "ao"]
+build: ["pkgconf" "--personality=i686-w64-mingw32" {os-distribution = "cygwin"} "ao"]
 depends: [
   "conf-pkg-config" {build}
   "conf-mingw-w64-gcc-i686" {build}

--- a/packages/conf-mingw-w64-ao-i686/conf-mingw-w64-ao-i686.1/opam
+++ b/packages/conf-mingw-w64-ao-i686/conf-mingw-w64-ao-i686.1/opam
@@ -1,7 +1,7 @@
 opam-version: "2.0"
 synopsis: "Virtual package for libao on i686 mingw-w64 (32-bit x86)"
 description: "Ensures the i686 version of libao for the mingw-w64 project is available"
-maintainer: "https://github.com/ocaml/opam-repository/issues"
+maintainer: "David Allsopp <dra27@dra27.uk>"
 authors: "libao dev team"
 license: "GPL-2.0-only"
 homepage: "https://www.xiph.org/ao/"

--- a/packages/conf-mingw-w64-ao-i686/conf-mingw-w64-ao-i686.1/opam
+++ b/packages/conf-mingw-w64-ao-i686/conf-mingw-w64-ao-i686.1/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-synopsis: "libao for i686 mingw-w64 (32-bit x86)"
+synopsis: "Virtual package for libao on i686 mingw-w64 (32-bit x86)"
 description: "Ensures the i686 version of libao for the mingw-w64 project is available"
 maintainer: "https://github.com/ocaml/opam-repository/issues"
 authors: "libao dev team"

--- a/packages/conf-mingw-w64-ao-i686/conf-mingw-w64-ao-i686.1/opam
+++ b/packages/conf-mingw-w64-ao-i686/conf-mingw-w64-ao-i686.1/opam
@@ -10,6 +10,8 @@ flags: conf
 available: os = "win32"
 build: ["pkgconf" "--personality=i686-w64-mingw32" {os-distribution = "cygwin"} "ao"]
 depends: [
+  "msys2" {build & os = "win32" & os-distribution = "msys2"}
+  "msys2-mingw32" {os = "win32" & os-distribution = "msys2"}
   "conf-pkg-config" {build}
   "conf-mingw-w64-gcc-i686" {build}
 ]

--- a/packages/conf-mingw-w64-ao-x86_64/conf-mingw-w64-ao-x86_64.1/opam
+++ b/packages/conf-mingw-w64-ao-x86_64/conf-mingw-w64-ao-x86_64.1/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-synopsis: "libao for x86_64 mingw-w64 (64-bit x86_64)"
+synopsis: "Virtual package for libao on x86_64 mingw-w64 (64-bit x86_64)"
 description: "Ensures the x86_64 version of libao for the mingw-w64 project is available"
 maintainer: "https://github.com/ocaml/opam-repository/issues"
 authors: "libao dev team"

--- a/packages/conf-mingw-w64-ao-x86_64/conf-mingw-w64-ao-x86_64.1/opam
+++ b/packages/conf-mingw-w64-ao-x86_64/conf-mingw-w64-ao-x86_64.1/opam
@@ -1,7 +1,7 @@
 opam-version: "2.0"
 synopsis: "Virtual package for libao on x86_64 mingw-w64 (64-bit x86_64)"
 description: "Ensures the x86_64 version of libao for the mingw-w64 project is available"
-maintainer: "https://github.com/ocaml/opam-repository/issues"
+maintainer: "David Allsopp <dra27@dra27.uk>"
 authors: "libao dev team"
 license: "GPL-2.0-only"
 homepage: "https://www.xiph.org/ao/"

--- a/packages/conf-mingw-w64-ao-x86_64/conf-mingw-w64-ao-x86_64.1/opam
+++ b/packages/conf-mingw-w64-ao-x86_64/conf-mingw-w64-ao-x86_64.1/opam
@@ -10,6 +10,8 @@ flags: conf
 available: os = "win32"
 build: ["pkgconf" "--personality=x86_64-w64-mingw32" {os-distribution = "cygwin"} "ao"]
 depends: [
+  "msys2" {build & os = "win32" & os-distribution = "msys2"}
+  "msys2-mingw64" {os = "win32" & os-distribution = "msys2"}
   "conf-pkg-config" {build}
   "conf-mingw-w64-gcc-x86_64" {build}
 ]

--- a/packages/conf-mingw-w64-ao-x86_64/conf-mingw-w64-ao-x86_64.1/opam
+++ b/packages/conf-mingw-w64-ao-x86_64/conf-mingw-w64-ao-x86_64.1/opam
@@ -8,7 +8,7 @@ homepage: "https://www.xiph.org/ao/"
 bug-reports: "https://github.com/ocaml/opam-repository/issues"
 flags: conf
 available: os = "win32"
-build: ["pkgconf" "--personality=x86_64-w64-mingw32" "ao"]
+build: ["pkgconf" "--personality=x86_64-w64-mingw32" {os-distribution = "cygwin"} "ao"]
 depends: [
   "conf-pkg-config" {build}
   "conf-mingw-w64-gcc-x86_64" {build}

--- a/packages/conf-mingw-w64-bzip2-i686/conf-mingw-w64-bzip2-i686.1/opam
+++ b/packages/conf-mingw-w64-bzip2-i686/conf-mingw-w64-bzip2-i686.1/opam
@@ -8,7 +8,9 @@ homepage: "https://sourceware.org/bzip2/"
 bug-reports: "https://github.com/ocaml/opam-repository/issues"
 flags: conf
 available: os = "win32"
-build: ["pkgconf" "--personality=i686-w64-mingw32" {os-distribution = "cygwin"} "bzip2"]
+# https://cygwin.com/cgi-bin2/package-cat.cgi?file=noarch%2Fmingw64-i686-bzip2%2Fmingw64-i686-bzip2-1.0.6-4
+# no bzip2.pc file in cygwin package
+build: ["pkgconf" "bzip2"] {os-distribution = "msys2"}
 depends: [
   "msys2" {build & os = "win32" & os-distribution = "msys2"}
   "msys2-mingw32" {os = "win32" & os-distribution = "msys2"}

--- a/packages/conf-mingw-w64-bzip2-i686/conf-mingw-w64-bzip2-i686.1/opam
+++ b/packages/conf-mingw-w64-bzip2-i686/conf-mingw-w64-bzip2-i686.1/opam
@@ -13,6 +13,7 @@ depends: [
   "msys2" {build & os = "win32" & os-distribution = "msys2"}
   "msys2-mingw32" {os = "win32" & os-distribution = "msys2"}
   "conf-pkg-config" {build}
+  "conf-mingw-w64-gcc-i686" {build}
 ]
 depexts: [
   ["mingw64-i686-bzip2"] {os = "win32" & os-distribution = "cygwin"}

--- a/packages/conf-mingw-w64-bzip2-i686/conf-mingw-w64-bzip2-i686.1/opam
+++ b/packages/conf-mingw-w64-bzip2-i686/conf-mingw-w64-bzip2-i686.1/opam
@@ -1,7 +1,7 @@
 opam-version: "2.0"
 synopsis: "Virtual package for bzip2 on i686 mingw-w64 (32-bit x86)"
 description: "Ensures the i686 version of bzip2 for the mingw-w64 project is available"
-maintainer: "Timothy Bourke <tim@tbrk.org>"
+maintainer: "David Allsopp <dra27@dra27.uk>"
 authors: ["Julian Seward"]
 license: "bzip2-1.0.6"
 homepage: "https://sourceware.org/bzip2/"

--- a/packages/conf-mingw-w64-bzip2-x86_64/conf-mingw-w64-bzip2-x86_64.1/opam
+++ b/packages/conf-mingw-w64-bzip2-x86_64/conf-mingw-w64-bzip2-x86_64.1/opam
@@ -1,7 +1,7 @@
 opam-version: "2.0"
 synopsis: "Virtual package for bzip2 on x86_64 mingw-w64 (64-bit x86_64)"
 description: "Ensures the x86_64 version of bzip2 for the mingw-w64 project is available"
-maintainer: "Timothy Bourke <tim@tbrk.org>"
+maintainer: "David Allsopp <dra27@dra27.uk>"
 authors: ["Julian Seward"]
 license: "bzip2-1.0.6"
 homepage: "https://sourceware.org/bzip2/"

--- a/packages/conf-mingw-w64-bzip2-x86_64/conf-mingw-w64-bzip2-x86_64.1/opam
+++ b/packages/conf-mingw-w64-bzip2-x86_64/conf-mingw-w64-bzip2-x86_64.1/opam
@@ -8,14 +8,9 @@ homepage: "https://sourceware.org/bzip2/"
 bug-reports: "https://github.com/ocaml/opam-repository/issues"
 flags: conf
 available: os = "win32"
-build: [
-    "true"	{os = "win32" & os-distribution = "cygwin"}
-		# https://cygwin.com/cgi-bin2/package-cat.cgi?file=noarch%2Fmingw64-x86_64-bzip2%2Fmingw64-x86_64-bzip2-1.0.6-4
-		# no bzip2.pc file in cygwin package
-    "pkgconf"
-    "--personality=x86_64-w64-mingw32" {os-distribution = "cygwin"}
-    "bzip2"
-]
+# https://cygwin.com/cgi-bin2/package-cat.cgi?file=noarch%2Fmingw64-x86_64-bzip2%2Fmingw64-x86_64-bzip2-1.0.6-4
+# no bzip2.pc file in cygwin package
+build: ["pkgconf" "bzip2"] {os-distribution = "msys2"}
 depends: [
   "msys2" {build & os = "win32" & os-distribution = "msys2"}
   "msys2-mingw64" {os = "win32" & os-distribution = "msys2"}

--- a/packages/conf-mingw-w64-bzip2-x86_64/conf-mingw-w64-bzip2-x86_64.1/opam
+++ b/packages/conf-mingw-w64-bzip2-x86_64/conf-mingw-w64-bzip2-x86_64.1/opam
@@ -20,6 +20,7 @@ depends: [
   "msys2" {build & os = "win32" & os-distribution = "msys2"}
   "msys2-mingw64" {os = "win32" & os-distribution = "msys2"}
   "conf-pkg-config" {build}
+  "conf-mingw-w64-gcc-x86_64" {build}
 ]
 depexts: [
   ["mingw64-x86_64-bzip2"] {os = "win32" & os-distribution = "cygwin"}

--- a/packages/conf-mingw-w64-cairo-i686/conf-mingw-w64-cairo-i686.1/opam
+++ b/packages/conf-mingw-w64-cairo-i686/conf-mingw-w64-cairo-i686.1/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-synopsis: "Provides cairo for i686 mingw-w64 (32-bit x86)"
-description: "Ensure that the i686 version of cairo for the mingw-w64 project is available"
+synopsis: "Virtual package for cairo on i686 mingw-w64 (32-bit x86)"
+description: "Ensures the i686 version of cairo for the mingw-w64 project is available"
 maintainer: "https://github.com/ocaml/opam-repository/issues"
 authors: ["Keith Packard" "Carl Worth" "Behdad Esfahbod"]
 license: ["LGPL-2.1-only" "MPL-1.1"]

--- a/packages/conf-mingw-w64-cairo-i686/conf-mingw-w64-cairo-i686.1/opam
+++ b/packages/conf-mingw-w64-cairo-i686/conf-mingw-w64-cairo-i686.1/opam
@@ -1,7 +1,7 @@
 opam-version: "2.0"
 synopsis: "Virtual package for cairo on i686 mingw-w64 (32-bit x86)"
 description: "Ensures the i686 version of cairo for the mingw-w64 project is available"
-maintainer: "https://github.com/ocaml/opam-repository/issues"
+maintainer: "David Allsopp <dra27@dra27.uk>"
 authors: ["Keith Packard" "Carl Worth" "Behdad Esfahbod"]
 license: ["LGPL-2.1-only" "MPL-1.1"]
 homepage: "http://cairographics.org/"

--- a/packages/conf-mingw-w64-cairo-i686/conf-mingw-w64-cairo-i686.1/opam
+++ b/packages/conf-mingw-w64-cairo-i686/conf-mingw-w64-cairo-i686.1/opam
@@ -8,7 +8,7 @@ homepage: "http://cairographics.org/"
 bug-reports: "https://github.com/ocaml/opam-repository/issues"
 flags: conf
 available: os = "win32"
-build: ["pkgconf" "--personality=i686-w64-mingw32" "cairo"]
+build: ["pkgconf" "--personality=i686-w64-mingw32" {os-distribution = "cygwin"} "cairo"]
 depends: [
   "conf-pkg-config" {build}
   "conf-mingw-w64-gcc-i686" {build}

--- a/packages/conf-mingw-w64-cairo-i686/conf-mingw-w64-cairo-i686.1/opam
+++ b/packages/conf-mingw-w64-cairo-i686/conf-mingw-w64-cairo-i686.1/opam
@@ -10,6 +10,8 @@ flags: conf
 available: os = "win32"
 build: ["pkgconf" "--personality=i686-w64-mingw32" {os-distribution = "cygwin"} "cairo"]
 depends: [
+  "msys2" {build & os = "win32" & os-distribution = "msys2"}
+  "msys2-mingw32" {os = "win32" & os-distribution = "msys2"}
   "conf-pkg-config" {build}
   "conf-mingw-w64-gcc-i686" {build}
 ]

--- a/packages/conf-mingw-w64-cairo-x86_64/conf-mingw-w64-cairo-x86_64.1/opam
+++ b/packages/conf-mingw-w64-cairo-x86_64/conf-mingw-w64-cairo-x86_64.1/opam
@@ -10,6 +10,8 @@ flags: conf
 available: os = "win32"
 build: ["pkgconf" "--personality=x86_64-w64-mingw32" {os-distribution = "cygwin"} "cairo"]
 depends: [
+  "msys2" {build & os = "win32" & os-distribution = "msys2"}
+  "msys2-mingw64" {os = "win32" & os-distribution = "msys2"}
   "conf-pkg-config" {build}
   "conf-mingw-w64-gcc-x86_64" {build}
 ]

--- a/packages/conf-mingw-w64-cairo-x86_64/conf-mingw-w64-cairo-x86_64.1/opam
+++ b/packages/conf-mingw-w64-cairo-x86_64/conf-mingw-w64-cairo-x86_64.1/opam
@@ -1,7 +1,7 @@
 opam-version: "2.0"
 synopsis: "Virtual package for cairo on x86_64 mingw-w64 (64-bit x86_64)"
 description: "Ensures the x86_64 version of cairo for the mingw-w64 project is available"
-maintainer: "https://github.com/ocaml/opam-repository/issues"
+maintainer: "David Allsopp <dra27@dra27.uk>"
 authors: ["Keith Packard" "Carl Worth" "Behdad Esfahbod"]
 license: ["LGPL-2.1-only" "MPL-1.1"]
 homepage: "http://cairographics.org/"

--- a/packages/conf-mingw-w64-cairo-x86_64/conf-mingw-w64-cairo-x86_64.1/opam
+++ b/packages/conf-mingw-w64-cairo-x86_64/conf-mingw-w64-cairo-x86_64.1/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-synopsis: "Provides cairo for x86_64 mingw-w64 (64-bit x86_64)"
-description: "Ensure that the x86_64 version of cairo for the mingw-w64 project is available"
+synopsis: "Virtual package for cairo on x86_64 mingw-w64 (64-bit x86_64)"
+description: "Ensures the x86_64 version of cairo for the mingw-w64 project is available"
 maintainer: "https://github.com/ocaml/opam-repository/issues"
 authors: ["Keith Packard" "Carl Worth" "Behdad Esfahbod"]
 license: ["LGPL-2.1-only" "MPL-1.1"]

--- a/packages/conf-mingw-w64-cairo-x86_64/conf-mingw-w64-cairo-x86_64.1/opam
+++ b/packages/conf-mingw-w64-cairo-x86_64/conf-mingw-w64-cairo-x86_64.1/opam
@@ -8,7 +8,7 @@ homepage: "http://cairographics.org/"
 bug-reports: "https://github.com/ocaml/opam-repository/issues"
 flags: conf
 available: os = "win32"
-build: ["pkgconf" "--personality=x86_64-w64-mingw32" "cairo"]
+build: ["pkgconf" "--personality=x86_64-w64-mingw32" {os-distribution = "cygwin"} "cairo"]
 depends: [
   "conf-pkg-config" {build}
   "conf-mingw-w64-gcc-x86_64" {build}

--- a/packages/conf-mingw-w64-curl-i686/conf-mingw-w64-curl-i686.1/opam
+++ b/packages/conf-mingw-w64-curl-i686/conf-mingw-w64-curl-i686.1/opam
@@ -8,7 +8,7 @@ homepage: "http://curl.haxx.se/"
 bug-reports: "https://github.com/ocaml/opam-repository/issues"
 flags: conf
 available: os = "win32"
-build: ["pkgconf" "--personality=i686-w64-mingw32" "libcurl"]
+build: ["pkgconf" "--personality=i686-w64-mingw32" {os-distribution = "cygwin"} "libcurl"]
 depends: [
   "conf-pkg-config" {build}
   "conf-mingw-w64-gcc-i686" {build}

--- a/packages/conf-mingw-w64-curl-i686/conf-mingw-w64-curl-i686.1/opam
+++ b/packages/conf-mingw-w64-curl-i686/conf-mingw-w64-curl-i686.1/opam
@@ -10,6 +10,8 @@ flags: conf
 available: os = "win32"
 build: ["pkgconf" "--personality=i686-w64-mingw32" {os-distribution = "cygwin"} "libcurl"]
 depends: [
+  "msys2" {build & os = "win32" & os-distribution = "msys2"}
+  "msys2-mingw32" {os = "win32" & os-distribution = "msys2"}
   "conf-pkg-config" {build}
   "conf-mingw-w64-gcc-i686" {build}
 ]

--- a/packages/conf-mingw-w64-curl-i686/conf-mingw-w64-curl-i686.1/opam
+++ b/packages/conf-mingw-w64-curl-i686/conf-mingw-w64-curl-i686.1/opam
@@ -1,7 +1,7 @@
 opam-version: "2.0"
 synopsis: "Virtual package for libcurl on i686 mingw-w64 (32-bit x86)"
 description: "Ensures the i686 version of libcurl for the mingw-w64 project is available"
-maintainer: "David Allsopp <david@tarides.com>"
+maintainer: "David Allsopp <dra27@dra27.uk>"
 license: "MIT"
 authors: ["Daniel Stenberg"]
 homepage: "http://curl.haxx.se/"

--- a/packages/conf-mingw-w64-curl-i686/conf-mingw-w64-curl-i686.1/opam
+++ b/packages/conf-mingw-w64-curl-i686/conf-mingw-w64-curl-i686.1/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-synopsis: "libcurl for i686 mingw-w64 (32-bit x86)"
+synopsis: "Virtual package for libcurl on i686 mingw-w64 (32-bit x86)"
 description: "Ensures the i686 version of libcurl for the mingw-w64 project is available"
 maintainer: "David Allsopp <david@tarides.com>"
 license: "MIT"

--- a/packages/conf-mingw-w64-curl-x86_64/conf-mingw-w64-curl-x86_64.1/opam
+++ b/packages/conf-mingw-w64-curl-x86_64/conf-mingw-w64-curl-x86_64.1/opam
@@ -8,7 +8,7 @@ homepage: "http://curl.haxx.se/"
 bug-reports: "https://github.com/ocaml/opam-repository/issues"
 flags: conf
 available: os = "win32"
-build: ["pkgconf" "--personality=x86_64-w64-mingw32" "libcurl"]
+build: ["pkgconf" "--personality=x86_64-w64-mingw32" {os-distribution = "cygwin"} "libcurl"]
 depends: [
   "conf-pkg-config" {build}
   "conf-mingw-w64-gcc-x86_64" {build}

--- a/packages/conf-mingw-w64-curl-x86_64/conf-mingw-w64-curl-x86_64.1/opam
+++ b/packages/conf-mingw-w64-curl-x86_64/conf-mingw-w64-curl-x86_64.1/opam
@@ -1,7 +1,7 @@
 opam-version: "2.0"
 synopsis: "Virtual package for libcurl on x86_64 mingw-w64 (64-bit x86_64)"
 description: "Ensures the x86_64 version of libcurl for the mingw-w64 project is available"
-maintainer: "David Allsopp <david@tarides.com>"
+maintainer: "David Allsopp <dra27@dra27.uk>"
 license: "MIT"
 authors: ["Daniel Stenberg"]
 homepage: "http://curl.haxx.se/"

--- a/packages/conf-mingw-w64-curl-x86_64/conf-mingw-w64-curl-x86_64.1/opam
+++ b/packages/conf-mingw-w64-curl-x86_64/conf-mingw-w64-curl-x86_64.1/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-synopsis: "libcurl for x86_64 mingw-w64 (64-bit x86_64)"
+synopsis: "Virtual package for libcurl on x86_64 mingw-w64 (64-bit x86_64)"
 description: "Ensures the x86_64 version of libcurl for the mingw-w64 project is available"
 maintainer: "David Allsopp <david@tarides.com>"
 license: "MIT"

--- a/packages/conf-mingw-w64-curl-x86_64/conf-mingw-w64-curl-x86_64.1/opam
+++ b/packages/conf-mingw-w64-curl-x86_64/conf-mingw-w64-curl-x86_64.1/opam
@@ -10,6 +10,8 @@ flags: conf
 available: os = "win32"
 build: ["pkgconf" "--personality=x86_64-w64-mingw32" {os-distribution = "cygwin"} "libcurl"]
 depends: [
+  "msys2" {build & os = "win32" & os-distribution = "msys2"}
+  "msys2-mingw64" {os = "win32" & os-distribution = "msys2"}
   "conf-pkg-config" {build}
   "conf-mingw-w64-gcc-x86_64" {build}
 ]

--- a/packages/conf-mingw-w64-freeglut-i686/conf-mingw-w64-freeglut-i686.1/opam
+++ b/packages/conf-mingw-w64-freeglut-i686/conf-mingw-w64-freeglut-i686.1/opam
@@ -1,7 +1,7 @@
 opam-version: "2.0"
 synopsis: "Virtual package for FreeGLUT on i686 mingw-w64 (32-bit x86)"
 description: "Ensures the i686 version of FreeGLUT for the mingw-w64 project is available"
-maintainer: "David Allsopp <david@tarides.com>"
+maintainer: "David Allsopp <dra27@dra27.uk>"
 authors: ["Pawel W. Olszta" "Andreas Umbach" "Steve Baker" "John F. Fay" "John Tsiombikas" "Diederick C. Niehorster"]
 license: "X11"
 homepage: "https://freeglut.sourceforge.net/"

--- a/packages/conf-mingw-w64-freeglut-i686/conf-mingw-w64-freeglut-i686.1/opam
+++ b/packages/conf-mingw-w64-freeglut-i686/conf-mingw-w64-freeglut-i686.1/opam
@@ -8,10 +8,8 @@ homepage: "https://freeglut.sourceforge.net/"
 bug-reports: "https://github.com/ocaml/opam-repository/issues"
 flags: conf
 available: os = "win32"
-build: [
-  # Cygwin is missing a pkg-config .pc file https://cygwin.com/packages/x86_64/mingw64-i686-freeglut/mingw64-i686-freeglut-2.8.1-1
-  ["pkg-config" "--personality=i686-w64-mingw32" "freeglut"] {os = "win32" & os-distribution = "msys2"}
-]
+# Cygwin is missing a pkg-config .pc file https://cygwin.com/packages/x86_64/mingw64-i686-freeglut/mingw64-i686-freeglut-2.8.1-1
+build: ["pkgconf" "freeglut"] {os-distribution = "msys2"}
 depends: [
   "msys2" {build & os = "win32" & os-distribution = "msys2"}
   "msys2-mingw32" {os = "win32" & os-distribution = "msys2"}

--- a/packages/conf-mingw-w64-freeglut-i686/conf-mingw-w64-freeglut-i686.1/opam
+++ b/packages/conf-mingw-w64-freeglut-i686/conf-mingw-w64-freeglut-i686.1/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-synopsis: "FreeGLUT for i686 mingw-w64 (32-bit x86)"
+synopsis: "Virtual package for FreeGLUT on i686 mingw-w64 (32-bit x86)"
 description: "Ensures the i686 version of FreeGLUT for the mingw-w64 project is available"
 maintainer: "David Allsopp <david@tarides.com>"
 authors: ["Pawel W. Olszta" "Andreas Umbach" "Steve Baker" "John F. Fay" "John Tsiombikas" "Diederick C. Niehorster"]

--- a/packages/conf-mingw-w64-freeglut-i686/conf-mingw-w64-freeglut-i686.1/opam
+++ b/packages/conf-mingw-w64-freeglut-i686/conf-mingw-w64-freeglut-i686.1/opam
@@ -13,6 +13,8 @@ build: [
   ["pkg-config" "--personality=i686-w64-mingw32" "freeglut"] {os = "win32" & os-distribution = "msys2"}
 ]
 depends: [
+  "msys2" {build & os = "win32" & os-distribution = "msys2"}
+  "msys2-mingw32" {os = "win32" & os-distribution = "msys2"}
   "conf-pkg-config" {build}
   "conf-mingw-w64-gcc-i686" {build}
 ]

--- a/packages/conf-mingw-w64-freeglut-x86_64/conf-mingw-w64-freeglut-x86_64.1/opam
+++ b/packages/conf-mingw-w64-freeglut-x86_64/conf-mingw-w64-freeglut-x86_64.1/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-synopsis: "FreeGLUT for x86_64 mingw-w64 (64-bit x86_64)"
+synopsis: "Virtual package for FreeGLUT on x86_64 mingw-w64 (64-bit x86_64)"
 description: "Ensures the x86_64 version of FreeGLUT for the mingw-w64 project is available"
 maintainer: "David Allsopp <david@tarides.com>"
 authors: ["Pawel W. Olszta" "Andreas Umbach" "Steve Baker" "John F. Fay" "John Tsiombikas" "Diederick C. Niehorster"]

--- a/packages/conf-mingw-w64-freeglut-x86_64/conf-mingw-w64-freeglut-x86_64.1/opam
+++ b/packages/conf-mingw-w64-freeglut-x86_64/conf-mingw-w64-freeglut-x86_64.1/opam
@@ -1,7 +1,7 @@
 opam-version: "2.0"
 synopsis: "Virtual package for FreeGLUT on x86_64 mingw-w64 (64-bit x86_64)"
 description: "Ensures the x86_64 version of FreeGLUT for the mingw-w64 project is available"
-maintainer: "David Allsopp <david@tarides.com>"
+maintainer: "David Allsopp <dra27@dra27.uk>"
 authors: ["Pawel W. Olszta" "Andreas Umbach" "Steve Baker" "John F. Fay" "John Tsiombikas" "Diederick C. Niehorster"]
 license: "X11"
 homepage: "https://freeglut.sourceforge.net/"

--- a/packages/conf-mingw-w64-freeglut-x86_64/conf-mingw-w64-freeglut-x86_64.1/opam
+++ b/packages/conf-mingw-w64-freeglut-x86_64/conf-mingw-w64-freeglut-x86_64.1/opam
@@ -8,10 +8,8 @@ homepage: "https://freeglut.sourceforge.net/"
 bug-reports: "https://github.com/ocaml/opam-repository/issues"
 flags: conf
 available: os = "win32"
-build: [
-  # Cygwin is missing a pkg-config .pc file https://www.cygwin.com/packages/x86_64/mingw64-x86_64-freeglut/mingw64-x86_64-freeglut-2.8.1-1
-  ["pkg-config" "--personality=x86_64-w64-mingw32" "freeglut"] {os = "win32" & os-distribution = "msys2"}
-]
+# Cygwin is missing a pkg-config .pc file https://www.cygwin.com/packages/x86_64/mingw64-x86_64-freeglut/mingw64-x86_64-freeglut-2.8.1-1
+build: ["pkgconf" "freeglut"] {os-distribution = "msys2"}
 depends: [
   "msys2" {build & os = "win32" & os-distribution = "msys2"}
   "msys2-mingw64" {os = "win32" & os-distribution = "msys2"}

--- a/packages/conf-mingw-w64-freeglut-x86_64/conf-mingw-w64-freeglut-x86_64.1/opam
+++ b/packages/conf-mingw-w64-freeglut-x86_64/conf-mingw-w64-freeglut-x86_64.1/opam
@@ -13,6 +13,8 @@ build: [
   ["pkg-config" "--personality=x86_64-w64-mingw32" "freeglut"] {os = "win32" & os-distribution = "msys2"}
 ]
 depends: [
+  "msys2" {build & os = "win32" & os-distribution = "msys2"}
+  "msys2-mingw64" {os = "win32" & os-distribution = "msys2"}
   "conf-pkg-config" {build}
   "conf-mingw-w64-gcc-x86_64" {build}
 ]

--- a/packages/conf-mingw-w64-freetype-i686/conf-mingw-w64-freetype-i686.1/opam
+++ b/packages/conf-mingw-w64-freetype-i686/conf-mingw-w64-freetype-i686.1/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-synopsis: "Provides freetype for i686 mingw-w64 (32-bit x86)"
-description: "Ensure that the i686 version of freetype for the mingw-w64 project is available"
+synopsis: "Virtual package for freetype on i686 mingw-w64 (32-bit x86)"
+description: "Ensures the i686 version of freetype for the mingw-w64 project is available"
 maintainer: "https://github.com/ocaml/opam-repository/issues"
 authors: ["Christophe Troestler <Christophe.Troestler@umons.ac.be>"]
 license: "GPL-1.0-or-later"

--- a/packages/conf-mingw-w64-freetype-i686/conf-mingw-w64-freetype-i686.1/opam
+++ b/packages/conf-mingw-w64-freetype-i686/conf-mingw-w64-freetype-i686.1/opam
@@ -1,7 +1,7 @@
 opam-version: "2.0"
 synopsis: "Virtual package for freetype on i686 mingw-w64 (32-bit x86)"
 description: "Ensures the i686 version of freetype for the mingw-w64 project is available"
-maintainer: "https://github.com/ocaml/opam-repository/issues"
+maintainer: "David Allsopp <dra27@dra27.uk>"
 authors: ["Christophe Troestler <Christophe.Troestler@umons.ac.be>"]
 license: "GPL-1.0-or-later"
 homepage: "http://www.freetype.org"

--- a/packages/conf-mingw-w64-freetype-i686/conf-mingw-w64-freetype-i686.1/opam
+++ b/packages/conf-mingw-w64-freetype-i686/conf-mingw-w64-freetype-i686.1/opam
@@ -8,7 +8,7 @@ homepage: "http://www.freetype.org"
 bug-reports: "https://github.com/ocaml/opam-repository/issues"
 flags: conf
 available: os = "win32"
-build: ["pkgconf" "--personality=i686-w64-mingw32" "freetype2"]
+build: ["pkgconf" "--personality=i686-w64-mingw32" {os-distribution = "cygwin"} "freetype2"]
 depends: [
   "conf-pkg-config" {build}
   "conf-mingw-w64-gcc-i686" {build}

--- a/packages/conf-mingw-w64-freetype-i686/conf-mingw-w64-freetype-i686.1/opam
+++ b/packages/conf-mingw-w64-freetype-i686/conf-mingw-w64-freetype-i686.1/opam
@@ -10,6 +10,8 @@ flags: conf
 available: os = "win32"
 build: ["pkgconf" "--personality=i686-w64-mingw32" {os-distribution = "cygwin"} "freetype2"]
 depends: [
+  "msys2" {build & os = "win32" & os-distribution = "msys2"}
+  "msys2-mingw32" {os = "win32" & os-distribution = "msys2"}
   "conf-pkg-config" {build}
   "conf-mingw-w64-gcc-i686" {build}
 ]

--- a/packages/conf-mingw-w64-freetype-x86_64/conf-mingw-w64-freetype-x86_64.1/opam
+++ b/packages/conf-mingw-w64-freetype-x86_64/conf-mingw-w64-freetype-x86_64.1/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-synopsis: "Provides freetype for x86_64 mingw-w64 (64-bit x86_64)"
-description: "Ensure that the x86_64 version of freetype for the mingw-w64 project is available"
+synopsis: "Virtual package for freetype on x86_64 mingw-w64 (64-bit x86_64)"
+description: "Ensures the x86_64 version of freetype for the mingw-w64 project is available"
 maintainer: "https://github.com/ocaml/opam-repository/issues"
 authors: ["Christophe Troestler <Christophe.Troestler@umons.ac.be>"]
 license: "GPL-1.0-or-later"

--- a/packages/conf-mingw-w64-freetype-x86_64/conf-mingw-w64-freetype-x86_64.1/opam
+++ b/packages/conf-mingw-w64-freetype-x86_64/conf-mingw-w64-freetype-x86_64.1/opam
@@ -10,6 +10,8 @@ flags: conf
 available: os = "win32"
 build: ["pkgconf" "--personality=x86_64-w64-mingw32" {os-distribution = "cygwin"} "freetype2"]
 depends: [
+  "msys2" {build & os = "win32" & os-distribution = "msys2"}
+  "msys2-mingw64" {os = "win32" & os-distribution = "msys2"}
   "conf-pkg-config" {build}
   "conf-mingw-w64-gcc-x86_64" {build}
 ]

--- a/packages/conf-mingw-w64-freetype-x86_64/conf-mingw-w64-freetype-x86_64.1/opam
+++ b/packages/conf-mingw-w64-freetype-x86_64/conf-mingw-w64-freetype-x86_64.1/opam
@@ -1,7 +1,7 @@
 opam-version: "2.0"
 synopsis: "Virtual package for freetype on x86_64 mingw-w64 (64-bit x86_64)"
 description: "Ensures the x86_64 version of freetype for the mingw-w64 project is available"
-maintainer: "https://github.com/ocaml/opam-repository/issues"
+maintainer: "David Allsopp <dra27@dra27.uk>"
 authors: ["Christophe Troestler <Christophe.Troestler@umons.ac.be>"]
 license: "GPL-1.0-or-later"
 homepage: "http://www.freetype.org"

--- a/packages/conf-mingw-w64-freetype-x86_64/conf-mingw-w64-freetype-x86_64.1/opam
+++ b/packages/conf-mingw-w64-freetype-x86_64/conf-mingw-w64-freetype-x86_64.1/opam
@@ -8,7 +8,7 @@ homepage: "http://www.freetype.org"
 bug-reports: "https://github.com/ocaml/opam-repository/issues"
 flags: conf
 available: os = "win32"
-build: ["pkgconf" "--personality=x86_64-w64-mingw32" "freetype2"]
+build: ["pkgconf" "--personality=x86_64-w64-mingw32" {os-distribution = "cygwin"} "freetype2"]
 depends: [
   "conf-pkg-config" {build}
   "conf-mingw-w64-gcc-x86_64" {build}

--- a/packages/conf-mingw-w64-g++-i686/conf-mingw-w64-g++-i686.1/opam
+++ b/packages/conf-mingw-w64-g++-i686/conf-mingw-w64-g++-i686.1/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
 synopsis: "Virtual package for g++ on i686 mingw-w64 (32-bit x86)"
-description: "Ensures the i686 version of g++ from the mingw-w64 project is available"
+description: "Ensures the i686 version of g++ for the mingw-w64 project is available"
 maintainer: "David Allsopp <david@tarides.com>"
 authors: "David Allsopp"
 license: "GPL-3.0-or-later"

--- a/packages/conf-mingw-w64-g++-i686/conf-mingw-w64-g++-i686.1/opam
+++ b/packages/conf-mingw-w64-g++-i686/conf-mingw-w64-g++-i686.1/opam
@@ -9,7 +9,11 @@ bug-reports: "https://github.com/ocaml/opam-repository/issues"
 flags: conf
 available: os = "win32"
 build: ["i686-w64-mingw32-g++" "--version"]
-depends: ["conf-mingw-w64-gcc-i686" {build}]
+depends: [
+  "msys2" {build & os = "win32" & os-distribution = "msys2"}
+  "msys2-mingw32" {os = "win32" & os-distribution = "msys2"}
+  "conf-mingw-w64-gcc-i686" {build}
+]
 depexts: [
   ["mingw64-i686-gcc-g++"] {os = "win32" & os-distribution = "cygwin"}
 ]

--- a/packages/conf-mingw-w64-g++-i686/conf-mingw-w64-g++-i686.1/opam
+++ b/packages/conf-mingw-w64-g++-i686/conf-mingw-w64-g++-i686.1/opam
@@ -1,7 +1,7 @@
 opam-version: "2.0"
 synopsis: "Virtual package for g++ on i686 mingw-w64 (32-bit x86)"
 description: "Ensures the i686 version of g++ for the mingw-w64 project is available"
-maintainer: "David Allsopp <david@tarides.com>"
+maintainer: "David Allsopp <dra27@dra27.uk>"
 authors: "David Allsopp"
 license: "GPL-3.0-or-later"
 homepage: "https://www.mingw-w64.org"

--- a/packages/conf-mingw-w64-g++-x86_64/conf-mingw-w64-g++-x86_64.1/opam
+++ b/packages/conf-mingw-w64-g++-x86_64/conf-mingw-w64-g++-x86_64.1/opam
@@ -9,7 +9,11 @@ bug-reports: "https://github.com/ocaml/opam-repository/issues"
 flags: conf
 available: os = "win32"
 build: ["x86_64-w64-mingw32-g++" "--version"]
-depends: ["conf-mingw-w64-gcc-x86_64" {build}]
+depends: [
+  "msys2" {build & os = "win32" & os-distribution = "msys2"}
+  "msys2-mingw64" {os = "win32" & os-distribution = "msys2"}
+  "conf-mingw-w64-gcc-x86_64" {build}
+]
 depexts: [
   ["mingw64-x86_64-gcc-g++"] {os = "win32" & os-distribution = "cygwin"}
 ]

--- a/packages/conf-mingw-w64-g++-x86_64/conf-mingw-w64-g++-x86_64.1/opam
+++ b/packages/conf-mingw-w64-g++-x86_64/conf-mingw-w64-g++-x86_64.1/opam
@@ -1,7 +1,7 @@
 opam-version: "2.0"
 synopsis: "Virtual package for g++ on x86_64 mingw-w64 (64-bit x86_64)"
 description: "Ensures the x86_64 version of g++ for the mingw-w64 project is available"
-maintainer: "David Allsopp <david@tarides.com>"
+maintainer: "David Allsopp <dra27@dra27.uk>"
 authors: "David Allsopp"
 license: "GPL-3.0-or-later"
 homepage: "https://www.mingw-w64.org"

--- a/packages/conf-mingw-w64-g++-x86_64/conf-mingw-w64-g++-x86_64.1/opam
+++ b/packages/conf-mingw-w64-g++-x86_64/conf-mingw-w64-g++-x86_64.1/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
 synopsis: "Virtual package for g++ on x86_64 mingw-w64 (64-bit x86_64)"
-description: "Ensures the x86_64 version of g++ from the mingw-w64 project is available"
+description: "Ensures the x86_64 version of g++ for the mingw-w64 project is available"
 maintainer: "David Allsopp <david@tarides.com>"
 authors: "David Allsopp"
 license: "GPL-3.0-or-later"

--- a/packages/conf-mingw-w64-gcc-i686/conf-mingw-w64-gcc-i686.1/opam
+++ b/packages/conf-mingw-w64-gcc-i686/conf-mingw-w64-gcc-i686.1/opam
@@ -1,7 +1,7 @@
 opam-version: "2.0"
 synopsis: "Virtual package for GCC on i686 mingw-w64 (32-bit x86)"
 description: "Ensures the i686 version of GCC for the mingw-w64 project is available"
-maintainer: "David Allsopp <david@tarides.com>"
+maintainer: "David Allsopp <dra27@dra27.uk>"
 authors: "David Allsopp"
 license: "GPL-3.0-or-later"
 homepage: "https://www.mingw-w64.org"

--- a/packages/conf-mingw-w64-gcc-i686/conf-mingw-w64-gcc-i686.1/opam
+++ b/packages/conf-mingw-w64-gcc-i686/conf-mingw-w64-gcc-i686.1/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
 synopsis: "Virtual package for GCC on i686 mingw-w64 (32-bit x86)"
-description: "Ensures the i686 version of GCC from the mingw-w64 project is available"
+description: "Ensures the i686 version of GCC for the mingw-w64 project is available"
 maintainer: "David Allsopp <david@tarides.com>"
 authors: "David Allsopp"
 license: "GPL-3.0-or-later"

--- a/packages/conf-mingw-w64-gcc-x86_64/conf-mingw-w64-gcc-x86_64.1/opam
+++ b/packages/conf-mingw-w64-gcc-x86_64/conf-mingw-w64-gcc-x86_64.1/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
 synopsis: "Virtual package for GCC on x86_64 mingw-w64 (64-bit x86_64)"
-description: "Ensures the x86_64 version of GCC from the mingw-w64 project is available"
+description: "Ensures the x86_64 version of GCC for the mingw-w64 project is available"
 maintainer: "David Allsopp <david@tarides.com>"
 authors: "David Allsopp"
 license: "GPL-3.0-or-later"

--- a/packages/conf-mingw-w64-gcc-x86_64/conf-mingw-w64-gcc-x86_64.1/opam
+++ b/packages/conf-mingw-w64-gcc-x86_64/conf-mingw-w64-gcc-x86_64.1/opam
@@ -1,7 +1,7 @@
 opam-version: "2.0"
 synopsis: "Virtual package for GCC on x86_64 mingw-w64 (64-bit x86_64)"
 description: "Ensures the x86_64 version of GCC for the mingw-w64 project is available"
-maintainer: "David Allsopp <david@tarides.com>"
+maintainer: "David Allsopp <dra27@dra27.uk>"
 authors: "David Allsopp"
 license: "GPL-3.0-or-later"
 homepage: "https://www.mingw-w64.org"

--- a/packages/conf-mingw-w64-glade-i686/conf-mingw-w64-glade-i686.1/opam
+++ b/packages/conf-mingw-w64-glade-i686/conf-mingw-w64-glade-i686.1/opam
@@ -13,7 +13,7 @@ depends: [
 synopsis: "Virtual package for glade on i686 mingw-w64 (32-bit x86)"
 description:
   "Ensures the i686 version of glade for the mingw-w64 project is available"
-maintainer: "David Allsopp <david@tarides.com>"
+maintainer: "David Allsopp <dra27@dra27.uk>"
 depexts: [
   ["mingw64-i686-libglade2.0"] {os = "win32" & os-distribution = "cygwin"}
   # no "mingw-w64-i686-libglade" package available at https://packages.msys2.org/base/mingw-w64-libglade

--- a/packages/conf-mingw-w64-glade-i686/conf-mingw-w64-glade-i686.1/opam
+++ b/packages/conf-mingw-w64-glade-i686/conf-mingw-w64-glade-i686.1/opam
@@ -5,7 +5,7 @@ bug-reports: "https://github.com/ocaml/opam-repository/issues"
 license: "LGPL-2.1-or-later"
 flags: conf
 available: os = "win32"
-build: ["pkgconf" "--personality=i686-w64-mingw32" "libglade-2.0"]
+build: ["pkgconf" "--personality=i686-w64-mingw32" {os-distribution = "cygwin"} "libglade-2.0"]
 depends: [
   "conf-pkg-config" {build}
   "conf-mingw-w64-gcc-i686" {build}

--- a/packages/conf-mingw-w64-glade-i686/conf-mingw-w64-glade-i686.1/opam
+++ b/packages/conf-mingw-w64-glade-i686/conf-mingw-w64-glade-i686.1/opam
@@ -12,9 +12,9 @@ depends: [
   "conf-pkg-config" {build}
   "conf-mingw-w64-gcc-i686" {build}
 ]
-synopsis: "glade for i686 mingw-w64"
+synopsis: "Virtual package for glade on i686 mingw-w64 (32-bit x86)"
 description:
-  "Ensure the i686 version of glade for the mingw-w64 project is available"
+  "Ensures the i686 version of glade for the mingw-w64 project is available"
 maintainer: "David Allsopp <david@tarides.com>"
 depexts: [
   ["mingw64-i686-libglade2.0"] {os = "win32" & os-distribution = "cygwin"}

--- a/packages/conf-mingw-w64-glade-i686/conf-mingw-w64-glade-i686.1/opam
+++ b/packages/conf-mingw-w64-glade-i686/conf-mingw-w64-glade-i686.1/opam
@@ -4,7 +4,7 @@ homepage: "https://glade.gnome.org/"
 bug-reports: "https://github.com/ocaml/opam-repository/issues"
 license: "LGPL-2.1-or-later"
 flags: conf
-available: os = "win32"
+available: os = "win32" & os-distribution = "cygwin"
 build: ["pkgconf" "--personality=i686-w64-mingw32" {os-distribution = "cygwin"} "libglade-2.0"]
 depends: [
   "conf-pkg-config" {build}

--- a/packages/conf-mingw-w64-glade-i686/conf-mingw-w64-glade-i686.1/opam
+++ b/packages/conf-mingw-w64-glade-i686/conf-mingw-w64-glade-i686.1/opam
@@ -7,6 +7,8 @@ flags: conf
 available: os = "win32"
 build: ["pkgconf" "--personality=i686-w64-mingw32" {os-distribution = "cygwin"} "libglade-2.0"]
 depends: [
+  "msys2" {build & os = "win32" & os-distribution = "msys2"}
+  "msys2-mingw32" {os = "win32" & os-distribution = "msys2"}
   "conf-pkg-config" {build}
   "conf-mingw-w64-gcc-i686" {build}
 ]

--- a/packages/conf-mingw-w64-glade-i686/conf-mingw-w64-glade-i686.1/opam
+++ b/packages/conf-mingw-w64-glade-i686/conf-mingw-w64-glade-i686.1/opam
@@ -7,8 +7,6 @@ flags: conf
 available: os = "win32"
 build: ["pkgconf" "--personality=i686-w64-mingw32" {os-distribution = "cygwin"} "libglade-2.0"]
 depends: [
-  "msys2" {build & os = "win32" & os-distribution = "msys2"}
-  "msys2-mingw32" {os = "win32" & os-distribution = "msys2"}
   "conf-pkg-config" {build}
   "conf-mingw-w64-gcc-i686" {build}
 ]

--- a/packages/conf-mingw-w64-glade-x86_64/conf-mingw-w64-glade-x86_64.1/opam
+++ b/packages/conf-mingw-w64-glade-x86_64/conf-mingw-w64-glade-x86_64.1/opam
@@ -7,6 +7,8 @@ flags: conf
 available: os = "win32"
 build: ["pkgconf" "--personality=x86_64-w64-mingw32" {os-distribution = "cygwin"} "libglade-2.0"]
 depends: [
+  "msys2" {build & os = "win32" & os-distribution = "msys2"}
+  "msys2-mingw64" {os = "win32" & os-distribution = "msys2"}
   "conf-pkg-config" {build}
   "conf-mingw-w64-gcc-x86_64" {build}
 ]

--- a/packages/conf-mingw-w64-glade-x86_64/conf-mingw-w64-glade-x86_64.1/opam
+++ b/packages/conf-mingw-w64-glade-x86_64/conf-mingw-w64-glade-x86_64.1/opam
@@ -15,7 +15,7 @@ depends: [
 synopsis: "Virtual package for glade on x86_64 mingw-w64 (64-bit x86_64)"
 description:
   "Ensures the x86_64 version of glade for the mingw-w64 project is available"
-maintainer: "David Allsopp <david@tarides.com>"
+maintainer: "David Allsopp <dra27@dra27.uk>"
 depexts: [
   ["mingw64-x86_64-libglade2.0"] {os = "win32" & os-distribution = "cygwin"}
   ["mingw-w64-x86_64-libglade"] {os = "win32" & os-distribution = "msys2"}

--- a/packages/conf-mingw-w64-glade-x86_64/conf-mingw-w64-glade-x86_64.1/opam
+++ b/packages/conf-mingw-w64-glade-x86_64/conf-mingw-w64-glade-x86_64.1/opam
@@ -12,9 +12,9 @@ depends: [
   "conf-pkg-config" {build}
   "conf-mingw-w64-gcc-x86_64" {build}
 ]
-synopsis: "glade for x86_64 mingw-w64"
+synopsis: "Virtual package for glade on x86_64 mingw-w64 (64-bit x86_64)"
 description:
-  "Ensure the x86_64 version of glade for the mingw-w64 project is available"
+  "Ensures the x86_64 version of glade for the mingw-w64 project is available"
 maintainer: "David Allsopp <david@tarides.com>"
 depexts: [
   ["mingw64-x86_64-libglade2.0"] {os = "win32" & os-distribution = "cygwin"}

--- a/packages/conf-mingw-w64-glade-x86_64/conf-mingw-w64-glade-x86_64.1/opam
+++ b/packages/conf-mingw-w64-glade-x86_64/conf-mingw-w64-glade-x86_64.1/opam
@@ -5,7 +5,7 @@ bug-reports: "https://github.com/ocaml/opam-repository/issues"
 license: "LGPL-2.1-or-later"
 flags: conf
 available: os = "win32"
-build: ["pkgconf" "--personality=x86_64-w64-mingw32" "libglade-2.0"]
+build: ["pkgconf" "--personality=x86_64-w64-mingw32" {os-distribution = "cygwin"} "libglade-2.0"]
 depends: [
   "conf-pkg-config" {build}
   "conf-mingw-w64-gcc-x86_64" {build}

--- a/packages/conf-mingw-w64-gmp-i686/conf-mingw-w64-gmp-i686.1/opam
+++ b/packages/conf-mingw-w64-gmp-i686/conf-mingw-w64-gmp-i686.1/opam
@@ -1,7 +1,7 @@
 opam-version: "2.0"
 synopsis: "Virtual package for libgmp on i686 mingw-w64 (32-bit x86)"
 description: "Ensures the i686 version of libgmp for the mingw-w64 project is available"
-maintainer: "David Allsopp <david@tarides.com>"
+maintainer: "David Allsopp <dra27@dra27.uk>"
 authors: "Torbjörn Granlund et al"
 license: "GPL-1.0-or-later"
 homepage: "http://gmplib.org/"

--- a/packages/conf-mingw-w64-gmp-x86_64/conf-mingw-w64-gmp-x86_64.1/opam
+++ b/packages/conf-mingw-w64-gmp-x86_64/conf-mingw-w64-gmp-x86_64.1/opam
@@ -1,7 +1,7 @@
 opam-version: "2.0"
 synopsis: "Virtual package for libgmp on x86_64 mingw-w64 (64-bit x86_64)"
 description: "Ensures the x86_64 version of libgmp for the mingw-w64 project is available"
-maintainer: "David Allsopp <david@tarides.com>"
+maintainer: "David Allsopp <dra27@dra27.uk>"
 authors: "Torbjörn Granlund et al"
 license: "GPL-1.0-or-later"
 homepage: "http://gmplib.org/"

--- a/packages/conf-mingw-w64-gnomecanvas-i686/conf-mingw-w64-gnomecanvas-i686.1/opam
+++ b/packages/conf-mingw-w64-gnomecanvas-i686/conf-mingw-w64-gnomecanvas-i686.1/opam
@@ -10,6 +10,8 @@ flags: conf
 available: os = "win32" & os-distribution = "cygwin"
 build: ["pkgconf" "--personality=i686-w64-mingw32" {os-distribution = "cygwin"} "libgnomecanvas-2.0"]
 depends: [
+  "msys2" {build & os = "win32" & os-distribution = "msys2"}
+  "msys2-mingw32" {os = "win32" & os-distribution = "msys2"}
   "conf-pkg-config" {build}
   "conf-mingw-w64-gcc-i686" {build}
 ]

--- a/packages/conf-mingw-w64-gnomecanvas-i686/conf-mingw-w64-gnomecanvas-i686.1/opam
+++ b/packages/conf-mingw-w64-gnomecanvas-i686/conf-mingw-w64-gnomecanvas-i686.1/opam
@@ -10,8 +10,6 @@ flags: conf
 available: os = "win32" & os-distribution = "cygwin"
 build: ["pkgconf" "--personality=i686-w64-mingw32" {os-distribution = "cygwin"} "libgnomecanvas-2.0"]
 depends: [
-  "msys2" {build & os = "win32" & os-distribution = "msys2"}
-  "msys2-mingw32" {os = "win32" & os-distribution = "msys2"}
   "conf-pkg-config" {build}
   "conf-mingw-w64-gcc-i686" {build}
 ]

--- a/packages/conf-mingw-w64-gnomecanvas-i686/conf-mingw-w64-gnomecanvas-i686.1/opam
+++ b/packages/conf-mingw-w64-gnomecanvas-i686/conf-mingw-w64-gnomecanvas-i686.1/opam
@@ -8,7 +8,7 @@ homepage: "https://developer.gnome.org/libgnomecanvas/2.30/"
 bug-reports: "https://github.com/ocaml/opam-repository/issues"
 flags: conf
 available: os = "win32" & os-distribution = "cygwin"
-build: ["pkgconf" "--personality=i686-w64-mingw32" "libgnomecanvas-2.0"]
+build: ["pkgconf" "--personality=i686-w64-mingw32" {os-distribution = "cygwin"} "libgnomecanvas-2.0"]
 depends: [
   "conf-pkg-config" {build}
   "conf-mingw-w64-gcc-i686" {build}

--- a/packages/conf-mingw-w64-gnomecanvas-i686/conf-mingw-w64-gnomecanvas-i686.1/opam
+++ b/packages/conf-mingw-w64-gnomecanvas-i686/conf-mingw-w64-gnomecanvas-i686.1/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-synopsis: "gnomecanvas for i686 mingw-w64 (32-bit x86)"
+synopsis: "Virtual package for gnomecanvas on i686 mingw-w64 (32-bit x86)"
 description: "Ensures the i686 version of gnomecanvas for the mingw-w64 project is available"
 maintainer: "David Allsopp <david@tarides.com>"
 authors: "The GNOME Project"

--- a/packages/conf-mingw-w64-gnomecanvas-i686/conf-mingw-w64-gnomecanvas-i686.1/opam
+++ b/packages/conf-mingw-w64-gnomecanvas-i686/conf-mingw-w64-gnomecanvas-i686.1/opam
@@ -1,7 +1,7 @@
 opam-version: "2.0"
 synopsis: "Virtual package for gnomecanvas on i686 mingw-w64 (32-bit x86)"
 description: "Ensures the i686 version of gnomecanvas for the mingw-w64 project is available"
-maintainer: "David Allsopp <david@tarides.com>"
+maintainer: "David Allsopp <dra27@dra27.uk>"
 authors: "The GNOME Project"
 license: "LGPL-2.1-or-later"
 homepage: "https://developer.gnome.org/libgnomecanvas/2.30/"

--- a/packages/conf-mingw-w64-gnomecanvas-x86_64/conf-mingw-w64-gnomecanvas-x86_64.1/opam
+++ b/packages/conf-mingw-w64-gnomecanvas-x86_64/conf-mingw-w64-gnomecanvas-x86_64.1/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-synopsis: "gnomecanvas for x86_64 mingw-w64 (64-bit x86_64)"
+synopsis: "Virtual package for gnomecanvas on x86_64 mingw-w64 (64-bit x86_64)"
 description: "Ensures the x86_64 version of gnomecanvas for the mingw-w64 project is available"
 maintainer: "David Allsopp <david@tarides.com>"
 authors: "The GNOME Project"

--- a/packages/conf-mingw-w64-gnomecanvas-x86_64/conf-mingw-w64-gnomecanvas-x86_64.1/opam
+++ b/packages/conf-mingw-w64-gnomecanvas-x86_64/conf-mingw-w64-gnomecanvas-x86_64.1/opam
@@ -1,7 +1,7 @@
 opam-version: "2.0"
 synopsis: "Virtual package for gnomecanvas on x86_64 mingw-w64 (64-bit x86_64)"
 description: "Ensures the x86_64 version of gnomecanvas for the mingw-w64 project is available"
-maintainer: "David Allsopp <david@tarides.com>"
+maintainer: "David Allsopp <dra27@dra27.uk>"
 authors: "The GNOME Project"
 license: "LGPL-2.1-or-later"
 homepage: "https://developer.gnome.org/libgnomecanvas/2.30/"

--- a/packages/conf-mingw-w64-gnomecanvas-x86_64/conf-mingw-w64-gnomecanvas-x86_64.1/opam
+++ b/packages/conf-mingw-w64-gnomecanvas-x86_64/conf-mingw-w64-gnomecanvas-x86_64.1/opam
@@ -13,6 +13,8 @@ build: [
   ["pkg-config" "libgnomecanvas-2.0"] {os = "win32" & os-distribution = "msys2"}
 ]
 depends: [
+  "msys2" {build & os = "win32" & os-distribution = "msys2"}
+  "msys2-mingw64" {os = "win32" & os-distribution = "msys2"}
   "conf-pkg-config" {build}
   "conf-mingw-w64-gcc-x86_64" {build}
 ]

--- a/packages/conf-mingw-w64-gnomecanvas-x86_64/conf-mingw-w64-gnomecanvas-x86_64.1/opam
+++ b/packages/conf-mingw-w64-gnomecanvas-x86_64/conf-mingw-w64-gnomecanvas-x86_64.1/opam
@@ -9,8 +9,7 @@ bug-reports: "https://github.com/ocaml/opam-repository/issues"
 flags: conf
 available: os = "win32"
 build: [
-  ["pkgconf" "--personality=x86_64-w64-mingw32" "libgnomecanvas-2.0"] {os = "win32" & os-distribution = "cygwin"}
-  ["pkg-config" "libgnomecanvas-2.0"] {os = "win32" & os-distribution = "msys2"}
+  ["pkgconf" "--personality=x86_64-w64-mingw32" {os-distribution = "cygwin"} "libgnomecanvas-2.0"]
 ]
 depends: [
   "msys2" {build & os = "win32" & os-distribution = "msys2"}

--- a/packages/conf-mingw-w64-gnutls-i686/conf-mingw-w64-gnutls-i686.1/opam
+++ b/packages/conf-mingw-w64-gnutls-i686/conf-mingw-w64-gnutls-i686.1/opam
@@ -7,6 +7,8 @@ flags: conf
 available: os = "win32"
 build: ["pkgconf" "--personality=i686-w64-mingw32" {os-distribution = "cygwin"} "gnutls"]
 depends: [
+  "msys2" {build & os = "win32" & os-distribution = "msys2"}
+  "msys2-mingw32" {os = "win32" & os-distribution = "msys2"}
   "conf-pkg-config" {build}
   "conf-mingw-w64-gcc-i686" {build}
 ]

--- a/packages/conf-mingw-w64-gnutls-i686/conf-mingw-w64-gnutls-i686.1/opam
+++ b/packages/conf-mingw-w64-gnutls-i686/conf-mingw-w64-gnutls-i686.1/opam
@@ -5,7 +5,7 @@ license: "LGPL-2.1-or-later"
 bug-reports: "https://github.com/ocaml/opam-repository/issues"
 flags: conf
 available: os = "win32"
-build: ["pkgconf" "--personality=i686-w64-mingw32" "gnutls"]
+build: ["pkgconf" "--personality=i686-w64-mingw32" {os-distribution = "cygwin"} "gnutls"]
 depends: [
   "conf-pkg-config" {build}
   "conf-mingw-w64-gcc-i686" {build}

--- a/packages/conf-mingw-w64-gnutls-i686/conf-mingw-w64-gnutls-i686.1/opam
+++ b/packages/conf-mingw-w64-gnutls-i686/conf-mingw-w64-gnutls-i686.1/opam
@@ -12,9 +12,9 @@ depends: [
   "conf-pkg-config" {build}
   "conf-mingw-w64-gcc-i686" {build}
 ]
-synopsis: "GnuTLS for i686 mingw-w64"
+synopsis: "Virtual package for GnuTLS on i686 mingw-w64 (32-bit x86)"
 description:
-  "Ensure the i686 version of gnutls for the mingw-w64 project is available"
+  "Ensures the i686 version of GnuTLS for the mingw-w64 project is available"
 maintainer: "David Allsopp <david@tarides.com>"
 depexts: [
   ["mingw64-i686-gnutls"] {os = "win32" & os-distribution = "cygwin"}

--- a/packages/conf-mingw-w64-gnutls-i686/conf-mingw-w64-gnutls-i686.1/opam
+++ b/packages/conf-mingw-w64-gnutls-i686/conf-mingw-w64-gnutls-i686.1/opam
@@ -15,7 +15,7 @@ depends: [
 synopsis: "Virtual package for GnuTLS on i686 mingw-w64 (32-bit x86)"
 description:
   "Ensures the i686 version of GnuTLS for the mingw-w64 project is available"
-maintainer: "David Allsopp <david@tarides.com>"
+maintainer: "David Allsopp <dra27@dra27.uk>"
 depexts: [
   ["mingw64-i686-gnutls"] {os = "win32" & os-distribution = "cygwin"}
   ["mingw-w64-i686-gnutls"] {os = "win32" & os-distribution = "msys2"}

--- a/packages/conf-mingw-w64-gnutls-x86_64/conf-mingw-w64-gnutls-x86_64.1/opam
+++ b/packages/conf-mingw-w64-gnutls-x86_64/conf-mingw-w64-gnutls-x86_64.1/opam
@@ -15,7 +15,7 @@ depends: [
 synopsis: "Virtual package for GnuTLS on x86_64 mingw-w64 (64-bit x86_64)"
 description:
   "Ensures the x86_64 version of GnuTLS for the mingw-w64 project is available"
-maintainer: "David Allsopp <david@tarides.com>"
+maintainer: "David Allsopp <dra27@dra27.uk>"
 depexts: [
   ["mingw64-x86_64-gnutls"] {os = "win32" & os-distribution = "cygwin"}
   ["mingw-w64-x86_64-gnutls"] {os = "win32" & os-distribution = "msys2"}

--- a/packages/conf-mingw-w64-gnutls-x86_64/conf-mingw-w64-gnutls-x86_64.1/opam
+++ b/packages/conf-mingw-w64-gnutls-x86_64/conf-mingw-w64-gnutls-x86_64.1/opam
@@ -5,7 +5,7 @@ license: "LGPL-2.1-or-later"
 bug-reports: "https://github.com/ocaml/opam-repository/issues"
 flags: conf
 available: os = "win32"
-build: ["pkgconf" "--personality=x86_64-w64-mingw32" "gnutls"]
+build: ["pkgconf" "--personality=x86_64-w64-mingw32" {os-distribution = "cygwin"} "gnutls"]
 depends: [
   "conf-pkg-config" {build}
   "conf-mingw-w64-gcc-x86_64" {build}

--- a/packages/conf-mingw-w64-gnutls-x86_64/conf-mingw-w64-gnutls-x86_64.1/opam
+++ b/packages/conf-mingw-w64-gnutls-x86_64/conf-mingw-w64-gnutls-x86_64.1/opam
@@ -7,6 +7,8 @@ flags: conf
 available: os = "win32"
 build: ["pkgconf" "--personality=x86_64-w64-mingw32" {os-distribution = "cygwin"} "gnutls"]
 depends: [
+  "msys2" {build & os = "win32" & os-distribution = "msys2"}
+  "msys2-mingw64" {os = "win32" & os-distribution = "msys2"}
   "conf-pkg-config" {build}
   "conf-mingw-w64-gcc-x86_64" {build}
 ]

--- a/packages/conf-mingw-w64-gnutls-x86_64/conf-mingw-w64-gnutls-x86_64.1/opam
+++ b/packages/conf-mingw-w64-gnutls-x86_64/conf-mingw-w64-gnutls-x86_64.1/opam
@@ -12,9 +12,9 @@ depends: [
   "conf-pkg-config" {build}
   "conf-mingw-w64-gcc-x86_64" {build}
 ]
-synopsis: "GnuTLS for x86_64 mingw-w64"
+synopsis: "Virtual package for GnuTLS on x86_64 mingw-w64 (64-bit x86_64)"
 description:
-  "Ensure the x86_64 version of gnutls for the mingw-w64 project is available"
+  "Ensures the x86_64 version of GnuTLS for the mingw-w64 project is available"
 maintainer: "David Allsopp <david@tarides.com>"
 depexts: [
   ["mingw64-x86_64-gnutls"] {os = "win32" & os-distribution = "cygwin"}

--- a/packages/conf-mingw-w64-gtk2-i686/conf-mingw-w64-gtk2-i686.1/opam
+++ b/packages/conf-mingw-w64-gtk2-i686/conf-mingw-w64-gtk2-i686.1/opam
@@ -7,7 +7,7 @@ license: "LGPL-2.1-or-later"
 homepage: "https://gtk.org/"
 bug-reports: "https://github.com/ocaml/opam-repository/issues"
 flags: conf
-available: os = "win32"
+available: os = "win32" & os-distribution = "cygwin"
 build: ["pkgconf" "--personality=i686-w64-mingw32" {os-distribution = "cygwin"} "gtk+-2.0"]
 depends: [
   "conf-pkg-config" {build}

--- a/packages/conf-mingw-w64-gtk2-i686/conf-mingw-w64-gtk2-i686.1/opam
+++ b/packages/conf-mingw-w64-gtk2-i686/conf-mingw-w64-gtk2-i686.1/opam
@@ -1,7 +1,7 @@
 opam-version: "2.0"
 synopsis: "Virtual package for gtk2 on i686 mingw-w64 (32-bit x86)"
 description: "Ensures the i686 version of gtk2 for the mingw-w64 project is available"
-maintainer: "https://github.com/ocaml/opam-repository/issues"
+maintainer: "David Allsopp <dra27@dra27.uk>"
 authors: ["The GNOME Project"]
 license: "LGPL-2.1-or-later"
 homepage: "https://gtk.org/"

--- a/packages/conf-mingw-w64-gtk2-i686/conf-mingw-w64-gtk2-i686.1/opam
+++ b/packages/conf-mingw-w64-gtk2-i686/conf-mingw-w64-gtk2-i686.1/opam
@@ -8,7 +8,7 @@ homepage: "https://gtk.org/"
 bug-reports: "https://github.com/ocaml/opam-repository/issues"
 flags: conf
 available: os = "win32"
-build: ["pkgconf" "--personality=i686-w64-mingw32" "gtk+-2.0"]
+build: ["pkgconf" "--personality=i686-w64-mingw32" {os-distribution = "cygwin"} "gtk+-2.0"]
 depends: [
   "conf-pkg-config" {build}
   "conf-mingw-w64-gcc-i686" {build}

--- a/packages/conf-mingw-w64-gtk2-i686/conf-mingw-w64-gtk2-i686.1/opam
+++ b/packages/conf-mingw-w64-gtk2-i686/conf-mingw-w64-gtk2-i686.1/opam
@@ -10,6 +10,8 @@ flags: conf
 available: os = "win32"
 build: ["pkgconf" "--personality=i686-w64-mingw32" {os-distribution = "cygwin"} "gtk+-2.0"]
 depends: [
+  "msys2" {build & os = "win32" & os-distribution = "msys2"}
+  "msys2-mingw32" {os = "win32" & os-distribution = "msys2"}
   "conf-pkg-config" {build}
   "conf-mingw-w64-gcc-i686" {build}
 ]

--- a/packages/conf-mingw-w64-gtk2-i686/conf-mingw-w64-gtk2-i686.1/opam
+++ b/packages/conf-mingw-w64-gtk2-i686/conf-mingw-w64-gtk2-i686.1/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-synopsis: "gtk2 for i686 mingw-w64 (32-bit x86)"
+synopsis: "Virtual package for gtk2 on i686 mingw-w64 (32-bit x86)"
 description: "Ensures the i686 version of gtk2 for the mingw-w64 project is available"
 maintainer: "https://github.com/ocaml/opam-repository/issues"
 authors: ["The GNOME Project"]

--- a/packages/conf-mingw-w64-gtk2-i686/conf-mingw-w64-gtk2-i686.1/opam
+++ b/packages/conf-mingw-w64-gtk2-i686/conf-mingw-w64-gtk2-i686.1/opam
@@ -10,8 +10,6 @@ flags: conf
 available: os = "win32"
 build: ["pkgconf" "--personality=i686-w64-mingw32" {os-distribution = "cygwin"} "gtk+-2.0"]
 depends: [
-  "msys2" {build & os = "win32" & os-distribution = "msys2"}
-  "msys2-mingw32" {os = "win32" & os-distribution = "msys2"}
   "conf-pkg-config" {build}
   "conf-mingw-w64-gcc-i686" {build}
 ]

--- a/packages/conf-mingw-w64-gtk2-x86_64/conf-mingw-w64-gtk2-x86_64.1/opam
+++ b/packages/conf-mingw-w64-gtk2-x86_64/conf-mingw-w64-gtk2-x86_64.1/opam
@@ -8,7 +8,7 @@ homepage: "https://gtk.org/"
 bug-reports: "https://github.com/ocaml/opam-repository/issues"
 flags: conf
 available: os = "win32"
-build: ["pkgconf" "--personality=x86_64-w64-mingw32" "gtk+-2.0"]
+build: ["pkgconf" "--personality=x86_64-w64-mingw32" {os-distribution = "cygwin"} "gtk+-2.0"]
 depends: [
   "conf-pkg-config" {build}
   "conf-mingw-w64-gcc-x86_64" {build}

--- a/packages/conf-mingw-w64-gtk2-x86_64/conf-mingw-w64-gtk2-x86_64.1/opam
+++ b/packages/conf-mingw-w64-gtk2-x86_64/conf-mingw-w64-gtk2-x86_64.1/opam
@@ -1,7 +1,7 @@
 opam-version: "2.0"
 synopsis: "Virtual package for gtk2 on x86_64 mingw-w64 (64-bit x86_64)"
 description: "Ensures the x86_64 version of gtk2 for the mingw-w64 project is available"
-maintainer: "https://github.com/ocaml/opam-repository/issues"
+maintainer: "David Allsopp <dra27@dra27.uk>"
 authors: ["The GNOME Project"]
 license: "LGPL-2.1-or-later"
 homepage: "https://gtk.org/"

--- a/packages/conf-mingw-w64-gtk2-x86_64/conf-mingw-w64-gtk2-x86_64.1/opam
+++ b/packages/conf-mingw-w64-gtk2-x86_64/conf-mingw-w64-gtk2-x86_64.1/opam
@@ -10,6 +10,8 @@ flags: conf
 available: os = "win32"
 build: ["pkgconf" "--personality=x86_64-w64-mingw32" {os-distribution = "cygwin"} "gtk+-2.0"]
 depends: [
+  "msys2" {build & os = "win32" & os-distribution = "msys2"}
+  "msys2-mingw64" {os = "win32" & os-distribution = "msys2"}
   "conf-pkg-config" {build}
   "conf-mingw-w64-gcc-x86_64" {build}
 ]

--- a/packages/conf-mingw-w64-gtk2-x86_64/conf-mingw-w64-gtk2-x86_64.1/opam
+++ b/packages/conf-mingw-w64-gtk2-x86_64/conf-mingw-w64-gtk2-x86_64.1/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-synopsis: "gtk2 for i686 mingw-w64 (32-bit x86)"
-description: "Ensures the i686 version of gtk2 for the mingw-w64 project is available"
+synopsis: "Virtual package for gtk2 on x86_64 mingw-w64 (64-bit x86_64)"
+description: "Ensures the x86_64 version of gtk2 for the mingw-w64 project is available"
 maintainer: "https://github.com/ocaml/opam-repository/issues"
 authors: ["The GNOME Project"]
 license: "LGPL-2.1-or-later"

--- a/packages/conf-mingw-w64-gtk3-i686/conf-mingw-w64-gtk3-i686.1/opam
+++ b/packages/conf-mingw-w64-gtk3-i686/conf-mingw-w64-gtk3-i686.1/opam
@@ -4,7 +4,7 @@ description: "Ensures the i686 version of GTK+ 3 for the mingw-w64 project is av
 maintainer: "https://github.com/ocaml/opam-repository/issues"
 authors: "The GTK Toolkit"
 license: "LGPL-2.1-or-later"
-homepage: "https://developer.gnome.org/"
+homepage: "https://www.gtk.org/"
 bug-reports: "https://github.com/ocaml/opam-repository/issues"
 flags: conf
 available: os = "win32"

--- a/packages/conf-mingw-w64-gtk3-i686/conf-mingw-w64-gtk3-i686.1/opam
+++ b/packages/conf-mingw-w64-gtk3-i686/conf-mingw-w64-gtk3-i686.1/opam
@@ -1,7 +1,7 @@
 opam-version: "2.0"
 synopsis: "Virtual package for GTK+ 3 on i686 mingw-w64 (32-bit x86)"
 description: "Ensures the i686 version of GTK+ 3 for the mingw-w64 project is available"
-maintainer: "https://github.com/ocaml/opam-repository/issues"
+maintainer: "David Allsopp <dra27@dra27.uk>"
 authors: "The GTK Toolkit"
 license: "LGPL-2.1-or-later"
 homepage: "https://www.gtk.org/"

--- a/packages/conf-mingw-w64-gtk3-i686/conf-mingw-w64-gtk3-i686.1/opam
+++ b/packages/conf-mingw-w64-gtk3-i686/conf-mingw-w64-gtk3-i686.1/opam
@@ -10,6 +10,8 @@ flags: conf
 available: os = "win32"
 build: ["pkgconf" "--personality=i686-w64-mingw32" {os-distribution = "cygwin"} "gtk+-3.0"]
 depends: [
+  "msys2" {build & os = "win32" & os-distribution = "msys2"}
+  "msys2-mingw32" {os = "win32" & os-distribution = "msys2"}
   "conf-pkg-config" {build}
   "conf-mingw-w64-gcc-i686" {build}
 ]

--- a/packages/conf-mingw-w64-gtk3-i686/conf-mingw-w64-gtk3-i686.1/opam
+++ b/packages/conf-mingw-w64-gtk3-i686/conf-mingw-w64-gtk3-i686.1/opam
@@ -8,7 +8,7 @@ homepage: "https://developer.gnome.org/"
 bug-reports: "https://github.com/ocaml/opam-repository/issues"
 flags: conf
 available: os = "win32"
-build: ["pkgconf" "--personality=i686-w64-mingw32" "gtk+-3.0"]
+build: ["pkgconf" "--personality=i686-w64-mingw32" {os-distribution = "cygwin"} "gtk+-3.0"]
 depends: [
   "conf-pkg-config" {build}
   "conf-mingw-w64-gcc-i686" {build}

--- a/packages/conf-mingw-w64-gtk3-i686/conf-mingw-w64-gtk3-i686.1/opam
+++ b/packages/conf-mingw-w64-gtk3-i686/conf-mingw-w64-gtk3-i686.1/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-synopsis: "GTK+ 3 for i686 mingw-w64 (32-bit x86)"
+synopsis: "Virtual package for GTK+ 3 on i686 mingw-w64 (32-bit x86)"
 description: "Ensures the i686 version of GTK+ 3 for the mingw-w64 project is available"
 maintainer: "https://github.com/ocaml/opam-repository/issues"
 authors: "The GTK Toolkit"

--- a/packages/conf-mingw-w64-gtk3-x86_64/conf-mingw-w64-gtk3-x86_64.1/opam
+++ b/packages/conf-mingw-w64-gtk3-x86_64/conf-mingw-w64-gtk3-x86_64.1/opam
@@ -10,6 +10,8 @@ flags: conf
 available: os = "win32"
 build: ["pkgconf" "--personality=x86_64-w64-mingw32" {os-distribution = "cygwin"} "gtk+-3.0"]
 depends: [
+  "msys2" {build & os = "win32" & os-distribution = "msys2"}
+  "msys2-mingw64" {os = "win32" & os-distribution = "msys2"}
   "conf-pkg-config" {build}
   "conf-mingw-w64-gcc-x86_64" {build}
 ]

--- a/packages/conf-mingw-w64-gtk3-x86_64/conf-mingw-w64-gtk3-x86_64.1/opam
+++ b/packages/conf-mingw-w64-gtk3-x86_64/conf-mingw-w64-gtk3-x86_64.1/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-synopsis: "GTK+ 3 for i686 mingw-w64 (32-bit x86)"
-description: "Ensures the i686 version of GTK+ 3 for the mingw-w64 project is available"
+synopsis: "Virtual package for GTK+ 3 on x86_64 mingw-w64 (64-bit x86_64)"
+description: "Ensures the x86_64 version of GTK+ 3 for the mingw-w64 project is available"
 maintainer: "https://github.com/ocaml/opam-repository/issues"
 authors: "The GTK Toolkit"
 license: "LGPL-2.1-or-later"

--- a/packages/conf-mingw-w64-gtk3-x86_64/conf-mingw-w64-gtk3-x86_64.1/opam
+++ b/packages/conf-mingw-w64-gtk3-x86_64/conf-mingw-w64-gtk3-x86_64.1/opam
@@ -8,7 +8,7 @@ homepage: "https://www.gtk.org/"
 bug-reports: "https://github.com/ocaml/opam-repository/issues"
 flags: conf
 available: os = "win32"
-build: ["pkgconf" "--personality=x86_64-w64-mingw32" "gtk+-3.0"]
+build: ["pkgconf" "--personality=x86_64-w64-mingw32" {os-distribution = "cygwin"} "gtk+-3.0"]
 depends: [
   "conf-pkg-config" {build}
   "conf-mingw-w64-gcc-x86_64" {build}

--- a/packages/conf-mingw-w64-gtk3-x86_64/conf-mingw-w64-gtk3-x86_64.1/opam
+++ b/packages/conf-mingw-w64-gtk3-x86_64/conf-mingw-w64-gtk3-x86_64.1/opam
@@ -1,7 +1,7 @@
 opam-version: "2.0"
 synopsis: "Virtual package for GTK+ 3 on x86_64 mingw-w64 (64-bit x86_64)"
 description: "Ensures the x86_64 version of GTK+ 3 for the mingw-w64 project is available"
-maintainer: "https://github.com/ocaml/opam-repository/issues"
+maintainer: "David Allsopp <dra27@dra27.uk>"
 authors: "The GTK Toolkit"
 license: "LGPL-2.1-or-later"
 homepage: "https://www.gtk.org/"

--- a/packages/conf-mingw-w64-gtksourceview3-i686/conf-mingw-w64-gtksourceview3-i686.1/opam
+++ b/packages/conf-mingw-w64-gtksourceview3-i686/conf-mingw-w64-gtksourceview3-i686.1/opam
@@ -1,7 +1,7 @@
 opam-version: "2.0"
 synopsis: "Virtual package for gtksourceview3 on i686 mingw-w64 (32-bit x86)"
 description: "Ensures the i686 version of gtksourceview3 for the mingw-w64 project is available"
-maintainer: "https://github.com/ocaml/opam-repository/issues"
+maintainer: "David Allsopp <dra27@dra27.uk>"
 authors: "The gtksourceview programmers"
 license: "LGPL-2.1-or-later"
 homepage: "https://projects.gnome.org/gtksourceview/"

--- a/packages/conf-mingw-w64-gtksourceview3-i686/conf-mingw-w64-gtksourceview3-i686.1/opam
+++ b/packages/conf-mingw-w64-gtksourceview3-i686/conf-mingw-w64-gtksourceview3-i686.1/opam
@@ -10,8 +10,6 @@ flags: conf
 available: os = "win32"
 build: ["pkgconf" "--personality=i686-w64-mingw32" {os-distribution = "cygwin"} "gtksourceview-3.0"]
 depends: [
-  "msys2" {build & os = "win32" & os-distribution = "msys2"}
-  "msys2-mingw32" {os = "win32" & os-distribution = "msys2"}
   "conf-pkg-config" {build}
   "conf-mingw-w64-gcc-i686" {build}
 ]

--- a/packages/conf-mingw-w64-gtksourceview3-i686/conf-mingw-w64-gtksourceview3-i686.1/opam
+++ b/packages/conf-mingw-w64-gtksourceview3-i686/conf-mingw-w64-gtksourceview3-i686.1/opam
@@ -8,7 +8,7 @@ homepage: "https://projects.gnome.org/gtksourceview/"
 bug-reports: "https://github.com/ocaml/opam-repository/issues"
 flags: conf
 available: os = "win32"
-build: ["pkgconf" "--personality=i686-w64-mingw32" "gtksourceview-3.0"]
+build: ["pkgconf" "--personality=i686-w64-mingw32" {os-distribution = "cygwin"} "gtksourceview-3.0"]
 depends: [
   "conf-pkg-config" {build}
   "conf-mingw-w64-gcc-i686" {build}

--- a/packages/conf-mingw-w64-gtksourceview3-i686/conf-mingw-w64-gtksourceview3-i686.1/opam
+++ b/packages/conf-mingw-w64-gtksourceview3-i686/conf-mingw-w64-gtksourceview3-i686.1/opam
@@ -10,6 +10,8 @@ flags: conf
 available: os = "win32"
 build: ["pkgconf" "--personality=i686-w64-mingw32" {os-distribution = "cygwin"} "gtksourceview-3.0"]
 depends: [
+  "msys2" {build & os = "win32" & os-distribution = "msys2"}
+  "msys2-mingw32" {os = "win32" & os-distribution = "msys2"}
   "conf-pkg-config" {build}
   "conf-mingw-w64-gcc-i686" {build}
 ]

--- a/packages/conf-mingw-w64-gtksourceview3-i686/conf-mingw-w64-gtksourceview3-i686.1/opam
+++ b/packages/conf-mingw-w64-gtksourceview3-i686/conf-mingw-w64-gtksourceview3-i686.1/opam
@@ -7,7 +7,7 @@ license: "LGPL-2.1-or-later"
 homepage: "https://projects.gnome.org/gtksourceview/"
 bug-reports: "https://github.com/ocaml/opam-repository/issues"
 flags: conf
-available: os = "win32"
+available: os = "win32" & os-distribution = "cygwin"
 build: ["pkgconf" "--personality=i686-w64-mingw32" {os-distribution = "cygwin"} "gtksourceview-3.0"]
 depends: [
   "conf-pkg-config" {build}

--- a/packages/conf-mingw-w64-gtksourceview3-i686/conf-mingw-w64-gtksourceview3-i686.1/opam
+++ b/packages/conf-mingw-w64-gtksourceview3-i686/conf-mingw-w64-gtksourceview3-i686.1/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-synopsis: "Provides gtksourceview3 for i686 mingw-w64 (32-bit x86)"
-description: "Ensure that the i686 version of gtksourceview3 for the mingw-w64 project is available"
+synopsis: "Virtual package for gtksourceview3 on i686 mingw-w64 (32-bit x86)"
+description: "Ensures the i686 version of gtksourceview3 for the mingw-w64 project is available"
 maintainer: "https://github.com/ocaml/opam-repository/issues"
 authors: "The gtksourceview programmers"
 license: "LGPL-2.1-or-later"

--- a/packages/conf-mingw-w64-gtksourceview3-x86_64/conf-mingw-w64-gtksourceview3-x86_64.1/opam
+++ b/packages/conf-mingw-w64-gtksourceview3-x86_64/conf-mingw-w64-gtksourceview3-x86_64.1/opam
@@ -1,7 +1,7 @@
 opam-version: "2.0"
 synopsis: "Virtual package for gtksourceview3 on x86_64 mingw-w64 (64-bit x86_64)"
 description: "Ensures the x86_64 version of gtksourceview3 for the mingw-w64 project is available"
-maintainer: "https://github.com/ocaml/opam-repository/issues"
+maintainer: "David Allsopp <dra27@dra27.uk>"
 authors: "The gtksourceview programmers"
 license: "LGPL-2.1-or-later"
 homepage: "https://projects.gnome.org/gtksourceview/"

--- a/packages/conf-mingw-w64-gtksourceview3-x86_64/conf-mingw-w64-gtksourceview3-x86_64.1/opam
+++ b/packages/conf-mingw-w64-gtksourceview3-x86_64/conf-mingw-w64-gtksourceview3-x86_64.1/opam
@@ -10,6 +10,8 @@ flags: conf
 available: os = "win32"
 build: ["pkgconf" "--personality=x86_64-w64-mingw32" {os-distribution = "cygwin"} "gtksourceview-3.0"]
 depends: [
+  "msys2" {build & os = "win32" & os-distribution = "msys2"}
+  "msys2-mingw64" {os = "win32" & os-distribution = "msys2"}
   "conf-pkg-config" {build}
   "conf-mingw-w64-gcc-x86_64" {build}
 ]

--- a/packages/conf-mingw-w64-gtksourceview3-x86_64/conf-mingw-w64-gtksourceview3-x86_64.1/opam
+++ b/packages/conf-mingw-w64-gtksourceview3-x86_64/conf-mingw-w64-gtksourceview3-x86_64.1/opam
@@ -8,7 +8,7 @@ homepage: "https://projects.gnome.org/gtksourceview/"
 bug-reports: "https://github.com/ocaml/opam-repository/issues"
 flags: conf
 available: os = "win32"
-build: ["pkgconf" "--personality=x86_64-w64-mingw32" "gtksourceview-3.0"]
+build: ["pkgconf" "--personality=x86_64-w64-mingw32" {os-distribution = "cygwin"} "gtksourceview-3.0"]
 depends: [
   "conf-pkg-config" {build}
   "conf-mingw-w64-gcc-x86_64" {build}

--- a/packages/conf-mingw-w64-gtksourceview3-x86_64/conf-mingw-w64-gtksourceview3-x86_64.1/opam
+++ b/packages/conf-mingw-w64-gtksourceview3-x86_64/conf-mingw-w64-gtksourceview3-x86_64.1/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-synopsis: "Provides gtksourceview3 for x86_64 mingw-w64 (64-bit x86_64)"
-description: "Ensure that the x86_64 version of gtksourceview3 for the mingw-w64 project is available"
+synopsis: "Virtual package for gtksourceview3 on x86_64 mingw-w64 (64-bit x86_64)"
+description: "Ensures the x86_64 version of gtksourceview3 for the mingw-w64 project is available"
 maintainer: "https://github.com/ocaml/opam-repository/issues"
 authors: "The gtksourceview programmers"
 license: "LGPL-2.1-or-later"

--- a/packages/conf-mingw-w64-libevent-i686/conf-mingw-w64-libevent-i686.1/opam
+++ b/packages/conf-mingw-w64-libevent-i686/conf-mingw-w64-libevent-i686.1/opam
@@ -7,6 +7,8 @@ flags: conf
 available: os = "win32"
 build: ["pkgconf" "--personality=i686-w64-mingw32" {os-distribution = "cygwin"} "libevent"]
 depends: [
+  "msys2" {build & os = "win32" & os-distribution = "msys2"}
+  "msys2-mingw32" {os = "win32" & os-distribution = "msys2"}
   "conf-pkg-config" {build}
   "conf-mingw-w64-gcc-i686" {build}
 ]

--- a/packages/conf-mingw-w64-libevent-i686/conf-mingw-w64-libevent-i686.1/opam
+++ b/packages/conf-mingw-w64-libevent-i686/conf-mingw-w64-libevent-i686.1/opam
@@ -4,11 +4,9 @@ authors: ["Libevent dev team"]
 license: "BSD-3-clause"
 bug-reports: "https://github.com/ocaml/opam-repository/issues"
 flags: conf
-available: os = "win32"
+available: os = "win32" & os-distribution = "cygwin"
 build: ["pkgconf" "--personality=i686-w64-mingw32" {os-distribution = "cygwin"} "libevent"]
 depends: [
-  "msys2" {build & os = "win32" & os-distribution = "msys2"}
-  "msys2-mingw32" {os = "win32" & os-distribution = "msys2"}
   "conf-pkg-config" {build}
   "conf-mingw-w64-gcc-i686" {build}
 ]
@@ -18,5 +16,5 @@ description:
 maintainer: "David Allsopp <david@tarides.com>"
 depexts: [
   ["mingw64-i686-libevent"] {os = "win32" & os-distribution = "cygwin"}
-  ["mingw-w64-i686-libevent"] {os = "win32" & os-distribution = "msys2"}
+  # no i686 package available at https://packages.msys2.org/base/mingw-w64-libevent
 ]

--- a/packages/conf-mingw-w64-libevent-i686/conf-mingw-w64-libevent-i686.1/opam
+++ b/packages/conf-mingw-w64-libevent-i686/conf-mingw-w64-libevent-i686.1/opam
@@ -12,9 +12,9 @@ depends: [
   "conf-pkg-config" {build}
   "conf-mingw-w64-gcc-i686" {build}
 ]
-synopsis: "Libevent for i686 mingw-w64"
+synopsis: "Virtual package for libevent on i686 mingw-w64 (32-bit x86)"
 description:
-  "Ensure the i686 version of libevent for the mingw-w64 project is available"
+  "Ensures the i686 version of libevent for the mingw-w64 project is available"
 maintainer: "David Allsopp <david@tarides.com>"
 depexts: [
   ["mingw64-i686-libevent"] {os = "win32" & os-distribution = "cygwin"}

--- a/packages/conf-mingw-w64-libevent-i686/conf-mingw-w64-libevent-i686.1/opam
+++ b/packages/conf-mingw-w64-libevent-i686/conf-mingw-w64-libevent-i686.1/opam
@@ -13,7 +13,7 @@ depends: [
 synopsis: "Virtual package for libevent on i686 mingw-w64 (32-bit x86)"
 description:
   "Ensures the i686 version of libevent for the mingw-w64 project is available"
-maintainer: "David Allsopp <david@tarides.com>"
+maintainer: "David Allsopp <dra27@dra27.uk>"
 depexts: [
   ["mingw64-i686-libevent"] {os = "win32" & os-distribution = "cygwin"}
   # no i686 package available at https://packages.msys2.org/base/mingw-w64-libevent

--- a/packages/conf-mingw-w64-libevent-i686/conf-mingw-w64-libevent-i686.1/opam
+++ b/packages/conf-mingw-w64-libevent-i686/conf-mingw-w64-libevent-i686.1/opam
@@ -5,7 +5,7 @@ license: "BSD-3-clause"
 bug-reports: "https://github.com/ocaml/opam-repository/issues"
 flags: conf
 available: os = "win32"
-build: ["pkgconf" "--personality=i686-w64-mingw32" "libevent"]
+build: ["pkgconf" "--personality=i686-w64-mingw32" {os-distribution = "cygwin"} "libevent"]
 depends: [
   "conf-pkg-config" {build}
   "conf-mingw-w64-gcc-i686" {build}

--- a/packages/conf-mingw-w64-libevent-x86_64/conf-mingw-w64-libevent-x86_64.1/opam
+++ b/packages/conf-mingw-w64-libevent-x86_64/conf-mingw-w64-libevent-x86_64.1/opam
@@ -7,6 +7,8 @@ flags: conf
 available: os = "win32"
 build: ["pkgconf" "--personality=x86_64-w64-mingw32" {os-distribution = "cygwin"} "libevent"]
 depends: [
+  "msys2" {build & os = "win32" & os-distribution = "msys2"}
+  "msys2-mingw64" {os = "win32" & os-distribution = "msys2"}
   "conf-pkg-config" {build}
   "conf-mingw-w64-gcc-x86_64" {build}
 ]

--- a/packages/conf-mingw-w64-libevent-x86_64/conf-mingw-w64-libevent-x86_64.1/opam
+++ b/packages/conf-mingw-w64-libevent-x86_64/conf-mingw-w64-libevent-x86_64.1/opam
@@ -12,9 +12,9 @@ depends: [
   "conf-pkg-config" {build}
   "conf-mingw-w64-gcc-x86_64" {build}
 ]
-synopsis: "Libevent for x86_64 mingw-w64"
+synopsis: "Virtual package for libevent on x86_64 mingw-w64 (64-bit x86_64)"
 description:
-  "Ensure the x86_64 version of libevent for the mingw-w64 project is available"
+  "Ensures the x86_64 version of libevent for the mingw-w64 project is available"
 maintainer: "David Allsopp <david@tarides.com>"
 depexts: [
   ["mingw64-x86_64-libevent"] {os = "win32" & os-distribution = "cygwin"}

--- a/packages/conf-mingw-w64-libevent-x86_64/conf-mingw-w64-libevent-x86_64.1/opam
+++ b/packages/conf-mingw-w64-libevent-x86_64/conf-mingw-w64-libevent-x86_64.1/opam
@@ -5,7 +5,7 @@ license: "BSD-3-clause"
 bug-reports: "https://github.com/ocaml/opam-repository/issues"
 flags: conf
 available: os = "win32"
-build: ["pkgconf" "--personality=x86_64-w64-mingw32" "libevent"]
+build: ["pkgconf" "--personality=x86_64-w64-mingw32" {os-distribution = "cygwin"} "libevent"]
 depends: [
   "conf-pkg-config" {build}
   "conf-mingw-w64-gcc-x86_64" {build}

--- a/packages/conf-mingw-w64-libevent-x86_64/conf-mingw-w64-libevent-x86_64.1/opam
+++ b/packages/conf-mingw-w64-libevent-x86_64/conf-mingw-w64-libevent-x86_64.1/opam
@@ -15,7 +15,7 @@ depends: [
 synopsis: "Virtual package for libevent on x86_64 mingw-w64 (64-bit x86_64)"
 description:
   "Ensures the x86_64 version of libevent for the mingw-w64 project is available"
-maintainer: "David Allsopp <david@tarides.com>"
+maintainer: "David Allsopp <dra27@dra27.uk>"
 depexts: [
   ["mingw64-x86_64-libevent"] {os = "win32" & os-distribution = "cygwin"}
   ["mingw-w64-x86_64-libevent"] {os = "win32" & os-distribution = "msys2"}

--- a/packages/conf-mingw-w64-libffi-i686/conf-mingw-w64-libffi-i686.1/opam
+++ b/packages/conf-mingw-w64-libffi-i686/conf-mingw-w64-libffi-i686.1/opam
@@ -10,6 +10,8 @@ flags: conf
 available: os = "win32"
 build: ["pkgconf" "--personality=i686-w64-mingw32" {os-distribution = "cygwin"} "libffi"]
 depends: [
+  "msys2" {build & os = "win32" & os-distribution = "msys2"}
+  "msys2-mingw32" {os = "win32" & os-distribution = "msys2"}
   "conf-pkg-config" {build}
   "conf-mingw-w64-gcc-i686" {build}
 ]

--- a/packages/conf-mingw-w64-libffi-i686/conf-mingw-w64-libffi-i686.1/opam
+++ b/packages/conf-mingw-w64-libffi-i686/conf-mingw-w64-libffi-i686.1/opam
@@ -8,7 +8,7 @@ homepage: "https://sourceware.org/libffi"
 bug-reports: "https://github.com/ocaml/opam-repository/issues"
 flags: conf
 available: os = "win32"
-build: ["pkgconf" "--personality=i686-w64-mingw32" "libffi"]
+build: ["pkgconf" "--personality=i686-w64-mingw32" {os-distribution = "cygwin"} "libffi"]
 depends: [
   "conf-pkg-config" {build}
   "conf-mingw-w64-gcc-i686" {build}

--- a/packages/conf-mingw-w64-libffi-i686/conf-mingw-w64-libffi-i686.1/opam
+++ b/packages/conf-mingw-w64-libffi-i686/conf-mingw-w64-libffi-i686.1/opam
@@ -1,7 +1,7 @@
 opam-version: "2.0"
 synopsis: "Virtual package for libffi on i686 mingw-w64 (32-bit x86)"
 description: "Ensures the i686 version of libffi for the mingw-w64 project is available"
-maintainer: "David Allsopp <david@tarides.com>"
+maintainer: "David Allsopp <dra27@dra27.uk>"
 authors: "Anthony Green"
 license: "MIT"
 homepage: "https://sourceware.org/libffi"

--- a/packages/conf-mingw-w64-libffi-i686/conf-mingw-w64-libffi-i686.1/opam
+++ b/packages/conf-mingw-w64-libffi-i686/conf-mingw-w64-libffi-i686.1/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-synopsis: "libffi for i686 mingw-w64 (32-bit x86)"
-description: "Ensures the i686 version of libfii for the mingw-w64 project is available"
+synopsis: "Virtual package for libffi on i686 mingw-w64 (32-bit x86)"
+description: "Ensures the i686 version of libffi for the mingw-w64 project is available"
 maintainer: "David Allsopp <david@tarides.com>"
 authors: "Anthony Green"
 license: "MIT"

--- a/packages/conf-mingw-w64-libffi-x86_64/conf-mingw-w64-libffi-x86_64.1/opam
+++ b/packages/conf-mingw-w64-libffi-x86_64/conf-mingw-w64-libffi-x86_64.1/opam
@@ -1,7 +1,7 @@
 opam-version: "2.0"
 synopsis: "Virtual package for libffi on x86_64 mingw-w64 (64-bit x86_64)"
 description: "Ensures the x86_64 version of libffi for the mingw-w64 project is available"
-maintainer: "David Allsopp <david@tarides.com>"
+maintainer: "David Allsopp <dra27@dra27.uk>"
 authors: "Anthony Green"
 license: "MIT"
 homepage: "https://sourceware.org/libffi"

--- a/packages/conf-mingw-w64-libffi-x86_64/conf-mingw-w64-libffi-x86_64.1/opam
+++ b/packages/conf-mingw-w64-libffi-x86_64/conf-mingw-w64-libffi-x86_64.1/opam
@@ -8,7 +8,7 @@ homepage: "https://sourceware.org/libffi"
 bug-reports: "https://github.com/ocaml/opam-repository/issues"
 flags: conf
 available: os = "win32"
-build: ["pkgconf" "--personality=x86_64-w64-mingw32" "libffi"]
+build: ["pkgconf" "--personality=x86_64-w64-mingw32" {os-distribution = "cygwin"} "libffi"]
 depends: [
   "conf-pkg-config" {build}
   "conf-mingw-w64-gcc-x86_64" {build}

--- a/packages/conf-mingw-w64-libffi-x86_64/conf-mingw-w64-libffi-x86_64.1/opam
+++ b/packages/conf-mingw-w64-libffi-x86_64/conf-mingw-w64-libffi-x86_64.1/opam
@@ -10,6 +10,8 @@ flags: conf
 available: os = "win32"
 build: ["pkgconf" "--personality=x86_64-w64-mingw32" {os-distribution = "cygwin"} "libffi"]
 depends: [
+  "msys2" {build & os = "win32" & os-distribution = "msys2"}
+  "msys2-mingw64" {os = "win32" & os-distribution = "msys2"}
   "conf-pkg-config" {build}
   "conf-mingw-w64-gcc-x86_64" {build}
 ]

--- a/packages/conf-mingw-w64-libffi-x86_64/conf-mingw-w64-libffi-x86_64.1/opam
+++ b/packages/conf-mingw-w64-libffi-x86_64/conf-mingw-w64-libffi-x86_64.1/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-synopsis: "libffi for x86_64 mingw-w64 (64-bit x86_64)"
-description: "Ensures the x86_64 version of libfii for the mingw-w64 project is available"
+synopsis: "Virtual package for libffi on x86_64 mingw-w64 (64-bit x86_64)"
+description: "Ensures the x86_64 version of libffi for the mingw-w64 project is available"
 maintainer: "David Allsopp <david@tarides.com>"
 authors: "Anthony Green"
 license: "MIT"

--- a/packages/conf-mingw-w64-liblz4-i686/conf-mingw-w64-liblz4-i686.1/opam
+++ b/packages/conf-mingw-w64-liblz4-i686/conf-mingw-w64-liblz4-i686.1/opam
@@ -8,7 +8,7 @@ homepage: "http://lz4.org"
 bug-reports: "https://github.com/ocaml/opam-repository/issues"
 flags: conf
 available: os = "win32"
-build: ["pkgconf" "--personality=i686-w64-mingw32" "liblz4"]
+build: ["pkgconf" "--personality=i686-w64-mingw32" {os-distribution = "cygwin"} "liblz4"]
 depends: [
   "conf-pkg-config" {build}
   "conf-mingw-w64-gcc-i686" {build}

--- a/packages/conf-mingw-w64-liblz4-i686/conf-mingw-w64-liblz4-i686.1/opam
+++ b/packages/conf-mingw-w64-liblz4-i686/conf-mingw-w64-liblz4-i686.1/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-synopsis: "Provides liblz4 for i686 mingw-w64 (32-bit x86)"
-description: "Ensure that the i686 version of liblz4 for the mingw-w64 project is available"
+synopsis: "Virtual package for liblz4 on i686 mingw-w64 (32-bit x86)"
+description: "Ensures the i686 version of liblz4 for the mingw-w64 project is available"
 maintainer: "https://github.com/ocaml/opam-repository/issues"
 authors: ["Yann Collet"]
 license: ["GPL-2.0-only" "BSD-2-Clause"]

--- a/packages/conf-mingw-w64-liblz4-i686/conf-mingw-w64-liblz4-i686.1/opam
+++ b/packages/conf-mingw-w64-liblz4-i686/conf-mingw-w64-liblz4-i686.1/opam
@@ -10,6 +10,8 @@ flags: conf
 available: os = "win32"
 build: ["pkgconf" "--personality=i686-w64-mingw32" {os-distribution = "cygwin"} "liblz4"]
 depends: [
+  "msys2" {build & os = "win32" & os-distribution = "msys2"}
+  "msys2-mingw32" {os = "win32" & os-distribution = "msys2"}
   "conf-pkg-config" {build}
   "conf-mingw-w64-gcc-i686" {build}
 ]

--- a/packages/conf-mingw-w64-liblz4-i686/conf-mingw-w64-liblz4-i686.1/opam
+++ b/packages/conf-mingw-w64-liblz4-i686/conf-mingw-w64-liblz4-i686.1/opam
@@ -1,7 +1,7 @@
 opam-version: "2.0"
 synopsis: "Virtual package for liblz4 on i686 mingw-w64 (32-bit x86)"
 description: "Ensures the i686 version of liblz4 for the mingw-w64 project is available"
-maintainer: "https://github.com/ocaml/opam-repository/issues"
+maintainer: "David Allsopp <dra27@dra27.uk>"
 authors: ["Yann Collet"]
 license: ["GPL-2.0-only" "BSD-2-Clause"]
 homepage: "http://lz4.org"

--- a/packages/conf-mingw-w64-liblz4-x86_64/conf-mingw-w64-liblz4-x86_64.1/opam
+++ b/packages/conf-mingw-w64-liblz4-x86_64/conf-mingw-w64-liblz4-x86_64.1/opam
@@ -8,7 +8,7 @@ homepage: "http://lz4.org"
 bug-reports: "https://github.com/ocaml/opam-repository/issues"
 flags: conf
 available: os = "win32"
-build: ["pkgconf" "--personality=x86_64-w64-mingw32" "liblz4"]
+build: ["pkgconf" "--personality=x86_64-w64-mingw32" {os-distribution = "cygwin"} "liblz4"]
 depends: [
   "conf-pkg-config" {build}
   "conf-mingw-w64-gcc-x86_64" {build}

--- a/packages/conf-mingw-w64-liblz4-x86_64/conf-mingw-w64-liblz4-x86_64.1/opam
+++ b/packages/conf-mingw-w64-liblz4-x86_64/conf-mingw-w64-liblz4-x86_64.1/opam
@@ -10,6 +10,8 @@ flags: conf
 available: os = "win32"
 build: ["pkgconf" "--personality=x86_64-w64-mingw32" {os-distribution = "cygwin"} "liblz4"]
 depends: [
+  "msys2" {build & os = "win32" & os-distribution = "msys2"}
+  "msys2-mingw64" {os = "win32" & os-distribution = "msys2"}
   "conf-pkg-config" {build}
   "conf-mingw-w64-gcc-x86_64" {build}
 ]

--- a/packages/conf-mingw-w64-liblz4-x86_64/conf-mingw-w64-liblz4-x86_64.1/opam
+++ b/packages/conf-mingw-w64-liblz4-x86_64/conf-mingw-w64-liblz4-x86_64.1/opam
@@ -1,7 +1,7 @@
 opam-version: "2.0"
 synopsis: "Virtual package for liblz4 on x86_64 mingw-w64 (64-bit x86_64)"
 description: "Ensures the x86_64 version of liblz4 for the mingw-w64 project is available"
-maintainer: "https://github.com/ocaml/opam-repository/issues"
+maintainer: "David Allsopp <dra27@dra27.uk>"
 authors: ["Yann Collet"]
 license: ["GPL-2.0-only" "BSD-2-Clause"]
 homepage: "http://lz4.org"

--- a/packages/conf-mingw-w64-liblz4-x86_64/conf-mingw-w64-liblz4-x86_64.1/opam
+++ b/packages/conf-mingw-w64-liblz4-x86_64/conf-mingw-w64-liblz4-x86_64.1/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-synopsis: "Provides liblz4 for x86_64 mingw-w64 (64-bit x86_64)"
-description: "Ensure that the x86_64 version of liblz4 for the mingw-w64 project is available"
+synopsis: "Virtual package for liblz4 on x86_64 mingw-w64 (64-bit x86_64)"
+description: "Ensures the x86_64 version of liblz4 for the mingw-w64 project is available"
 maintainer: "https://github.com/ocaml/opam-repository/issues"
 authors: ["Yann Collet"]
 license: ["GPL-2.0-only" "BSD-2-Clause"]

--- a/packages/conf-mingw-w64-mbedtls-x86_64/conf-mingw-w64-mbedtls-x86_64.1/opam
+++ b/packages/conf-mingw-w64-mbedtls-x86_64/conf-mingw-w64-mbedtls-x86_64.1/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-synopsis: "Libmbedtls for x86_64 mingw-w64 (64-bit x86_64)"
+synopsis: "Virtual package for libmbedtls on x86_64 mingw-w64 (64-bit x86_64)"
 description: "Ensures the x86_64 version of libmbedtls for the mingw-w64 project is available"
 maintainer: "tobil4sk"
 authors: "Mbedtls contributors"

--- a/packages/conf-mingw-w64-mbedtls-x86_64/conf-mingw-w64-mbedtls-x86_64.1/opam
+++ b/packages/conf-mingw-w64-mbedtls-x86_64/conf-mingw-w64-mbedtls-x86_64.1/opam
@@ -12,6 +12,8 @@ build: [
   ["pkgconf" "--personality=x86_64-w64-mingw32" "mbedtls"]
 ]
 depends: [
+  "msys2" {build & os = "win32" & os-distribution = "msys2"}
+  "msys2-mingw64" {os = "win32" & os-distribution = "msys2"}
   "conf-pkg-config" {build}
   "conf-mingw-w64-gcc-x86_64" {build}
 ]

--- a/packages/conf-mingw-w64-mbedtls-x86_64/conf-mingw-w64-mbedtls-x86_64.1/opam
+++ b/packages/conf-mingw-w64-mbedtls-x86_64/conf-mingw-w64-mbedtls-x86_64.1/opam
@@ -1,10 +1,10 @@
 opam-version: "2.0"
 synopsis: "Virtual package for libmbedtls on x86_64 mingw-w64 (64-bit x86_64)"
 description: "Ensures the x86_64 version of libmbedtls for the mingw-w64 project is available"
-maintainer: "tobil4sk"
+maintainer: "David Allsopp <dra27@dra27.uk>"
 authors: "Mbedtls contributors"
 homepage: "https://www.trustedfirmware.org/projects/mbed-tls/"
-bug-reports: "https://github.com/Mbed-TLS/mbedtls/issues"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
 license: "Apache-2.0"
 flags: conf
 available: os = "win32" & os-distribution = "msys2"

--- a/packages/conf-mingw-w64-mbedtls-x86_64/conf-mingw-w64-mbedtls-x86_64.1/opam
+++ b/packages/conf-mingw-w64-mbedtls-x86_64/conf-mingw-w64-mbedtls-x86_64.1/opam
@@ -7,9 +7,10 @@ homepage: "https://www.trustedfirmware.org/projects/mbed-tls/"
 bug-reports: "https://github.com/Mbed-TLS/mbedtls/issues"
 license: "Apache-2.0"
 flags: conf
-available: os = "win32" & os-distribution != "cygwin"
+available: os = "win32" & os-distribution = "msys2"
 build: [
-  ["pkgconf" "--personality=x86_64-w64-mingw32" "mbedtls"]
+  "pkgconf"
+  "mbedtls"
 ]
 depends: [
   "msys2" {build & os = "win32" & os-distribution = "msys2"}

--- a/packages/conf-mingw-w64-ncurses-i686/conf-mingw-w64-ncurses-i686.1/opam
+++ b/packages/conf-mingw-w64-ncurses-i686/conf-mingw-w64-ncurses-i686.1/opam
@@ -18,7 +18,7 @@ depends: [
 synopsis: "Virtual package for ncurses on i686 mingw-w64 (32-bit x86)"
 description:
   "Ensures the i686 version of ncurses for the mingw-w64 project is available"
-maintainer: "David Allsopp <david@tarides.com>"
+maintainer: "David Allsopp <dra27@dra27.uk>"
 depexts: [
   ["mingw64-i686-ncurses"] {os = "win32" & os-distribution = "cygwin"}
   ["mingw-w64-i686-ncurses"] {os = "win32" & os-distribution = "msys2"}

--- a/packages/conf-mingw-w64-ncurses-i686/conf-mingw-w64-ncurses-i686.1/opam
+++ b/packages/conf-mingw-w64-ncurses-i686/conf-mingw-w64-ncurses-i686.1/opam
@@ -10,6 +10,8 @@ build: ["pkgconf" "--personality=i686-w64-mingw32" {os-distribution = "cygwin"}
         "ncursesw" {os-distribution = "msys2"}
 ]
 depends: [
+  "msys2" {build & os = "win32" & os-distribution = "msys2"}
+  "msys2-mingw32" {os = "win32" & os-distribution = "msys2"}
   "conf-pkg-config" {build}
   "conf-mingw-w64-gcc-i686" {build}
 ]

--- a/packages/conf-mingw-w64-ncurses-i686/conf-mingw-w64-ncurses-i686.1/opam
+++ b/packages/conf-mingw-w64-ncurses-i686/conf-mingw-w64-ncurses-i686.1/opam
@@ -5,7 +5,7 @@ bug-reports: "https://github.com/ocaml/opam-repository/issues"
 license: "MIT"
 flags: conf
 available: os = "win32"
-build: ["pkgconf" "--personality=i686-w64-mingw32"
+build: ["pkgconf" "--personality=i686-w64-mingw32" {os-distribution = "cygwin"}
         "ncurses"  {os-distribution = "cygwin"}
         "ncursesw" {os-distribution = "msys2"}
 ]

--- a/packages/conf-mingw-w64-ncurses-i686/conf-mingw-w64-ncurses-i686.1/opam
+++ b/packages/conf-mingw-w64-ncurses-i686/conf-mingw-w64-ncurses-i686.1/opam
@@ -15,9 +15,9 @@ depends: [
   "conf-pkg-config" {build}
   "conf-mingw-w64-gcc-i686" {build}
 ]
-synopsis: "ncurses for i686 mingw-w64"
+synopsis: "Virtual package for ncurses on i686 mingw-w64 (32-bit x86)"
 description:
-  "Ensure the i686 version of ncurses for the mingw-w64 project is available"
+  "Ensures the i686 version of ncurses for the mingw-w64 project is available"
 maintainer: "David Allsopp <david@tarides.com>"
 depexts: [
   ["mingw64-i686-ncurses"] {os = "win32" & os-distribution = "cygwin"}

--- a/packages/conf-mingw-w64-ncurses-x86_64/conf-mingw-w64-ncurses-x86_64.1/opam
+++ b/packages/conf-mingw-w64-ncurses-x86_64/conf-mingw-w64-ncurses-x86_64.1/opam
@@ -15,9 +15,9 @@ depends: [
   "conf-pkg-config" {build}
   "conf-mingw-w64-gcc-x86_64" {build}
 ]
-synopsis: "ncurses for x86_64 mingw-w64"
+synopsis: "Virtual package for ncurses on x86_64 mingw-w64 (64-bit x86_64)"
 description:
-  "Ensure the x86_64 version of ncurses for the mingw-w64 project is available"
+  "Ensures the x86_64 version of ncurses for the mingw-w64 project is available"
 maintainer: "David Allsopp <david@tarides.com>"
 depexts: [
   ["mingw64-x86_64-ncurses"] {os = "win32" & os-distribution = "cygwin"}

--- a/packages/conf-mingw-w64-ncurses-x86_64/conf-mingw-w64-ncurses-x86_64.1/opam
+++ b/packages/conf-mingw-w64-ncurses-x86_64/conf-mingw-w64-ncurses-x86_64.1/opam
@@ -5,7 +5,7 @@ bug-reports: "https://github.com/ocaml/opam-repository/issues"
 license: "MIT"
 flags: conf
 available: os = "win32"
-build: ["pkgconf" "--personality=x86_64-w64-mingw32"
+build: ["pkgconf" "--personality=x86_64-w64-mingw32" {os-distribution = "cygwin"}
         "ncurses"  {os-distribution = "cygwin"}
         "ncursesw" {os-distribution = "msys2"}
 ]

--- a/packages/conf-mingw-w64-ncurses-x86_64/conf-mingw-w64-ncurses-x86_64.1/opam
+++ b/packages/conf-mingw-w64-ncurses-x86_64/conf-mingw-w64-ncurses-x86_64.1/opam
@@ -10,6 +10,8 @@ build: ["pkgconf" "--personality=x86_64-w64-mingw32" {os-distribution = "cygwin"
         "ncursesw" {os-distribution = "msys2"}
 ]
 depends: [
+  "msys2" {build & os = "win32" & os-distribution = "msys2"}
+  "msys2-mingw64" {os = "win32" & os-distribution = "msys2"}
   "conf-pkg-config" {build}
   "conf-mingw-w64-gcc-x86_64" {build}
 ]

--- a/packages/conf-mingw-w64-ncurses-x86_64/conf-mingw-w64-ncurses-x86_64.1/opam
+++ b/packages/conf-mingw-w64-ncurses-x86_64/conf-mingw-w64-ncurses-x86_64.1/opam
@@ -18,7 +18,7 @@ depends: [
 synopsis: "Virtual package for ncurses on x86_64 mingw-w64 (64-bit x86_64)"
 description:
   "Ensures the x86_64 version of ncurses for the mingw-w64 project is available"
-maintainer: "David Allsopp <david@tarides.com>"
+maintainer: "David Allsopp <dra27@dra27.uk>"
 depexts: [
   ["mingw64-x86_64-ncurses"] {os = "win32" & os-distribution = "cygwin"}
   ["mingw-w64-x86_64-ncurses"] {os = "win32" & os-distribution = "msys2"}

--- a/packages/conf-mingw-w64-nettle-i686/conf-mingw-w64-nettle-i686.1/opam
+++ b/packages/conf-mingw-w64-nettle-i686/conf-mingw-w64-nettle-i686.1/opam
@@ -15,7 +15,7 @@ depends: [
 synopsis: "Virtual package for nettle on i686 mingw-w64 (32-bit x86)"
 description:
   "Ensures the i686 version of nettle for the mingw-w64 project is available"
-maintainer: "David Allsopp <david@tarides.com>"
+maintainer: "David Allsopp <dra27@dra27.uk>"
 depexts: [
   ["mingw64-i686-nettle"] {os = "win32" & os-distribution = "cygwin"}
   ["mingw-w64-i686-nettle"] {os = "win32" & os-distribution = "msys2"}

--- a/packages/conf-mingw-w64-nettle-i686/conf-mingw-w64-nettle-i686.1/opam
+++ b/packages/conf-mingw-w64-nettle-i686/conf-mingw-w64-nettle-i686.1/opam
@@ -12,9 +12,9 @@ depends: [
   "conf-pkg-config" {build}
   "conf-mingw-w64-gcc-i686" {build}
 ]
-synopsis: "Nettle for i686 mingw-w64"
+synopsis: "Virtual package for nettle on i686 mingw-w64 (32-bit x86)"
 description:
-  "Ensure the i686 version of nettle for the mingw-w64 project is available"
+  "Ensures the i686 version of nettle for the mingw-w64 project is available"
 maintainer: "David Allsopp <david@tarides.com>"
 depexts: [
   ["mingw64-i686-nettle"] {os = "win32" & os-distribution = "cygwin"}

--- a/packages/conf-mingw-w64-nettle-i686/conf-mingw-w64-nettle-i686.1/opam
+++ b/packages/conf-mingw-w64-nettle-i686/conf-mingw-w64-nettle-i686.1/opam
@@ -5,7 +5,7 @@ license: "LGPL-2.1-or-later"
 bug-reports: "https://github.com/ocaml/opam-repository/issues"
 flags: conf
 available: os = "win32"
-build: ["pkgconf" "--personality=i686-w64-mingw32" "nettle"]
+build: ["pkgconf" "--personality=i686-w64-mingw32" {os-distribution = "cygwin"} "nettle"]
 depends: [
   "conf-pkg-config" {build}
   "conf-mingw-w64-gcc-i686" {build}

--- a/packages/conf-mingw-w64-nettle-i686/conf-mingw-w64-nettle-i686.1/opam
+++ b/packages/conf-mingw-w64-nettle-i686/conf-mingw-w64-nettle-i686.1/opam
@@ -7,6 +7,8 @@ flags: conf
 available: os = "win32"
 build: ["pkgconf" "--personality=i686-w64-mingw32" {os-distribution = "cygwin"} "nettle"]
 depends: [
+  "msys2" {build & os = "win32" & os-distribution = "msys2"}
+  "msys2-mingw32" {os = "win32" & os-distribution = "msys2"}
   "conf-pkg-config" {build}
   "conf-mingw-w64-gcc-i686" {build}
 ]

--- a/packages/conf-mingw-w64-nettle-x86_64/conf-mingw-w64-nettle-x86_64.1/opam
+++ b/packages/conf-mingw-w64-nettle-x86_64/conf-mingw-w64-nettle-x86_64.1/opam
@@ -7,6 +7,8 @@ flags: conf
 available: os = "win32"
 build: ["pkgconf" "--personality=x86_64-w64-mingw32" {os-distribution = "cygwin"} "nettle"]
 depends: [
+  "msys2" {build & os = "win32" & os-distribution = "msys2"}
+  "msys2-mingw64" {os = "win32" & os-distribution = "msys2"}
   "conf-pkg-config" {build}
   "conf-mingw-w64-gcc-x86_64" {build}
 ]

--- a/packages/conf-mingw-w64-nettle-x86_64/conf-mingw-w64-nettle-x86_64.1/opam
+++ b/packages/conf-mingw-w64-nettle-x86_64/conf-mingw-w64-nettle-x86_64.1/opam
@@ -15,7 +15,7 @@ depends: [
 synopsis: "Virtual package for nettle on x86_64 mingw-w64 (64-bit x86_64)"
 description:
   "Ensures the x86_64 version of nettle for the mingw-w64 project is available"
-maintainer: "David Allsopp <david@tarides.com>"
+maintainer: "David Allsopp <dra27@dra27.uk>"
 depexts: [
   ["mingw64-x86_64-nettle"] {os = "win32" & os-distribution = "cygwin"}
   ["mingw-w64-x86_64-nettle"] {os = "win32" & os-distribution = "msys2"}

--- a/packages/conf-mingw-w64-nettle-x86_64/conf-mingw-w64-nettle-x86_64.1/opam
+++ b/packages/conf-mingw-w64-nettle-x86_64/conf-mingw-w64-nettle-x86_64.1/opam
@@ -5,7 +5,7 @@ license: "LGPL-2.1-or-later"
 bug-reports: "https://github.com/ocaml/opam-repository/issues"
 flags: conf
 available: os = "win32"
-build: ["pkgconf" "--personality=x86_64-w64-mingw32" "nettle"]
+build: ["pkgconf" "--personality=x86_64-w64-mingw32" {os-distribution = "cygwin"} "nettle"]
 depends: [
   "conf-pkg-config" {build}
   "conf-mingw-w64-gcc-x86_64" {build}

--- a/packages/conf-mingw-w64-nettle-x86_64/conf-mingw-w64-nettle-x86_64.1/opam
+++ b/packages/conf-mingw-w64-nettle-x86_64/conf-mingw-w64-nettle-x86_64.1/opam
@@ -12,9 +12,9 @@ depends: [
   "conf-pkg-config" {build}
   "conf-mingw-w64-gcc-x86_64" {build}
 ]
-synopsis: "Nettle for x86_64 mingw-w64"
+synopsis: "Virtual package for nettle on x86_64 mingw-w64 (64-bit x86_64)"
 description:
-  "Ensure the x86_64 version of nettle for the mingw-w64 project is available"
+  "Ensures the x86_64 version of nettle for the mingw-w64 project is available"
 maintainer: "David Allsopp <david@tarides.com>"
 depexts: [
   ["mingw64-x86_64-nettle"] {os = "win32" & os-distribution = "cygwin"}

--- a/packages/conf-mingw-w64-openssl-i686/conf-mingw-w64-openssl-i686.1/opam
+++ b/packages/conf-mingw-w64-openssl-i686/conf-mingw-w64-openssl-i686.1/opam
@@ -8,7 +8,7 @@ homepage: "https://www.openssl.org"
 bug-reports: "https://github.com/ocaml/opam-repository/issues"
 flags: conf
 available: os = "win32"
-build: ["pkgconf" "--personality=i686-w64-mingw32" "openssl"]
+build: ["pkgconf" "--personality=i686-w64-mingw32" {os-distribution = "cygwin"} "openssl"]
 depends: [
   "conf-pkg-config" {build}
   "conf-mingw-w64-gcc-i686" {build}

--- a/packages/conf-mingw-w64-openssl-i686/conf-mingw-w64-openssl-i686.1/opam
+++ b/packages/conf-mingw-w64-openssl-i686/conf-mingw-w64-openssl-i686.1/opam
@@ -1,7 +1,7 @@
 opam-version: "2.0"
 synopsis: "Virtual package for libssl on i686 mingw-w64 (32-bit x86)"
 description: "Ensures the i686 version of libssl for the mingw-w64 project is available"
-maintainer: "David Allsopp <david@tarides.com>"
+maintainer: "David Allsopp <dra27@dra27.uk>"
 authors: "The OpenSSL Project"
 license: "Apache-1.0"
 homepage: "https://www.openssl.org"

--- a/packages/conf-mingw-w64-openssl-i686/conf-mingw-w64-openssl-i686.1/opam
+++ b/packages/conf-mingw-w64-openssl-i686/conf-mingw-w64-openssl-i686.1/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-synopsis: "libssl for i686 mingw-w64 (32-bit x86)"
+synopsis: "Virtual package for libssl on i686 mingw-w64 (32-bit x86)"
 description: "Ensures the i686 version of libssl for the mingw-w64 project is available"
 maintainer: "David Allsopp <david@tarides.com>"
 authors: "The OpenSSL Project"

--- a/packages/conf-mingw-w64-openssl-i686/conf-mingw-w64-openssl-i686.1/opam
+++ b/packages/conf-mingw-w64-openssl-i686/conf-mingw-w64-openssl-i686.1/opam
@@ -10,6 +10,8 @@ flags: conf
 available: os = "win32"
 build: ["pkgconf" "--personality=i686-w64-mingw32" {os-distribution = "cygwin"} "openssl"]
 depends: [
+  "msys2" {build & os = "win32" & os-distribution = "msys2"}
+  "msys2-mingw32" {os = "win32" & os-distribution = "msys2"}
   "conf-pkg-config" {build}
   "conf-mingw-w64-gcc-i686" {build}
 ]

--- a/packages/conf-mingw-w64-openssl-x86_64/conf-mingw-w64-openssl-x86_64.1/opam
+++ b/packages/conf-mingw-w64-openssl-x86_64/conf-mingw-w64-openssl-x86_64.1/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-synopsis: "libssl for x86_64 mingw-w64 (64-bit x86_64)"
+synopsis: "Virtual package for libssl on x86_64 mingw-w64 (64-bit x86_64)"
 description: "Ensures the x86_64 version of libssl for the mingw-w64 project is available"
 maintainer: "David Allsopp <david@tarides.com>"
 authors: "The OpenSSL Project"

--- a/packages/conf-mingw-w64-openssl-x86_64/conf-mingw-w64-openssl-x86_64.1/opam
+++ b/packages/conf-mingw-w64-openssl-x86_64/conf-mingw-w64-openssl-x86_64.1/opam
@@ -8,7 +8,7 @@ homepage: "https://www.openssl.org"
 bug-reports: "https://github.com/ocaml/opam-repository/issues"
 flags: conf
 available: os = "win32"
-build: ["pkgconf" "--personality=x86_64-w64-mingw32" "openssl"]
+build: ["pkgconf" "--personality=x86_64-w64-mingw32" {os-distribution = "cygwin"} "openssl"]
 depends: [
   "conf-pkg-config" {build}
   "conf-mingw-w64-gcc-x86_64" {build}

--- a/packages/conf-mingw-w64-openssl-x86_64/conf-mingw-w64-openssl-x86_64.1/opam
+++ b/packages/conf-mingw-w64-openssl-x86_64/conf-mingw-w64-openssl-x86_64.1/opam
@@ -1,7 +1,7 @@
 opam-version: "2.0"
 synopsis: "Virtual package for libssl on x86_64 mingw-w64 (64-bit x86_64)"
 description: "Ensures the x86_64 version of libssl for the mingw-w64 project is available"
-maintainer: "David Allsopp <david@tarides.com>"
+maintainer: "David Allsopp <dra27@dra27.uk>"
 authors: "The OpenSSL Project"
 license: "Apache-1.0"
 homepage: "https://www.openssl.org"

--- a/packages/conf-mingw-w64-openssl-x86_64/conf-mingw-w64-openssl-x86_64.1/opam
+++ b/packages/conf-mingw-w64-openssl-x86_64/conf-mingw-w64-openssl-x86_64.1/opam
@@ -10,6 +10,8 @@ flags: conf
 available: os = "win32"
 build: ["pkgconf" "--personality=x86_64-w64-mingw32" {os-distribution = "cygwin"} "openssl"]
 depends: [
+  "msys2" {build & os = "win32" & os-distribution = "msys2"}
+  "msys2-mingw64" {os = "win32" & os-distribution = "msys2"}
   "conf-pkg-config" {build}
   "conf-mingw-w64-gcc-x86_64" {build}
 ]

--- a/packages/conf-mingw-w64-pcre-i686/conf-mingw-w64-pcre-i686.1/opam
+++ b/packages/conf-mingw-w64-pcre-i686/conf-mingw-w64-pcre-i686.1/opam
@@ -11,7 +11,7 @@ homepage: "https://www.pcre.org/"
 bug-reports: "https://github.com/ocaml/opam-repository/issues"
 flags: conf
 available: os = "win32"
-build: ["pkgconf" "--personality=i686-w64-mingw32" "libpcre"]
+build: ["pkgconf" "--personality=i686-w64-mingw32" {os-distribution = "cygwin"} "libpcre"]
 depends: [
   "conf-pkg-config" {build}
   "conf-mingw-w64-gcc-i686" {build}

--- a/packages/conf-mingw-w64-pcre-i686/conf-mingw-w64-pcre-i686.1/opam
+++ b/packages/conf-mingw-w64-pcre-i686/conf-mingw-w64-pcre-i686.1/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-synopsis: "Libpcre for i686 mingw-w64 (32-bit x86)"
+synopsis: "Virtual package for libpcre on i686 mingw-w64 (32-bit x86)"
 description: "Ensures the i686 version of libpcre for the mingw-w64 project is available"
 maintainer: "Yosef Alsuhaibani <yosef@semgrep.com>"
 authors:[

--- a/packages/conf-mingw-w64-pcre-i686/conf-mingw-w64-pcre-i686.1/opam
+++ b/packages/conf-mingw-w64-pcre-i686/conf-mingw-w64-pcre-i686.1/opam
@@ -1,7 +1,7 @@
 opam-version: "2.0"
 synopsis: "Virtual package for libpcre on i686 mingw-w64 (32-bit x86)"
 description: "Ensures the i686 version of libpcre for the mingw-w64 project is available"
-maintainer: "Yosef Alsuhaibani <yosef@semgrep.com>"
+maintainer: "David Allsopp <dra27@dra27.uk>"
 authors:[
   "Philip Hazel"
   "Zoltan Herczeg"

--- a/packages/conf-mingw-w64-pcre-i686/conf-mingw-w64-pcre-i686.1/opam
+++ b/packages/conf-mingw-w64-pcre-i686/conf-mingw-w64-pcre-i686.1/opam
@@ -13,6 +13,8 @@ flags: conf
 available: os = "win32"
 build: ["pkgconf" "--personality=i686-w64-mingw32" {os-distribution = "cygwin"} "libpcre"]
 depends: [
+  "msys2" {build & os = "win32" & os-distribution = "msys2"}
+  "msys2-mingw32" {os = "win32" & os-distribution = "msys2"}
   "conf-pkg-config" {build}
   "conf-mingw-w64-gcc-i686" {build}
 ]

--- a/packages/conf-mingw-w64-pcre-i686/conf-mingw-w64-pcre-i686.1/opam
+++ b/packages/conf-mingw-w64-pcre-i686/conf-mingw-w64-pcre-i686.1/opam
@@ -10,15 +10,13 @@ license: "BSD-3-Clause"
 homepage: "https://www.pcre.org/"
 bug-reports: "https://github.com/ocaml/opam-repository/issues"
 flags: conf
-available: os = "win32"
+available: os = "win32" & os-distribution = "cygwin"
 build: ["pkgconf" "--personality=i686-w64-mingw32" {os-distribution = "cygwin"} "libpcre"]
 depends: [
-  "msys2" {build & os = "win32" & os-distribution = "msys2"}
-  "msys2-mingw32" {os = "win32" & os-distribution = "msys2"}
   "conf-pkg-config" {build}
   "conf-mingw-w64-gcc-i686" {build}
 ]
 depexts: [
   ["mingw64-i686-pcre"] {os = "win32" & os-distribution = "cygwin"}
-  ["mingw-w64-i686-pcre"] {os = "win32" & os-distribution = "msys2"}
+  # no i686 package available at https://packages.msys2.org/base/mingw-w64-pcre
 ]

--- a/packages/conf-mingw-w64-pcre-x86_64/conf-mingw-w64-pcre-x86_64.1/opam
+++ b/packages/conf-mingw-w64-pcre-x86_64/conf-mingw-w64-pcre-x86_64.1/opam
@@ -13,6 +13,8 @@ flags: conf
 available: os = "win32"
 build: ["pkgconf" "--personality=x86_64-w64-mingw32" {os-distribution = "cygwin"} "libpcre"]
 depends: [
+  "msys2" {build & os = "win32" & os-distribution = "msys2"}
+  "msys2-mingw64" {os = "win32" & os-distribution = "msys2"}
   "conf-pkg-config" {build}
   "conf-mingw-w64-gcc-x86_64" {build}
 ]

--- a/packages/conf-mingw-w64-pcre-x86_64/conf-mingw-w64-pcre-x86_64.1/opam
+++ b/packages/conf-mingw-w64-pcre-x86_64/conf-mingw-w64-pcre-x86_64.1/opam
@@ -11,7 +11,7 @@ homepage: "https://www.pcre.org/"
 bug-reports: "https://github.com/ocaml/opam-repository/issues"
 flags: conf
 available: os = "win32"
-build: ["pkgconf" "--personality=x86_64-w64-mingw32" "libpcre"]
+build: ["pkgconf" "--personality=x86_64-w64-mingw32" {os-distribution = "cygwin"} "libpcre"]
 depends: [
   "conf-pkg-config" {build}
   "conf-mingw-w64-gcc-x86_64" {build}

--- a/packages/conf-mingw-w64-pcre-x86_64/conf-mingw-w64-pcre-x86_64.1/opam
+++ b/packages/conf-mingw-w64-pcre-x86_64/conf-mingw-w64-pcre-x86_64.1/opam
@@ -1,7 +1,7 @@
 opam-version: "2.0"
 synopsis: "Virtual package for libpcre on x86_64 mingw-w64 (64-bit x86_64)"
 description: "Ensures the x86_64 version of libpcre for the mingw-w64 project is available"
-maintainer: "Yosef Alsuhaibani <yosef@semgrep.com>"
+maintainer: "David Allsopp <dra27@dra27.uk>"
 authors:[
   "Philip Hazel"
   "Zoltan Herczeg"

--- a/packages/conf-mingw-w64-pcre-x86_64/conf-mingw-w64-pcre-x86_64.1/opam
+++ b/packages/conf-mingw-w64-pcre-x86_64/conf-mingw-w64-pcre-x86_64.1/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-synopsis: "Libpcre for x86_64 mingw-w64 (64-bit x86_64)"
+synopsis: "Virtual package for libpcre on x86_64 mingw-w64 (64-bit x86_64)"
 description: "Ensures the x86_64 version of libpcre for the mingw-w64 project is available"
 maintainer: "Yosef Alsuhaibani <yosef@semgrep.com>"
 authors:[

--- a/packages/conf-mingw-w64-pcre2-i686/conf-mingw-w64-pcre2-i686.1/opam
+++ b/packages/conf-mingw-w64-pcre2-i686/conf-mingw-w64-pcre2-i686.1/opam
@@ -1,7 +1,7 @@
 opam-version: "2.0"
 synopsis: "Virtual package for libpcre2 on i686 mingw-w64 (32-bit x86)"
 description: "Ensures the i686 version of libpcre2 for the mingw-w64 project is available"
-maintainer: "tobil4sk"
+maintainer: "David Allsopp <dra27@dra27.uk>"
 authors:[
   "Philip Hazel"
   "Zoltan Herczeg"

--- a/packages/conf-mingw-w64-pcre2-i686/conf-mingw-w64-pcre2-i686.1/opam
+++ b/packages/conf-mingw-w64-pcre2-i686/conf-mingw-w64-pcre2-i686.1/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-synopsis: "Libpcre2 for i686 mingw-w64 (32-bit x86)"
+synopsis: "Virtual package for libpcre2 on i686 mingw-w64 (32-bit x86)"
 description: "Ensures the i686 version of libpcre2 for the mingw-w64 project is available"
 maintainer: "tobil4sk"
 authors:[

--- a/packages/conf-mingw-w64-pcre2-i686/conf-mingw-w64-pcre2-i686.1/opam
+++ b/packages/conf-mingw-w64-pcre2-i686/conf-mingw-w64-pcre2-i686.1/opam
@@ -10,8 +10,8 @@ license: "BSD-3-Clause"
 homepage: "https://www.pcre.org/"
 bug-reports: "https://github.com/ocaml/opam-repository/issues"
 flags: conf
-available: os = "win32" & os-distribution = "cygwin"
-build: ["pkgconf" "--personality=i686-w64-mingw32" "libpcre2-8"]
+available: os = "win32"
+build: ["pkgconf" "--personality=i686-w64-mingw32" {os-distribution = "cygwin"} "libpcre2-8"]
 depends: [
   "msys2" {build & os = "win32" & os-distribution = "msys2"}
   "msys2-mingw32" {os = "win32" & os-distribution = "msys2"}

--- a/packages/conf-mingw-w64-pcre2-i686/conf-mingw-w64-pcre2-i686.1/opam
+++ b/packages/conf-mingw-w64-pcre2-i686/conf-mingw-w64-pcre2-i686.1/opam
@@ -13,6 +13,8 @@ flags: conf
 available: os = "win32" & os-distribution = "cygwin"
 build: ["pkgconf" "--personality=i686-w64-mingw32" "libpcre2-8"]
 depends: [
+  "msys2" {build & os = "win32" & os-distribution = "msys2"}
+  "msys2-mingw32" {os = "win32" & os-distribution = "msys2"}
   "conf-pkg-config" {build}
   "conf-mingw-w64-gcc-i686" {build}
 ]

--- a/packages/conf-mingw-w64-pcre2-x86_64/conf-mingw-w64-pcre2-x86_64.1/opam
+++ b/packages/conf-mingw-w64-pcre2-x86_64/conf-mingw-w64-pcre2-x86_64.1/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-synopsis: "Libpcre2 for x86_64 mingw-w64 (64-bit x86_64)"
+synopsis: "Virtual package for libpcre2 on x86_64 mingw-w64 (64-bit x86_64)"
 description: "Ensures the x86_64 version of libpcre2 for the mingw-w64 project is available"
 maintainer: "tobil4sk"
 authors:[

--- a/packages/conf-mingw-w64-pcre2-x86_64/conf-mingw-w64-pcre2-x86_64.1/opam
+++ b/packages/conf-mingw-w64-pcre2-x86_64/conf-mingw-w64-pcre2-x86_64.1/opam
@@ -13,6 +13,8 @@ flags: conf
 available: os = "win32"
 build: ["pkgconf" "--personality=x86_64-w64-mingw32" {os-distribution = "cygwin"} "libpcre2-8"]
 depends: [
+  "msys2" {build & os = "win32" & os-distribution = "msys2"}
+  "msys2-mingw64" {os = "win32" & os-distribution = "msys2"}
   "conf-pkg-config" {build}
   "conf-mingw-w64-gcc-x86_64" {build}
 ]

--- a/packages/conf-mingw-w64-pcre2-x86_64/conf-mingw-w64-pcre2-x86_64.1/opam
+++ b/packages/conf-mingw-w64-pcre2-x86_64/conf-mingw-w64-pcre2-x86_64.1/opam
@@ -11,7 +11,7 @@ homepage: "https://www.pcre.org/"
 bug-reports: "https://github.com/ocaml/opam-repository/issues"
 flags: conf
 available: os = "win32"
-build: ["pkgconf" "--personality=x86_64-w64-mingw32" "libpcre2-8"]
+build: ["pkgconf" "--personality=x86_64-w64-mingw32" {os-distribution = "cygwin"} "libpcre2-8"]
 depends: [
   "conf-pkg-config" {build}
   "conf-mingw-w64-gcc-x86_64" {build}

--- a/packages/conf-mingw-w64-pcre2-x86_64/conf-mingw-w64-pcre2-x86_64.1/opam
+++ b/packages/conf-mingw-w64-pcre2-x86_64/conf-mingw-w64-pcre2-x86_64.1/opam
@@ -1,7 +1,7 @@
 opam-version: "2.0"
 synopsis: "Virtual package for libpcre2 on x86_64 mingw-w64 (64-bit x86_64)"
 description: "Ensures the x86_64 version of libpcre2 for the mingw-w64 project is available"
-maintainer: "tobil4sk"
+maintainer: "David Allsopp <dra27@dra27.uk>"
 authors:[
   "Philip Hazel"
   "Zoltan Herczeg"

--- a/packages/conf-mingw-w64-pkgconf-i686/conf-mingw-w64-pkgconf-i686.1/opam
+++ b/packages/conf-mingw-w64-pkgconf-i686/conf-mingw-w64-pkgconf-i686.1/opam
@@ -7,7 +7,7 @@ license: "ISC"
 homepage: "http://pkgconf.org"
 bug-reports: "https://github.com/ocaml/opam-repository/issues"
 flags: conf
-available: os = "win32"
+available: os = "win32" & os-distribution = "msys2"
 depends: [
   "msys2" {build & os = "win32" & os-distribution = "msys2"}
   "msys2-mingw32" {os = "win32" & os-distribution = "msys2"}

--- a/packages/conf-mingw-w64-pkgconf-i686/conf-mingw-w64-pkgconf-i686.1/opam
+++ b/packages/conf-mingw-w64-pkgconf-i686/conf-mingw-w64-pkgconf-i686.1/opam
@@ -1,7 +1,7 @@
 opam-version: "2.0"
 synopsis: "Virtual package for pkgconf on i686 mingw-w64 (32-bit x86)"
 description: "Ensures the i686 version of pkgconf for the mingw-w64 project is available"
-maintainer: "David Allsopp <david@tarides.com>"
+maintainer: "David Allsopp <dra27@dra27.uk>"
 authors: "Ariadne Conill et al"
 license: "ISC"
 homepage: "http://pkgconf.org"

--- a/packages/conf-mingw-w64-pkgconf-x86_64/conf-mingw-w64-pkgconf-x86_64.1/opam
+++ b/packages/conf-mingw-w64-pkgconf-x86_64/conf-mingw-w64-pkgconf-x86_64.1/opam
@@ -1,7 +1,7 @@
 opam-version: "2.0"
 synopsis: "Virtual package for pkgconf on x86_64 mingw-w64 (64-bit x86_64)"
 description: "Ensures the x86_64 version of pkgconf for the mingw-w64 project is available"
-maintainer: "David Allsopp <david@tarides.com>"
+maintainer: "David Allsopp <dra27@dra27.uk>"
 authors: "Ariadne Conill et al"
 license: "ISC"
 homepage: "http://pkgconf.org"

--- a/packages/conf-mingw-w64-postgresql-i686/conf-mingw-w64-postgresql-i686.1/opam
+++ b/packages/conf-mingw-w64-postgresql-i686/conf-mingw-w64-postgresql-i686.1/opam
@@ -7,15 +7,13 @@ license: "blessing"
 homepage: "http://www.postgresql.org"
 bug-reports: "https://github.com/ocaml/opam-repository/issues"
 flags: conf
-available: os = "win32"
+available: os = "win32" & os-distribution = "cygwin"
 build: ["pkgconf" "--personality=i686-w64-mingw32" {os-distribution = "cygwin"} "libpq"]
 depends: [
-  "msys2" {build & os = "win32" & os-distribution = "msys2"}
-  "msys2-mingw32" {os = "win32" & os-distribution = "msys2"}
   "conf-pkg-config" {build}
   "conf-mingw-w64-gcc-i686" {build}
 ]
 depexts: [
   ["mingw64-i686-postgresql"] {os = "win32" & os-distribution = "cygwin"}
-  ["mingw-w64-i686-postgresql"] {os = "win32" & os-distribution = "msys2"}
+  # no i686 package available at https://packages.msys2.org/base/mingw-w64-postgresql
 ]

--- a/packages/conf-mingw-w64-postgresql-i686/conf-mingw-w64-postgresql-i686.1/opam
+++ b/packages/conf-mingw-w64-postgresql-i686/conf-mingw-w64-postgresql-i686.1/opam
@@ -10,6 +10,8 @@ flags: conf
 available: os = "win32"
 build: ["pkgconf" "--personality=i686-w64-mingw32" {os-distribution = "cygwin"} "libpq"]
 depends: [
+  "msys2" {build & os = "win32" & os-distribution = "msys2"}
+  "msys2-mingw32" {os = "win32" & os-distribution = "msys2"}
   "conf-pkg-config" {build}
   "conf-mingw-w64-gcc-i686" {build}
 ]

--- a/packages/conf-mingw-w64-postgresql-i686/conf-mingw-w64-postgresql-i686.1/opam
+++ b/packages/conf-mingw-w64-postgresql-i686/conf-mingw-w64-postgresql-i686.1/opam
@@ -1,7 +1,7 @@
 opam-version: "2.0"
 synopsis: "Virtual package for postgresql on i686 mingw-w64 (32-bit x86)"
 description: "Ensures the i686 version of postgresql for the mingw-w64 project is available"
-maintainer: "David Allsopp <david@tarides.com>"
+maintainer: "David Allsopp <dra27@dra27.uk>"
 authors: "Markus Mottl"
 license: "blessing"
 homepage: "http://www.postgresql.org"

--- a/packages/conf-mingw-w64-postgresql-i686/conf-mingw-w64-postgresql-i686.1/opam
+++ b/packages/conf-mingw-w64-postgresql-i686/conf-mingw-w64-postgresql-i686.1/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-synopsis: "Postgresql for i686 mingw-w64 (32-bit x86)"
+synopsis: "Virtual package for postgresql on i686 mingw-w64 (32-bit x86)"
 description: "Ensures the i686 version of postgresql for the mingw-w64 project is available"
 maintainer: "David Allsopp <david@tarides.com>"
 authors: "Markus Mottl"

--- a/packages/conf-mingw-w64-postgresql-i686/conf-mingw-w64-postgresql-i686.1/opam
+++ b/packages/conf-mingw-w64-postgresql-i686/conf-mingw-w64-postgresql-i686.1/opam
@@ -8,7 +8,7 @@ homepage: "http://www.postgresql.org"
 bug-reports: "https://github.com/ocaml/opam-repository/issues"
 flags: conf
 available: os = "win32"
-build: ["pkgconf" "--personality=i686-w64-mingw32" "libpq"]
+build: ["pkgconf" "--personality=i686-w64-mingw32" {os-distribution = "cygwin"} "libpq"]
 depends: [
   "conf-pkg-config" {build}
   "conf-mingw-w64-gcc-i686" {build}

--- a/packages/conf-mingw-w64-postgresql-x86_64/conf-mingw-w64-postgresql-x86_64.1/opam
+++ b/packages/conf-mingw-w64-postgresql-x86_64/conf-mingw-w64-postgresql-x86_64.1/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-synopsis: "Postgresql for x86_64 mingw-w64 (64-bit x86_64)"
+synopsis: "Virtual package for postgresql on x86_64 mingw-w64 (64-bit x86_64)"
 description: "Ensures the x86_64 version of postgresql for the mingw-w64 project is available"
 maintainer: "David Allsopp <david@tarides.com>"
 authors: "Markus Mottl"

--- a/packages/conf-mingw-w64-postgresql-x86_64/conf-mingw-w64-postgresql-x86_64.1/opam
+++ b/packages/conf-mingw-w64-postgresql-x86_64/conf-mingw-w64-postgresql-x86_64.1/opam
@@ -10,6 +10,8 @@ flags: conf
 available: os = "win32"
 build: ["pkgconf" "--personality=x86_64-w64-mingw32" {os-distribution = "cygwin"} "libpq"]
 depends: [
+  "msys2" {build & os = "win32" & os-distribution = "msys2"}
+  "msys2-mingw64" {os = "win32" & os-distribution = "msys2"}
   "conf-pkg-config" {build}
   "conf-mingw-w64-gcc-x86_64" {build}
 ]

--- a/packages/conf-mingw-w64-postgresql-x86_64/conf-mingw-w64-postgresql-x86_64.1/opam
+++ b/packages/conf-mingw-w64-postgresql-x86_64/conf-mingw-w64-postgresql-x86_64.1/opam
@@ -1,7 +1,7 @@
 opam-version: "2.0"
 synopsis: "Virtual package for postgresql on x86_64 mingw-w64 (64-bit x86_64)"
 description: "Ensures the x86_64 version of postgresql for the mingw-w64 project is available"
-maintainer: "David Allsopp <david@tarides.com>"
+maintainer: "David Allsopp <dra27@dra27.uk>"
 authors: "Markus Mottl"
 license: "blessing"
 homepage: "http://www.postgresql.org"

--- a/packages/conf-mingw-w64-postgresql-x86_64/conf-mingw-w64-postgresql-x86_64.1/opam
+++ b/packages/conf-mingw-w64-postgresql-x86_64/conf-mingw-w64-postgresql-x86_64.1/opam
@@ -8,7 +8,7 @@ homepage: "http://www.postgresql.org"
 bug-reports: "https://github.com/ocaml/opam-repository/issues"
 flags: conf
 available: os = "win32"
-build: ["pkgconf" "--personality=x86_64-w64-mingw32" "libpq"]
+build: ["pkgconf" "--personality=x86_64-w64-mingw32" {os-distribution = "cygwin"} "libpq"]
 depends: [
   "conf-pkg-config" {build}
   "conf-mingw-w64-gcc-x86_64" {build}

--- a/packages/conf-mingw-w64-sdl2-i686/conf-mingw-w64-sdl2-i686.1/opam
+++ b/packages/conf-mingw-w64-sdl2-i686/conf-mingw-w64-sdl2-i686.1/opam
@@ -5,7 +5,7 @@ bug-reports: "https://github.com/ocaml/opam-repository/issues"
 license: "Zlib"
 flags: conf
 available: os = "win32"
-build: ["pkgconf" "--personality=i686-w64-mingw32" "sdl2"]
+build: ["pkgconf" "--personality=i686-w64-mingw32" {os-distribution = "cygwin"} "sdl2"]
 depends: [
   "conf-pkg-config" {build}
   "conf-mingw-w64-gcc-i686" {build}

--- a/packages/conf-mingw-w64-sdl2-i686/conf-mingw-w64-sdl2-i686.1/opam
+++ b/packages/conf-mingw-w64-sdl2-i686/conf-mingw-w64-sdl2-i686.1/opam
@@ -7,6 +7,8 @@ flags: conf
 available: os = "win32"
 build: ["pkgconf" "--personality=i686-w64-mingw32" {os-distribution = "cygwin"} "sdl2"]
 depends: [
+  "msys2" {build & os = "win32" & os-distribution = "msys2"}
+  "msys2-mingw32" {os = "win32" & os-distribution = "msys2"}
   "conf-pkg-config" {build}
   "conf-mingw-w64-gcc-i686" {build}
 ]

--- a/packages/conf-mingw-w64-sdl2-i686/conf-mingw-w64-sdl2-i686.1/opam
+++ b/packages/conf-mingw-w64-sdl2-i686/conf-mingw-w64-sdl2-i686.1/opam
@@ -12,9 +12,9 @@ depends: [
   "conf-pkg-config" {build}
   "conf-mingw-w64-gcc-i686" {build}
 ]
-synopsis: "sdl2 for i686 mingw-w64"
+synopsis: "Virtual package for sdl2 on i686 mingw-w64 (32-bit x86)"
 description:
-  "Ensure the i686 version of sdl2 for the mingw-w64 project is available"
+  "Ensures the i686 version of sdl2 for the mingw-w64 project is available"
 maintainer: "David Allsopp <david@tarides.com>"
 depexts: [
   ["mingw64-i686-SDL2"] {os = "win32" & os-distribution = "cygwin"}

--- a/packages/conf-mingw-w64-sdl2-i686/conf-mingw-w64-sdl2-i686.1/opam
+++ b/packages/conf-mingw-w64-sdl2-i686/conf-mingw-w64-sdl2-i686.1/opam
@@ -15,7 +15,7 @@ depends: [
 synopsis: "Virtual package for sdl2 on i686 mingw-w64 (32-bit x86)"
 description:
   "Ensures the i686 version of sdl2 for the mingw-w64 project is available"
-maintainer: "David Allsopp <david@tarides.com>"
+maintainer: "David Allsopp <dra27@dra27.uk>"
 depexts: [
   ["mingw64-i686-SDL2"] {os = "win32" & os-distribution = "cygwin"}
   ["mingw-w64-i686-SDL2"] {os = "win32" & os-distribution = "msys2"}

--- a/packages/conf-mingw-w64-sdl2-image-i686/conf-mingw-w64-sdl2-image-i686.1/opam
+++ b/packages/conf-mingw-w64-sdl2-image-i686/conf-mingw-w64-sdl2-image-i686.1/opam
@@ -1,7 +1,7 @@
 opam-version: "2.0"
 synopsis: "Virtual package for sdl2-image on i686 mingw-w64 (32-bit x86)"
 description: "Ensures the i686 version of sdl2-image for the mingw-w64 project is available"
-maintainer: "https://github.com/ocaml/opam-repository/issues"
+maintainer: "David Allsopp <dra27@dra27.uk>"
 authors: "Sam Lantinga"
 license: "Zlib"
 homepage: "http://www.libsdl.org/projects/SDL_image/"

--- a/packages/conf-mingw-w64-sdl2-image-i686/conf-mingw-w64-sdl2-image-i686.1/opam
+++ b/packages/conf-mingw-w64-sdl2-image-i686/conf-mingw-w64-sdl2-image-i686.1/opam
@@ -10,8 +10,6 @@ flags: conf
 available: os = "win32"
 build: ["pkgconf" "--personality=i686-w64-mingw32" {os-distribution = "cygwin"} "SDL2_image"]
 depends: [
-  "msys2" {build & os = "win32" & os-distribution = "msys2"}
-  "msys2-mingw32" {os = "win32" & os-distribution = "msys2"}
   "conf-pkg-config" {build}
   "conf-mingw-w64-gcc-i686" {build}
 ]

--- a/packages/conf-mingw-w64-sdl2-image-i686/conf-mingw-w64-sdl2-image-i686.1/opam
+++ b/packages/conf-mingw-w64-sdl2-image-i686/conf-mingw-w64-sdl2-image-i686.1/opam
@@ -10,6 +10,8 @@ flags: conf
 available: os = "win32"
 build: ["pkgconf" "--personality=i686-w64-mingw32" {os-distribution = "cygwin"} "SDL2_image"]
 depends: [
+  "msys2" {build & os = "win32" & os-distribution = "msys2"}
+  "msys2-mingw32" {os = "win32" & os-distribution = "msys2"}
   "conf-pkg-config" {build}
   "conf-mingw-w64-gcc-i686" {build}
 ]

--- a/packages/conf-mingw-w64-sdl2-image-i686/conf-mingw-w64-sdl2-image-i686.1/opam
+++ b/packages/conf-mingw-w64-sdl2-image-i686/conf-mingw-w64-sdl2-image-i686.1/opam
@@ -7,7 +7,7 @@ license: "Zlib"
 homepage: "http://www.libsdl.org/projects/SDL_image/"
 bug-reports: "https://github.com/ocaml/opam-repository/issues"
 flags: conf
-available: os = "win32"
+available: os = "win32" & os-distribution = "cygwin"
 build: ["pkgconf" "--personality=i686-w64-mingw32" {os-distribution = "cygwin"} "SDL2_image"]
 depends: [
   "conf-pkg-config" {build}

--- a/packages/conf-mingw-w64-sdl2-image-i686/conf-mingw-w64-sdl2-image-i686.1/opam
+++ b/packages/conf-mingw-w64-sdl2-image-i686/conf-mingw-w64-sdl2-image-i686.1/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-synopsis: "Provides sdl2-image for i686 mingw-w64 (32-bit x86)"
-description: "Ensure that the i686 version of sdl2-image for the mingw-w64 project is available"
+synopsis: "Virtual package for sdl2-image on i686 mingw-w64 (32-bit x86)"
+description: "Ensures the i686 version of sdl2-image for the mingw-w64 project is available"
 maintainer: "https://github.com/ocaml/opam-repository/issues"
 authors: "Sam Lantinga"
 license: "Zlib"

--- a/packages/conf-mingw-w64-sdl2-image-i686/conf-mingw-w64-sdl2-image-i686.1/opam
+++ b/packages/conf-mingw-w64-sdl2-image-i686/conf-mingw-w64-sdl2-image-i686.1/opam
@@ -8,7 +8,7 @@ homepage: "http://www.libsdl.org/projects/SDL_image/"
 bug-reports: "https://github.com/ocaml/opam-repository/issues"
 flags: conf
 available: os = "win32"
-build: ["pkgconf" "--personality=i686-w64-mingw32" "SDL2_image"]
+build: ["pkgconf" "--personality=i686-w64-mingw32" {os-distribution = "cygwin"} "SDL2_image"]
 depends: [
   "conf-pkg-config" {build}
   "conf-mingw-w64-gcc-i686" {build}

--- a/packages/conf-mingw-w64-sdl2-image-x86_64/conf-mingw-w64-sdl2-image-x86_64.1/opam
+++ b/packages/conf-mingw-w64-sdl2-image-x86_64/conf-mingw-w64-sdl2-image-x86_64.1/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-synopsis: "Provides sdl2-image for x86_64 mingw-w64 (64-bit x86_64)"
-description: "Ensure that the x86_64 version of sdl2-image for the mingw-w64 project is available"
+synopsis: "Virtual package for sdl2-image on x86_64 mingw-w64 (64-bit x86_64)"
+description: "Ensures the x86_64 version of sdl2-image for the mingw-w64 project is available"
 maintainer: "https://github.com/ocaml/opam-repository/issues"
 authors: "Sam Lantinga"
 license: "Zlib"

--- a/packages/conf-mingw-w64-sdl2-image-x86_64/conf-mingw-w64-sdl2-image-x86_64.1/opam
+++ b/packages/conf-mingw-w64-sdl2-image-x86_64/conf-mingw-w64-sdl2-image-x86_64.1/opam
@@ -10,6 +10,8 @@ flags: conf
 available: os = "win32"
 build: ["pkgconf" "--personality=x86_64-w64-mingw32" {os-distribution = "cygwin"} "SDL2_image"]
 depends: [
+  "msys2" {build & os = "win32" & os-distribution = "msys2"}
+  "msys2-mingw64" {os = "win32" & os-distribution = "msys2"}
   "conf-pkg-config" {build}
   "conf-mingw-w64-gcc-x86_64" {build}
 ]

--- a/packages/conf-mingw-w64-sdl2-image-x86_64/conf-mingw-w64-sdl2-image-x86_64.1/opam
+++ b/packages/conf-mingw-w64-sdl2-image-x86_64/conf-mingw-w64-sdl2-image-x86_64.1/opam
@@ -8,7 +8,7 @@ homepage: "http://www.libsdl.org/projects/SDL_image/"
 bug-reports: "https://github.com/ocaml/opam-repository/issues"
 flags: conf
 available: os = "win32"
-build: ["pkgconf" "--personality=x86_64-w64-mingw32" "SDL2_image"]
+build: ["pkgconf" "--personality=x86_64-w64-mingw32" {os-distribution = "cygwin"} "SDL2_image"]
 depends: [
   "conf-pkg-config" {build}
   "conf-mingw-w64-gcc-x86_64" {build}

--- a/packages/conf-mingw-w64-sdl2-image-x86_64/conf-mingw-w64-sdl2-image-x86_64.1/opam
+++ b/packages/conf-mingw-w64-sdl2-image-x86_64/conf-mingw-w64-sdl2-image-x86_64.1/opam
@@ -1,7 +1,7 @@
 opam-version: "2.0"
 synopsis: "Virtual package for sdl2-image on x86_64 mingw-w64 (64-bit x86_64)"
 description: "Ensures the x86_64 version of sdl2-image for the mingw-w64 project is available"
-maintainer: "https://github.com/ocaml/opam-repository/issues"
+maintainer: "David Allsopp <dra27@dra27.uk>"
 authors: "Sam Lantinga"
 license: "Zlib"
 homepage: "http://www.libsdl.org/projects/SDL_image/"

--- a/packages/conf-mingw-w64-sdl2-mixer-i686/conf-mingw-w64-sdl2-mixer-i686.1/opam
+++ b/packages/conf-mingw-w64-sdl2-mixer-i686/conf-mingw-w64-sdl2-mixer-i686.1/opam
@@ -1,7 +1,7 @@
 opam-version: "2.0"
 synopsis: "Virtual package for sdl2-mixer on i686 mingw-w64 (32-bit x86)"
 description: "Ensures the i686 version of sdl2-mixer for the mingw-w64 project is available"
-maintainer: "https://github.com/ocaml/opam-repository/issues"
+maintainer: "David Allsopp <dra27@dra27.uk>"
 authors: "Sam Lantinga"
 license: "Zlib"
 homepage: "http://www.libsdl.org/projects/SDL_mixer/"

--- a/packages/conf-mingw-w64-sdl2-mixer-i686/conf-mingw-w64-sdl2-mixer-i686.1/opam
+++ b/packages/conf-mingw-w64-sdl2-mixer-i686/conf-mingw-w64-sdl2-mixer-i686.1/opam
@@ -10,6 +10,8 @@ flags: conf
 available: os = "win32"
 build: ["pkgconf" "--personality=i686-w64-mingw32" {os-distribution = "cygwin"} "SDL2_mixer"]
 depends: [
+  "msys2" {build & os = "win32" & os-distribution = "msys2"}
+  "msys2-mingw32" {os = "win32" & os-distribution = "msys2"}
   "conf-pkg-config" {build}
   "conf-mingw-w64-gcc-i686" {build}
 ]

--- a/packages/conf-mingw-w64-sdl2-mixer-i686/conf-mingw-w64-sdl2-mixer-i686.1/opam
+++ b/packages/conf-mingw-w64-sdl2-mixer-i686/conf-mingw-w64-sdl2-mixer-i686.1/opam
@@ -8,7 +8,7 @@ homepage: "http://www.libsdl.org/projects/SDL_mixer/"
 bug-reports: "https://github.com/ocaml/opam-repository/issues"
 flags: conf
 available: os = "win32"
-build: ["pkgconf" "--personality=i686-w64-mingw32" "SDL2_mixer"]
+build: ["pkgconf" "--personality=i686-w64-mingw32" {os-distribution = "cygwin"} "SDL2_mixer"]
 depends: [
   "conf-pkg-config" {build}
   "conf-mingw-w64-gcc-i686" {build}

--- a/packages/conf-mingw-w64-sdl2-mixer-i686/conf-mingw-w64-sdl2-mixer-i686.1/opam
+++ b/packages/conf-mingw-w64-sdl2-mixer-i686/conf-mingw-w64-sdl2-mixer-i686.1/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-synopsis: "Provides sdl2-mixer for i686 mingw-w64 (32-bit x86)"
-description: "Ensure that the i686 version of sdl2-mixer for the mingw-w64 project is available"
+synopsis: "Virtual package for sdl2-mixer on i686 mingw-w64 (32-bit x86)"
+description: "Ensures the i686 version of sdl2-mixer for the mingw-w64 project is available"
 maintainer: "https://github.com/ocaml/opam-repository/issues"
 authors: "Sam Lantinga"
 license: "Zlib"

--- a/packages/conf-mingw-w64-sdl2-mixer-x86_64/conf-mingw-w64-sdl2-mixer-x86_64.1/opam
+++ b/packages/conf-mingw-w64-sdl2-mixer-x86_64/conf-mingw-w64-sdl2-mixer-x86_64.1/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-synopsis: "Provides sdl2-mixer for x86_64 mingw-w64 (64-bit x86_64)"
-description: "Ensure that the x86_64 version of sdl2-mixer for the mingw-w64 project is available"
+synopsis: "Virtual package for sdl2-mixer on x86_64 mingw-w64 (64-bit x86_64)"
+description: "Ensures the x86_64 version of sdl2-mixer for the mingw-w64 project is available"
 maintainer: "https://github.com/ocaml/opam-repository/issues"
 authors: "Sam Lantinga"
 license: "Zlib"

--- a/packages/conf-mingw-w64-sdl2-mixer-x86_64/conf-mingw-w64-sdl2-mixer-x86_64.1/opam
+++ b/packages/conf-mingw-w64-sdl2-mixer-x86_64/conf-mingw-w64-sdl2-mixer-x86_64.1/opam
@@ -8,7 +8,7 @@ homepage: "http://www.libsdl.org/projects/SDL_mixer/"
 bug-reports: "https://github.com/ocaml/opam-repository/issues"
 flags: conf
 available: os = "win32"
-build: ["pkgconf" "--personality=x86_64-w64-mingw32" "SDL2_mixer"]
+build: ["pkgconf" "--personality=x86_64-w64-mingw32" {os-distribution = "cygwin"} "SDL2_mixer"]
 depends: [
   "conf-pkg-config" {build}
   "conf-mingw-w64-gcc-x86_64" {build}

--- a/packages/conf-mingw-w64-sdl2-mixer-x86_64/conf-mingw-w64-sdl2-mixer-x86_64.1/opam
+++ b/packages/conf-mingw-w64-sdl2-mixer-x86_64/conf-mingw-w64-sdl2-mixer-x86_64.1/opam
@@ -1,7 +1,7 @@
 opam-version: "2.0"
 synopsis: "Virtual package for sdl2-mixer on x86_64 mingw-w64 (64-bit x86_64)"
 description: "Ensures the x86_64 version of sdl2-mixer for the mingw-w64 project is available"
-maintainer: "https://github.com/ocaml/opam-repository/issues"
+maintainer: "David Allsopp <dra27@dra27.uk>"
 authors: "Sam Lantinga"
 license: "Zlib"
 homepage: "http://www.libsdl.org/projects/SDL_mixer/"

--- a/packages/conf-mingw-w64-sdl2-mixer-x86_64/conf-mingw-w64-sdl2-mixer-x86_64.1/opam
+++ b/packages/conf-mingw-w64-sdl2-mixer-x86_64/conf-mingw-w64-sdl2-mixer-x86_64.1/opam
@@ -10,6 +10,8 @@ flags: conf
 available: os = "win32"
 build: ["pkgconf" "--personality=x86_64-w64-mingw32" {os-distribution = "cygwin"} "SDL2_mixer"]
 depends: [
+  "msys2" {build & os = "win32" & os-distribution = "msys2"}
+  "msys2-mingw64" {os = "win32" & os-distribution = "msys2"}
   "conf-pkg-config" {build}
   "conf-mingw-w64-gcc-x86_64" {build}
 ]

--- a/packages/conf-mingw-w64-sdl2-net-i686/conf-mingw-w64-sdl2-net-i686.1/opam
+++ b/packages/conf-mingw-w64-sdl2-net-i686/conf-mingw-w64-sdl2-net-i686.1/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-synopsis: "Provides sdl2-net for i686 mingw-w64 (32-bit x86)"
-description: "Ensure that the i686 version of sdl2-net for the mingw-w64 project is available"
+synopsis: "Virtual package for sdl2-net on i686 mingw-w64 (32-bit x86)"
+description: "Ensures the i686 version of sdl2-net for the mingw-w64 project is available"
 maintainer: "https://github.com/ocaml/opam-repository/issues"
 authors: "Sam Lantinga"
 license: "Zlib"

--- a/packages/conf-mingw-w64-sdl2-net-i686/conf-mingw-w64-sdl2-net-i686.1/opam
+++ b/packages/conf-mingw-w64-sdl2-net-i686/conf-mingw-w64-sdl2-net-i686.1/opam
@@ -8,7 +8,7 @@ homepage: "http://www.libsdl.org/projects/SDL_net/"
 bug-reports: "https://github.com/ocaml/opam-repository/issues"
 flags: conf
 available: os = "win32"
-build: ["pkgconf" "--personality=i686-w64-mingw32" "SDL2_net"]
+build: ["pkgconf" "--personality=i686-w64-mingw32" {os-distribution = "cygwin"} "SDL2_net"]
 depends: [
   "conf-pkg-config" {build}
   "conf-mingw-w64-gcc-i686" {build}

--- a/packages/conf-mingw-w64-sdl2-net-i686/conf-mingw-w64-sdl2-net-i686.1/opam
+++ b/packages/conf-mingw-w64-sdl2-net-i686/conf-mingw-w64-sdl2-net-i686.1/opam
@@ -1,7 +1,7 @@
 opam-version: "2.0"
 synopsis: "Virtual package for sdl2-net on i686 mingw-w64 (32-bit x86)"
 description: "Ensures the i686 version of sdl2-net for the mingw-w64 project is available"
-maintainer: "https://github.com/ocaml/opam-repository/issues"
+maintainer: "David Allsopp <dra27@dra27.uk>"
 authors: "Sam Lantinga"
 license: "Zlib"
 homepage: "http://www.libsdl.org/projects/SDL_net/"

--- a/packages/conf-mingw-w64-sdl2-net-i686/conf-mingw-w64-sdl2-net-i686.1/opam
+++ b/packages/conf-mingw-w64-sdl2-net-i686/conf-mingw-w64-sdl2-net-i686.1/opam
@@ -10,6 +10,8 @@ flags: conf
 available: os = "win32"
 build: ["pkgconf" "--personality=i686-w64-mingw32" {os-distribution = "cygwin"} "SDL2_net"]
 depends: [
+  "msys2" {build & os = "win32" & os-distribution = "msys2"}
+  "msys2-mingw32" {os = "win32" & os-distribution = "msys2"}
   "conf-pkg-config" {build}
   "conf-mingw-w64-gcc-i686" {build}
 ]

--- a/packages/conf-mingw-w64-sdl2-net-x86_64/conf-mingw-w64-sdl2-net-x86_64.1/opam
+++ b/packages/conf-mingw-w64-sdl2-net-x86_64/conf-mingw-w64-sdl2-net-x86_64.1/opam
@@ -1,7 +1,7 @@
 opam-version: "2.0"
 synopsis: "Virtual package for sdl2-net on x86_64 mingw-w64 (64-bit x86_64)"
 description: "Ensures the x86_64 version of sdl2-net for the mingw-w64 project is available"
-maintainer: "https://github.com/ocaml/opam-repository/issues"
+maintainer: "David Allsopp <dra27@dra27.uk>"
 authors: "Sam Lantinga"
 license: "Zlib"
 homepage: "http://www.libsdl.org/projects/SDL_net/"

--- a/packages/conf-mingw-w64-sdl2-net-x86_64/conf-mingw-w64-sdl2-net-x86_64.1/opam
+++ b/packages/conf-mingw-w64-sdl2-net-x86_64/conf-mingw-w64-sdl2-net-x86_64.1/opam
@@ -8,7 +8,7 @@ homepage: "http://www.libsdl.org/projects/SDL_net/"
 bug-reports: "https://github.com/ocaml/opam-repository/issues"
 flags: conf
 available: os = "win32"
-build: ["pkgconf" "--personality=x86_64-w64-mingw32" "SDL2_net"]
+build: ["pkgconf" "--personality=x86_64-w64-mingw32" {os-distribution = "cygwin"} "SDL2_net"]
 depends: [
   "conf-pkg-config" {build}
   "conf-mingw-w64-gcc-x86_64" {build}

--- a/packages/conf-mingw-w64-sdl2-net-x86_64/conf-mingw-w64-sdl2-net-x86_64.1/opam
+++ b/packages/conf-mingw-w64-sdl2-net-x86_64/conf-mingw-w64-sdl2-net-x86_64.1/opam
@@ -10,6 +10,8 @@ flags: conf
 available: os = "win32"
 build: ["pkgconf" "--personality=x86_64-w64-mingw32" {os-distribution = "cygwin"} "SDL2_net"]
 depends: [
+  "msys2" {build & os = "win32" & os-distribution = "msys2"}
+  "msys2-mingw64" {os = "win32" & os-distribution = "msys2"}
   "conf-pkg-config" {build}
   "conf-mingw-w64-gcc-x86_64" {build}
 ]

--- a/packages/conf-mingw-w64-sdl2-net-x86_64/conf-mingw-w64-sdl2-net-x86_64.1/opam
+++ b/packages/conf-mingw-w64-sdl2-net-x86_64/conf-mingw-w64-sdl2-net-x86_64.1/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-synopsis: "Provides sdl2-net for x86_64 mingw-w64 (64-bit x86_64)"
-description: "Ensure that the x86_64 version of sdl2-net for the mingw-w64 project is available"
+synopsis: "Virtual package for sdl2-net on x86_64 mingw-w64 (64-bit x86_64)"
+description: "Ensures the x86_64 version of sdl2-net for the mingw-w64 project is available"
 maintainer: "https://github.com/ocaml/opam-repository/issues"
 authors: "Sam Lantinga"
 license: "Zlib"

--- a/packages/conf-mingw-w64-sdl2-ttf-i686/conf-mingw-w64-sdl2-ttf-i686.1/opam
+++ b/packages/conf-mingw-w64-sdl2-ttf-i686/conf-mingw-w64-sdl2-ttf-i686.1/opam
@@ -10,6 +10,8 @@ flags: conf
 available: os = "win32"
 build: ["pkgconf" "--personality=i686-w64-mingw32" {os-distribution = "cygwin"} "SDL2_ttf"]
 depends: [
+  "msys2" {build & os = "win32" & os-distribution = "msys2"}
+  "msys2-mingw32" {os = "win32" & os-distribution = "msys2"}
   "conf-pkg-config" {build}
   "conf-mingw-w64-gcc-i686" {build}
 ]

--- a/packages/conf-mingw-w64-sdl2-ttf-i686/conf-mingw-w64-sdl2-ttf-i686.1/opam
+++ b/packages/conf-mingw-w64-sdl2-ttf-i686/conf-mingw-w64-sdl2-ttf-i686.1/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-synopsis: "Provides sdl2-ttf for i686 mingw-w64 (32-bit x86)"
-description: "Ensure that the i686 version of sdl2-ttf for the mingw-w64 project is available"
+synopsis: "Virtual package for sdl2-ttf on i686 mingw-w64 (32-bit x86)"
+description: "Ensures the i686 version of sdl2-ttf for the mingw-w64 project is available"
 maintainer: "https://github.com/ocaml/opam-repository/issues"
 authors: "Sam Lantinga"
 license: "Zlib"

--- a/packages/conf-mingw-w64-sdl2-ttf-i686/conf-mingw-w64-sdl2-ttf-i686.1/opam
+++ b/packages/conf-mingw-w64-sdl2-ttf-i686/conf-mingw-w64-sdl2-ttf-i686.1/opam
@@ -8,7 +8,7 @@ homepage: "http://www.libsdl.org/projects/SDL_ttf/"
 bug-reports: "https://github.com/ocaml/opam-repository/issues"
 flags: conf
 available: os = "win32"
-build: ["pkgconf" "--personality=i686-w64-mingw32" "SDL2_ttf"]
+build: ["pkgconf" "--personality=i686-w64-mingw32" {os-distribution = "cygwin"} "SDL2_ttf"]
 depends: [
   "conf-pkg-config" {build}
   "conf-mingw-w64-gcc-i686" {build}

--- a/packages/conf-mingw-w64-sdl2-ttf-i686/conf-mingw-w64-sdl2-ttf-i686.1/opam
+++ b/packages/conf-mingw-w64-sdl2-ttf-i686/conf-mingw-w64-sdl2-ttf-i686.1/opam
@@ -1,7 +1,7 @@
 opam-version: "2.0"
 synopsis: "Virtual package for sdl2-ttf on i686 mingw-w64 (32-bit x86)"
 description: "Ensures the i686 version of sdl2-ttf for the mingw-w64 project is available"
-maintainer: "https://github.com/ocaml/opam-repository/issues"
+maintainer: "David Allsopp <dra27@dra27.uk>"
 authors: "Sam Lantinga"
 license: "Zlib"
 homepage: "http://www.libsdl.org/projects/SDL_ttf/"

--- a/packages/conf-mingw-w64-sdl2-ttf-x86_64/conf-mingw-w64-sdl2-ttf-x86_64.1/opam
+++ b/packages/conf-mingw-w64-sdl2-ttf-x86_64/conf-mingw-w64-sdl2-ttf-x86_64.1/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
-synopsis: "Provides sdl2-ttf for x86_64 mingw-w64 (64-bit x86_64)"
-description: "Ensure that the x86_64 version of sdl2-ttf for the mingw-w64 project is available"
+synopsis: "Virtual package for sdl2-ttf on x86_64 mingw-w64 (64-bit x86_64)"
+description: "Ensures the x86_64 version of sdl2-ttf for the mingw-w64 project is available"
 maintainer: "https://github.com/ocaml/opam-repository/issues"
 authors: "Sam Lantinga"
 license: "Zlib"

--- a/packages/conf-mingw-w64-sdl2-ttf-x86_64/conf-mingw-w64-sdl2-ttf-x86_64.1/opam
+++ b/packages/conf-mingw-w64-sdl2-ttf-x86_64/conf-mingw-w64-sdl2-ttf-x86_64.1/opam
@@ -1,7 +1,7 @@
 opam-version: "2.0"
 synopsis: "Virtual package for sdl2-ttf on x86_64 mingw-w64 (64-bit x86_64)"
 description: "Ensures the x86_64 version of sdl2-ttf for the mingw-w64 project is available"
-maintainer: "https://github.com/ocaml/opam-repository/issues"
+maintainer: "David Allsopp <dra27@dra27.uk>"
 authors: "Sam Lantinga"
 license: "Zlib"
 homepage: "http://www.libsdl.org/projects/SDL_ttf/"

--- a/packages/conf-mingw-w64-sdl2-ttf-x86_64/conf-mingw-w64-sdl2-ttf-x86_64.1/opam
+++ b/packages/conf-mingw-w64-sdl2-ttf-x86_64/conf-mingw-w64-sdl2-ttf-x86_64.1/opam
@@ -8,7 +8,7 @@ homepage: "http://www.libsdl.org/projects/SDL_ttf/"
 bug-reports: "https://github.com/ocaml/opam-repository/issues"
 flags: conf
 available: os = "win32"
-build: ["pkgconf" "--personality=x86_64-w64-mingw32" "SDL2_ttf"]
+build: ["pkgconf" "--personality=x86_64-w64-mingw32" {os-distribution = "cygwin"} "SDL2_ttf"]
 depends: [
   "conf-pkg-config" {build}
   "conf-mingw-w64-gcc-x86_64" {build}

--- a/packages/conf-mingw-w64-sdl2-ttf-x86_64/conf-mingw-w64-sdl2-ttf-x86_64.1/opam
+++ b/packages/conf-mingw-w64-sdl2-ttf-x86_64/conf-mingw-w64-sdl2-ttf-x86_64.1/opam
@@ -10,6 +10,8 @@ flags: conf
 available: os = "win32"
 build: ["pkgconf" "--personality=x86_64-w64-mingw32" {os-distribution = "cygwin"} "SDL2_ttf"]
 depends: [
+  "msys2" {build & os = "win32" & os-distribution = "msys2"}
+  "msys2-mingw64" {os = "win32" & os-distribution = "msys2"}
   "conf-pkg-config" {build}
   "conf-mingw-w64-gcc-x86_64" {build}
 ]

--- a/packages/conf-mingw-w64-sdl2-x86_64/conf-mingw-w64-sdl2-x86_64.1/opam
+++ b/packages/conf-mingw-w64-sdl2-x86_64/conf-mingw-w64-sdl2-x86_64.1/opam
@@ -12,9 +12,9 @@ depends: [
   "conf-pkg-config" {build}
   "conf-mingw-w64-gcc-x86_64" {build}
 ]
-synopsis: "sdl2 for x86_64 mingw-w64"
+synopsis: "Virtual package for sdl2 on x86_64 mingw-w64 (64-bit x86_64)"
 description:
-  "Ensure the x86_64 version of sdl2 for the mingw-w64 project is available"
+  "Ensures the x86_64 version of sdl2 for the mingw-w64 project is available"
 maintainer: "David Allsopp <david@tarides.com>"
 depexts: [
   ["mingw64-x86_64-SDL2"] {os = "win32" & os-distribution = "cygwin"}

--- a/packages/conf-mingw-w64-sdl2-x86_64/conf-mingw-w64-sdl2-x86_64.1/opam
+++ b/packages/conf-mingw-w64-sdl2-x86_64/conf-mingw-w64-sdl2-x86_64.1/opam
@@ -15,7 +15,7 @@ depends: [
 synopsis: "Virtual package for sdl2 on x86_64 mingw-w64 (64-bit x86_64)"
 description:
   "Ensures the x86_64 version of sdl2 for the mingw-w64 project is available"
-maintainer: "David Allsopp <david@tarides.com>"
+maintainer: "David Allsopp <dra27@dra27.uk>"
 depexts: [
   ["mingw64-x86_64-SDL2"] {os = "win32" & os-distribution = "cygwin"}
   ["mingw-w64-x86_64-SDL2"] {os = "win32" & os-distribution = "msys2"}

--- a/packages/conf-mingw-w64-sdl2-x86_64/conf-mingw-w64-sdl2-x86_64.1/opam
+++ b/packages/conf-mingw-w64-sdl2-x86_64/conf-mingw-w64-sdl2-x86_64.1/opam
@@ -5,7 +5,7 @@ bug-reports: "https://github.com/ocaml/opam-repository/issues"
 license: "Zlib"
 flags: conf
 available: os = "win32"
-build: ["pkgconf" "--personality=x86_64-w64-mingw32" "sdl2"]
+build: ["pkgconf" "--personality=x86_64-w64-mingw32" {os-distribution = "cygwin"} "sdl2"]
 depends: [
   "conf-pkg-config" {build}
   "conf-mingw-w64-gcc-x86_64" {build}

--- a/packages/conf-mingw-w64-sdl2-x86_64/conf-mingw-w64-sdl2-x86_64.1/opam
+++ b/packages/conf-mingw-w64-sdl2-x86_64/conf-mingw-w64-sdl2-x86_64.1/opam
@@ -7,6 +7,8 @@ flags: conf
 available: os = "win32"
 build: ["pkgconf" "--personality=x86_64-w64-mingw32" {os-distribution = "cygwin"} "sdl2"]
 depends: [
+  "msys2" {build & os = "win32" & os-distribution = "msys2"}
+  "msys2-mingw64" {os = "win32" & os-distribution = "msys2"}
   "conf-pkg-config" {build}
   "conf-mingw-w64-gcc-x86_64" {build}
 ]

--- a/packages/conf-mingw-w64-sqlite3-i686/conf-mingw-w64-sqlite3-i686.1/opam
+++ b/packages/conf-mingw-w64-sqlite3-i686/conf-mingw-w64-sqlite3-i686.1/opam
@@ -1,7 +1,7 @@
 opam-version: "2.0"
 synopsis: "Virtual package for sqlite3 on i686 mingw-w64 (32-bit x86)"
 description: "Ensures the i686 version of sqlite3 for the mingw-w64 project is available"
-maintainer: "David Allsopp <david@tarides.com>"
+maintainer: "David Allsopp <dra27@dra27.uk>"
 authors: [
   "D. Richard Hipp"
   "Dan Kennedy"

--- a/packages/conf-mingw-w64-sqlite3-i686/conf-mingw-w64-sqlite3-i686.1/opam
+++ b/packages/conf-mingw-w64-sqlite3-i686/conf-mingw-w64-sqlite3-i686.1/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-synopsis: "sqlite3 for i686 mingw-w64 (32-bit x86)"
+synopsis: "Virtual package for sqlite3 on i686 mingw-w64 (32-bit x86)"
 description: "Ensures the i686 version of sqlite3 for the mingw-w64 project is available"
 maintainer: "David Allsopp <david@tarides.com>"
 authors: [

--- a/packages/conf-mingw-w64-sqlite3-i686/conf-mingw-w64-sqlite3-i686.1/opam
+++ b/packages/conf-mingw-w64-sqlite3-i686/conf-mingw-w64-sqlite3-i686.1/opam
@@ -14,6 +14,8 @@ flags: conf
 available: os = "win32"
 build: ["pkgconf" "--personality=i686-w64-mingw32" {os-distribution = "cygwin"} "sqlite3"]
 depends: [
+  "msys2" {build & os = "win32" & os-distribution = "msys2"}
+  "msys2-mingw32" {os = "win32" & os-distribution = "msys2"}
   "conf-pkg-config" {build}
   "conf-mingw-w64-gcc-i686" {build}
 ]

--- a/packages/conf-mingw-w64-sqlite3-i686/conf-mingw-w64-sqlite3-i686.1/opam
+++ b/packages/conf-mingw-w64-sqlite3-i686/conf-mingw-w64-sqlite3-i686.1/opam
@@ -12,7 +12,7 @@ homepage: "http://www.sqlite3.org"
 bug-reports: "https://github.com/ocaml/opam-repository/issues"
 flags: conf
 available: os = "win32"
-build: ["pkgconf" "--personality=i686-w64-mingw32" "sqlite3"]
+build: ["pkgconf" "--personality=i686-w64-mingw32" {os-distribution = "cygwin"} "sqlite3"]
 depends: [
   "conf-pkg-config" {build}
   "conf-mingw-w64-gcc-i686" {build}

--- a/packages/conf-mingw-w64-sqlite3-x86_64/conf-mingw-w64-sqlite3-x86_64.1/opam
+++ b/packages/conf-mingw-w64-sqlite3-x86_64/conf-mingw-w64-sqlite3-x86_64.1/opam
@@ -12,7 +12,7 @@ homepage: "http://www.sqlite3.org"
 bug-reports: "https://github.com/ocaml/opam-repository/issues"
 flags: conf
 available: os = "win32"
-build: ["pkgconf" "--personality=x86_64-w64-mingw32" "sqlite3"]
+build: ["pkgconf" "--personality=x86_64-w64-mingw32" {os-distribution = "cygwin"} "sqlite3"]
 depends: [
   "conf-pkg-config" {build}
   "conf-mingw-w64-gcc-x86_64" {build}

--- a/packages/conf-mingw-w64-sqlite3-x86_64/conf-mingw-w64-sqlite3-x86_64.1/opam
+++ b/packages/conf-mingw-w64-sqlite3-x86_64/conf-mingw-w64-sqlite3-x86_64.1/opam
@@ -14,6 +14,8 @@ flags: conf
 available: os = "win32"
 build: ["pkgconf" "--personality=x86_64-w64-mingw32" {os-distribution = "cygwin"} "sqlite3"]
 depends: [
+  "msys2" {build & os = "win32" & os-distribution = "msys2"}
+  "msys2-mingw64" {os = "win32" & os-distribution = "msys2"}
   "conf-pkg-config" {build}
   "conf-mingw-w64-gcc-x86_64" {build}
 ]

--- a/packages/conf-mingw-w64-sqlite3-x86_64/conf-mingw-w64-sqlite3-x86_64.1/opam
+++ b/packages/conf-mingw-w64-sqlite3-x86_64/conf-mingw-w64-sqlite3-x86_64.1/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-synopsis: "sqlite3 for x86_64 mingw-w64 (64-bit x86_64)"
+synopsis: "Virtual package for sqlite3 on x86_64 mingw-w64 (64-bit x86_64)"
 description: "Ensures the x86_64 version of sqlite3 for the mingw-w64 project is available"
 maintainer: "David Allsopp <david@tarides.com>"
 authors: [

--- a/packages/conf-mingw-w64-sqlite3-x86_64/conf-mingw-w64-sqlite3-x86_64.1/opam
+++ b/packages/conf-mingw-w64-sqlite3-x86_64/conf-mingw-w64-sqlite3-x86_64.1/opam
@@ -1,7 +1,7 @@
 opam-version: "2.0"
 synopsis: "Virtual package for sqlite3 on x86_64 mingw-w64 (64-bit x86_64)"
 description: "Ensures the x86_64 version of sqlite3 for the mingw-w64 project is available"
-maintainer: "David Allsopp <david@tarides.com>"
+maintainer: "David Allsopp <dra27@dra27.uk>"
 authors: [
   "D. Richard Hipp"
   "Dan Kennedy"

--- a/packages/conf-mingw-w64-zlib-i686/conf-mingw-w64-zlib-i686.1/opam
+++ b/packages/conf-mingw-w64-zlib-i686/conf-mingw-w64-zlib-i686.1/opam
@@ -1,7 +1,7 @@
 opam-version: "2.0"
 synopsis: "Virtual package for zlib on i686 mingw-w64 (32-bit x86)"
 description: "Ensures the i686 version of zlib for the mingw-w64 project is available"
-maintainer: "David Allsopp <david@tarides.com>"
+maintainer: "David Allsopp <dra27@dra27.uk>"
 authors: ["Jean-loup Gailly" "Mark Adler"]
 license: "zlib"
 homepage: "http://www.zlib.net/"

--- a/packages/conf-mingw-w64-zlib-x86_64/conf-mingw-w64-zlib-x86_64.1/opam
+++ b/packages/conf-mingw-w64-zlib-x86_64/conf-mingw-w64-zlib-x86_64.1/opam
@@ -1,7 +1,7 @@
 opam-version: "2.0"
 synopsis: "Virtual package for zlib on x86_64 mingw-w64 (64-bit x86_64)"
 description: "Ensures the x86_64 version of zlib for the mingw-w64 project is available"
-maintainer: "David Allsopp <david@tarides.com>"
+maintainer: "David Allsopp <dra27@dra27.uk>"
 authors: ["Jean-loup Gailly" "Mark Adler"]
 license: "zlib"
 homepage: "http://www.zlib.net/"

--- a/packages/conf-mingw-w64-zstd-i686/conf-mingw-w64-zstd-i686.1/opam
+++ b/packages/conf-mingw-w64-zstd-i686/conf-mingw-w64-zstd-i686.1/opam
@@ -1,7 +1,7 @@
 opam-version: "2.0"
 synopsis: "Virtual package for libzstd on i686 mingw-w64 (32-bit x86)"
 description: "Ensures the i686 version of libzstd for the mingw-w64 project is available"
-maintainer: "David Allsopp <david@tarides.com>"
+maintainer: "David Allsopp <dra27@dra27.uk>"
 authors: "Facebook"
 license: "BSD-3-Clause"
 homepage: "http://zstd.net"

--- a/packages/conf-mingw-w64-zstd-x86_64/conf-mingw-w64-zstd-x86_64.1/opam
+++ b/packages/conf-mingw-w64-zstd-x86_64/conf-mingw-w64-zstd-x86_64.1/opam
@@ -1,7 +1,7 @@
 opam-version: "2.0"
 synopsis: "Virtual package for libzstd on x86_64 mingw-w64 (64-bit x86_64)"
 description: "Ensures the x86_64 version of libzstd for the mingw-w64 project is available"
-maintainer: "David Allsopp <david@tarides.com>"
+maintainer: "David Allsopp <dra27@dra27.uk>"
 authors: "Facebook"
 license: "BSD-3-Clause"
 homepage: "http://zstd.net"


### PR DESCRIPTION
This is the first of a series of PRs which will ultimately add support for the MSYS2 UCRT64 build environment. The mingw-w64 version of GCC is able to target both the very venerable Microsoft Visual C Runtime ("MSVCRT") and the more modern Universal CRT ("UCRT"). For various reasons, OCaml has leaned towards the MSVCRT version, but the mingw-w64 project has changed its default and begun the deprecation process for this. Naturally, announcing a deprecation does not require knee-jerk updates to things which already work, but we should of course begin preparations.

The Windows ports are complex because the available compilation experience is vastly superior to Unix and macOS 🫣 That is to say, cross-compilation stares us in the face at all times. This manifests in opam-repository by a much richer (or, if you must, "complex") depext specification system. In particular, in addition to the usual `conf-foo` package, we end up with packages `conf-mingw-w64-foo-x86_64` and `conf-mingw-w64-foo-i686` packages.

As I have banged on about at various points, writing the first few of these packages by hand was a necessity to ensure the [immense task](https://github.com/ocaml/opam-repository/pull/25861) of getting Windows compilers into opam-repository actually happened. This PR is the result of actually mechanising all the conf-mingw-w64- packages.

I strongly recommend reviewing this commit by commit, as the overall diff is very noisy. In particular:
- `Harden pkgconf calls to MSYS2` is a mechanical addition of `{os-distribution = "cygwin"}` to `--personality=` arguments (MSYS2 somewhat annoyingly doesn't configure `pkgconf` this way and silently ignores it).
- `Explicitly depend on msystem packages for MSYS` ensures that the guard packages are installed on MSYS2. These maintain the consistency of the [MSYS2 Environment](https://www.msys2.org/docs/environments/) - that is that if you're working in a MINGW64 environment, then you can only install x86\_64 mingw-w64 packages to it (I'm working on a relaxation of this for other reasons, although it's made difficult by the `pkgconf --personality` thing).
- `Remove unnecessary MSYS2 references` conversely _removes_ some of the dependencies from packages which are only available on Cygwin.
- `Consistent synopsis/descr for conf-mingw-w64-*` is a mechanical update of the `synopsis` and `description` fields for all these packages to use the same template as the originals (and is just a consequence of this being mechanised).
- `Ensure MSYS2/Cygwin libs depend on the C compiler`. This is a hygiene fix enforced in opam-repository. The Cygwin library packages either explicitly or implicitly require the corresponding GCC package to be installed alongside a library. MSYS2 doesn't have this constraint, but opam-repository puts a dependency on the GCC depext for uniformity between the two. It's missing from a few packages.
- The other commits are smaller in scope and should be mostly self-evident in their fixes/clarifications.

Finally, mainly to update my email address and, again, partly because the whole thing is mechanised, the `maintainer` (and in at least one case, `bug-reports`) fields are updated for all these packages to swing back to the silly hobbyist who maintains these things...

For the CI checks:
- `conf-allegro5` and `conf-mbedtls` are not packaged for Cygwin
- Cygwin uses a single `pkgconf` installation with `--personality`, which is why `conf-mingw-w64-pkgconf-i686.1` and `conf-mingw-w64-pkgconf-x86_64.1` are not installable.
- All of the packages skipped on MSYS2 are for packages where MSYS2 no longer ships an i686 build (in many of these cases the Cygwin package is also very old, but as it's still there it's perfectly reasonable for the depext system to reflect that)

The last commit `Shim the compiler out` should be removed just prior to merging this PR. None of these conf packages require OCaml, but because there's a mix of i686 and x86_64 the CI checks will otherwise keep switching between a 32-bit and 64-bit OCaml which adds, um, a lot of compilation time for no CI benefit! Fun though it would be to extend the analysis stage to do a better mass solve and derive a better environment, there are only so many hours of train journey in my working day...