### PR TITLE
Revert "Shim the compiler out" from #29795

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -58,14 +58,7 @@ jobs:
           opam-pin: false
           windows-environment: ${{ matrix.windows_environment }}
 
-      - name: Remove the compiler
-        run: |
-          opam switch set-invariant -n ${{ matrix.windows_environment == 'msys2' && 'msys2-mingw64' || 'host-system-mingw' }}
-          opam remove ocaml-compiler ocaml -y
-          opam switch set-invariant -n host-system-mingw
-
       - name: Install packages
-        if: always()
         run: |
           $failed = $false
           Foreach ($pkg in '${{ matrix.packages }}' -split ' ') {


### PR DESCRIPTION
This reverts commit e28fadf7e063e089b716122394b081ac266bcb6a from  #29795 which we forgot to remove again.