### PR TITLE
[new release] tracy-client (0.7.1)

### DIFF
--- a/packages/tracy-client/tracy-client.0.7.1/opam
+++ b/packages/tracy-client/tracy-client.0.7.1/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+synopsis: "Client bindings to the Tracy profiler (v0.13)"
+maintainer: ["Simon Cruanes"]
+authors: ["Bartosz Taudul" "Simon Cruanes"]
+license: "BSD-3-Clause"
+homepage: "https://github.com/ocaml-tracing/ocaml-tracy"
+bug-reports: "https://github.com/ocaml-tracing/ocaml-tracy/issues"
+depends: [
+  "dune" {>= "2.7"}
+  "ocaml" {>= "4.14"}
+  "trace" {>= "0.11" & < "0.13"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/ocaml-tracing/ocaml-tracy.git"
+depexts: [
+ ["linux-headers"] {os-distribution = "alpine"}
+]
+available: [os != "win32"]
+url {
+  src:
+    "https://github.com/ocaml-tracing/ocaml-tracy/releases/download/v0.7.1/tracy-client-0.7.1.tbz"
+  checksum: [
+    "sha256=f422403aea744125cc2539c46e42604269ce16e26a54e6b63d21d0cee69a3b2b"
+    "sha512=43b436b5664228b50c34a132ea8c236ff53cfbacf39c07f8a941e91d3bb7952c28ccfc828c8de23fc5ac4e0d8714a0877d1a0cd968fbc18660980dda7e73c2a1"
+  ]
+}
+x-commit-hash: "fe44b3d1f0cce38850619f9befadc5565fc41a86"


### PR DESCRIPTION
Client bindings to the Tracy profiler (v0.13)

- Project page: <a href="https://github.com/ocaml-tracing/ocaml-tracy">https://github.com/ocaml-tracing/ocaml-tracy</a>

##### CHANGES:

- require OCaml 4.14
- compat trace 0.12
