### PR TITLE
Packages bin_there.0.2.1a1 and ppx_bin_there.0.2.1a1

### DIFF
--- a/packages/bin_there/bin_there.0.2.1a1/opam
+++ b/packages/bin_there/bin_there.0.2.1a1/opam
@@ -1,0 +1,29 @@
+opam-version: "2.0"
+synopsis: "Serialization/deserialization with support for shared values"
+description: """\
+bin_there provides a binary serialization and deserialization library for OCaml
+with first-class support for shared values (graph-shaped data)."""
+maintainer: "David 'Yoric' Teller yteller@gitlab.com"
+authors: "David 'Yoric' Teller yteller@gitlab.com"
+license: "MIT"
+homepage: "https://gitlab.com/yteller/binthere"
+bug-reports: "https://gitlab.com/yteller/binthere/-/work_items"
+depends: [
+  "ocaml" {>= "4.14"}
+  "dune" {>= "3.0"}
+  "alcotest" {with-test}
+  "base-threads" {with-test}
+  "qcheck-alcotest" {with-test}
+  "camlzip" {with-test}
+]
+build: ["dune" "build" "-p" name "-j" jobs]
+run-test: ["dune" "runtest" "-p" name "-j" jobs]
+dev-repo: "git+https://gitlab.com/yteller/binthere.git"
+url {
+  src:
+    "https://gitlab.com/yteller/binthere/-/package_files/294911170/download"
+  checksum: [
+    "md5=f720bca43fe04092cc9b96e6622afd7a"
+    "sha512=d2aafbae3995e63ff83ea7d8d550682980475ac267f124216fc3ae3921376a5b2657943ce6e5fffed063a0a3ce4b9ae42ab74119897c63249b7dfe3b725580ec"
+  ]
+}

--- a/packages/ppx_bin_there/ppx_bin_there.0.2.1a1/opam
+++ b/packages/ppx_bin_there/ppx_bin_there.0.2.1a1/opam
@@ -1,0 +1,30 @@
+opam-version: "2.0"
+synopsis:
+  "PPX rewriter to derive bin_there serializers from type definitions"
+description: """\
+ppx_bin_there is a PPX rewriter that automatically derives Bthere_<type> modules
+with serialize and deserialize functions compatible with the bin_there library
+from OCaml type definitions, using [@@deriving bthere]."""
+maintainer: "David 'Yoric' Teller yteller@gitlab.com"
+authors: "David 'Yoric' Teller yteller@gitlab.com"
+license: "MIT"
+homepage: "https://gitlab.com/yteller/binthere"
+bug-reports: "https://gitlab.com/yteller/binthere/-/work_items"
+depends: [
+  "ocaml" {>= "4.14"}
+  "dune" {>= "3.0"}
+  "ppxlib" {>= "0.28.0"}
+  "bin_there" {version}
+  "alcotest" {with-test}
+]
+build: ["dune" "build" "-p" name "-j" jobs]
+run-test: ["dune" "runtest" "-p" name "-j" jobs]
+dev-repo: "git+https://gitlab.com/yteller/binthere.git"
+url {
+  src:
+    "https://gitlab.com/yteller/binthere/-/package_files/294911183/download"
+  checksum: [
+    "md5=bbe8eee168160bcbfd3b0908b860c0c5"
+    "sha512=25cc8ac69345421b6fc4610ec00ddc8881a27774426639ebdf7e88c6003bc15bc3b5175768898db48afbe1c3c9a18664307bab73d801a4302305acec85997050"
+  ]
+}


### PR DESCRIPTION
This pull-request concerns:
- `bin_there.0.2.1a1`: Serialization/deserialization with support for shared values
- `ppx_bin_there.0.2.1a1`: PPX rewriter to derive bin_there serializers from type definitions



---
* Homepage: https://gitlab.com/yteller/binthere
* Source repo: git+https://gitlab.com/yteller/binthere.git
* Bug tracker: https://gitlab.com/yteller/binthere/-/work_items

---
:camel: Pull-request generated by opam-publish v3.0.0