### PR TITLE
[new release] uspf (3 packages) (0.2.1)

### DIFF
--- a/packages/uspf-lwt/uspf-lwt.0.2.1/opam
+++ b/packages/uspf-lwt/uspf-lwt.0.2.1/opam
@@ -1,0 +1,34 @@
+opam-version: "2.0"
+maintainer:   "Romain Calascibetta <romain.calascibetta@gmail.com>"
+authors:      "Romain Calascibetta <romain.calascibetta@gmail.com>"
+homepage:     "https://github.com/mirage/uspf"
+bug-reports:  "https://github.com/mirage/uspf/issues"
+dev-repo:     "git+https://github.com/mirage/uspf.git"
+doc:          "https://mirage.github.io/uspf/"
+license:      "MIT"
+synopsis:     "SPF implementation in OCaml (with LWT)"
+description: """uspf-lwt is an implementation of the SPF verifier in OCaml
+compatible with MirageOS. It uses LWT as the scheduler."""
+
+build: [ "dune" "build" "-p" name "-j" jobs ]
+run-test: [ "dune" "runtest" "-p" name "-j" jobs ]
+
+depends: [
+  "ocaml"       {>= "4.12.0"}
+  "dune"        {>= "2.8.0"}
+  "uspf"        {= version}
+  "lwt"
+  "dns-client-lwt"
+  "alcotest"    {with-test}
+  "rresult"     {>= "0.7.0" & with-test}
+]
+x-maintenance-intent: [ "(latest)" ]
+url {
+  src:
+    "https://github.com/mirage/uspf/releases/download/0.2.1/uspf-0.2.1.tbz"
+  checksum: [
+    "sha256=e4e7ecd1422ce2c0baa5da982f58ec4f1986913772f1cd16bf24f46b4b411f95"
+    "sha512=02dfe40a2e5d8b3c4f361cb9a78f96e437a4fc4de36a7256b0c4f1af7b1efa15525e219219d9fef9a54518162f3c4fae68e32ca5aa7b10cd4673245ccd690335"
+  ]
+}
+x-commit-hash: "8cbdcf91d6a4ba328ec2ea2bbc4b4ebaf3f793db"

--- a/packages/uspf-mirage/uspf-mirage.0.2.1/opam
+++ b/packages/uspf-mirage/uspf-mirage.0.2.1/opam
@@ -1,0 +1,34 @@
+opam-version: "2.0"
+maintainer:   "Romain Calascibetta <romain.calascibetta@gmail.com>"
+authors:      "Romain Calascibetta <romain.calascibetta@gmail.com>"
+homepage:     "https://github.com/mirage/uspf"
+bug-reports:  "https://github.com/mirage/uspf/issues"
+dev-repo:     "git+https://github.com/mirage/uspf.git"
+doc:          "https://mirage.github.io/uspf/"
+license:      "MIT"
+synopsis:     "SPF implementation in OCaml (with for Mirage)"
+description: """uspf-mirage is an implementation of the SPF verifier in OCaml
+compatible with MirageOS. It uses LWT as the scheduler."""
+
+build: [ "dune" "build" "-p" name "-j" jobs ]
+run-test: [ "dune" "runtest" "-p" name "-j" jobs ]
+
+depends: [
+  "ocaml"       {>= "4.12.0"}
+  "dune"        {>= "2.8.0"}
+  "uspf"        {= version}
+  "lwt"
+  "dns-client-mirage"
+  "alcotest"    {with-test}
+  "rresult"     {>= "0.7.0" & with-test}
+]
+x-maintenance-intent: [ "(latest)" ]
+url {
+  src:
+    "https://github.com/mirage/uspf/releases/download/0.2.1/uspf-0.2.1.tbz"
+  checksum: [
+    "sha256=e4e7ecd1422ce2c0baa5da982f58ec4f1986913772f1cd16bf24f46b4b411f95"
+    "sha512=02dfe40a2e5d8b3c4f361cb9a78f96e437a4fc4de36a7256b0c4f1af7b1efa15525e219219d9fef9a54518162f3c4fae68e32ca5aa7b10cd4673245ccd690335"
+  ]
+}
+x-commit-hash: "8cbdcf91d6a4ba328ec2ea2bbc4b4ebaf3f793db"

--- a/packages/uspf/uspf.0.2.1/opam
+++ b/packages/uspf/uspf.0.2.1/opam
@@ -1,0 +1,42 @@
+opam-version: "2.0"
+maintainer:   "Romain Calascibetta <romain.calascibetta@gmail.com>"
+authors:      "Romain Calascibetta <romain.calascibetta@gmail.com>"
+homepage:     "https://github.com/mirage/uspf"
+bug-reports:  "https://github.com/mirage/uspf/issues"
+dev-repo:     "git+https://github.com/mirage/uspf.git"
+doc:          "https://mirage.github.io/uspf/"
+license:      "MIT"
+synopsis:     "SPF implementation in OCaml"
+description: """uspf is an implementation of the SPF verifier in OCaml
+compatible with MirageOS."""
+
+build: [ "dune" "build" "-p" name "-j" jobs ]
+run-test: [ "dune" "runtest" "-p" name "-j" jobs ]
+
+depends: [
+  "ocaml"       {>= "4.12.0"}
+  "dune"        {>= "2.8.0"}
+  "logs"
+  "colombe"     {>= "0.13.0"}
+  "mrmime"      {>= "0.5.0"}
+  "ipaddr"      {>= "5.2.0"}
+  "hmap"
+  "angstrom"    {>= "0.15.0"}
+  "domain-name"
+  "dns"         {>= "5.0.1"}
+  "lwt"
+  "dns-client"  {>= "6.1.0"}
+  "fmt"         {>= "0.8.9"}
+  "alcotest"    {with-test}
+  "rresult"     {>= "0.7.0" & with-test}
+]
+x-maintenance-intent: [ "(latest)" ]
+url {
+  src:
+    "https://github.com/mirage/uspf/releases/download/0.2.1/uspf-0.2.1.tbz"
+  checksum: [
+    "sha256=e4e7ecd1422ce2c0baa5da982f58ec4f1986913772f1cd16bf24f46b4b411f95"
+    "sha512=02dfe40a2e5d8b3c4f361cb9a78f96e437a4fc4de36a7256b0c4f1af7b1efa15525e219219d9fef9a54518162f3c4fae68e32ca5aa7b10cd4673245ccd690335"
+  ]
+}
+x-commit-hash: "8cbdcf91d6a4ba328ec2ea2bbc4b4ebaf3f793db"


### PR DESCRIPTION
SPF implementation in OCaml

- Project page: <a href="https://github.com/mirage/uspf">https://github.com/mirage/uspf</a>
- Documentation: <a href="https://mirage.github.io/uspf/">https://mirage.github.io/uspf/</a>

##### CHANGES:

- Handle dual stack for MX and A keys (@BChabanne, mirage/uspf#36)
- Upgrade with the new version of `colombe.emile` (@dinosaure, `2dd0900`)
