### PR TITLE
Add an idna.0.4 upper bound for jsonschema-validation.0.1.0

### DIFF
--- a/packages/jsonschema-validation/jsonschema-validation.0.1.0/opam
+++ b/packages/jsonschema-validation/jsonschema-validation.0.1.0/opam
@@ -14,7 +14,7 @@ depends: [
   "ipaddr" {>= "5.0"}
   "domain-name" {>= "0.4"}
   "ptime" {>= "1.0"}
-  "idna" {>= "0.3"}
+  "idna" {>= "0.3" & < "0.4"}
   "alcotest" {with-test}
   "odoc" {with-doc}
 ]


### PR DESCRIPTION
From #29801:
https://opam.ci.ocaml.org/github/ocaml/opam-repository/commit/28b642ad752f5700646f96c00832c94ee180e76a/variant/compilers,5.4,idna.0.4.0,revdeps,jsonschema-validation.0.1.0
```
#=== ERROR while compiling jsonschema-validation.0.1.0 ========================#
# context              2.5.1 | linux/x86_64 | ocaml-base-compiler.5.4.1 | file:///home/opam/opam-repository
# path                 ~/.opam/5.4/.opam-switch/build/jsonschema-validation.0.1.0
# command              ~/.opam/opam-init/hooks/sandbox.sh build dune build -p jsonschema-validation -j 255 @install
# exit-code            1
# env-file             ~/.opam/log/jsonschema-validation-7-2dbd94.env
# output-file          ~/.opam/log/jsonschema-validation-7-2dbd94.out
### output ###
# (cd _build/default && /home/opam/.opam/5.4/bin/ocamlc.opt -w -40 -g -bin-annot -bin-annot-occurrences -I lib/jsonschema-validation/.jsonschema_validation.objs/byte -I /home/opam/.opam/5.4/lib/angstrom -I /home/opam/.opam/5.4/lib/bigstringaf -I /home/opam/.opam/5.4/lib/domain-name -I /home/opam/.opam/5.4/lib/idna -I /home/opam/.opam/5.4/lib/idna/intranges -I /home/opam/.opam/5.4/lib/idna/tables -I /home/opam/.opam/5.4/lib/ipaddr -I /home/opam/.opam/5.4/lib/jsonschema-core -I /home/opam/.opam/5.4/lib/macaddr -I /home/opam/.opam/5.4/lib/ocaml/str -I /home/opam/.opam/5.4/lib/ptime -I /home/opam/.opam/5.4/lib/re -I /home/opam/.opam/5.4/lib/stringext -I /home/opam/.opam/5.4/lib/uri -I /home/opam/.opam/5.4/lib/yojson -no-alias-deps -open Jsonschema_validation__ -o lib/jsonschema-validation/.jsonschema_validation.objs/byte/jsonschema_validation__Fmt_hostname.cmo -c -impl lib/jsonschema-validation/fmt_hostname.ml)
# File "lib/jsonschema-validation/fmt_hostname.ml", line 11, characters 7-29:
# 11 |   else Idna.is_valid_hostname s
#             ^^^^^^^^^^^^^^^^^^^^^^
# Error: Unbound value Idna.is_valid_hostname
```