### PR TITLE
Packages bin_there.0.2.1a2 and ppx_bin_there.0.2.1a2

### DIFF
--- a/packages/bin_there/bin_there.0.2.1a2/opam
+++ b/packages/bin_there/bin_there.0.2.1a2/opam
@@ -1,0 +1,30 @@
+opam-version: "2.0"
+synopsis: "Serialization/deserialization with support for shared values"
+description: """\
+bin_there provides a binary serialization and deserialization library for OCaml
+with first-class support for shared values (graph-shaped data)."""
+maintainer: "David 'Yoric' Teller yteller@gitlab.com"
+authors: "David 'Yoric' Teller yteller@gitlab.com"
+license: "MIT"
+homepage: "https://gitlab.com/yteller/binthere"
+bug-reports: "https://gitlab.com/yteller/binthere/-/work_items"
+depends: [
+  "ocaml" {>= "4.14"}
+  "dune" {>= "3.8"}
+  "alcotest" {with-test}
+  "base-threads" {with-test}
+  "qcheck-alcotest" {with-test}
+  "camlzip" {with-test}
+]
+build: ["dune" "build" "-p" name "-j" jobs]
+run-test:
+  ["dune" "runtest" "-p" name "-j" jobs] {arch != "x86_32" & arch != "arm32"}
+dev-repo: "git+https://gitlab.com/yteller/binthere.git"
+url {
+  src:
+    "https://gitlab.com/api/v4/projects/81089450/packages/generic/bin_there/0.2.1a2/bin_there-0.2.1a2.tar.gz"
+  checksum: [
+    "md5=3efe5e125a0ac6ea05685c987ce0f124"
+    "sha512=9d496a2163312f13e0c7cb62c784422b683f28309d4c87d673fc1c827bc71dc6b90b27748805eec126c30bb1280ee8b527af5de9c3dcd0311f0946d7ae2411dc"
+  ]
+}

--- a/packages/bin_there/bin_there.0.2.1a2/opam
+++ b/packages/bin_there/bin_there.0.2.1a2/opam
@@ -9,7 +9,7 @@ license: "MIT"
 homepage: "https://gitlab.com/yteller/binthere"
 bug-reports: "https://gitlab.com/yteller/binthere/-/work_items"
 depends: [
-  "ocaml" {>= "4.14"}
+  "ocaml" {>= "4.14" & < "5"}
   "dune" {>= "3.8"}
   "alcotest" {with-test}
   "base-threads" {with-test}

--- a/packages/ppx_bin_there/ppx_bin_there.0.2.1a2/opam
+++ b/packages/ppx_bin_there/ppx_bin_there.0.2.1a2/opam
@@ -1,0 +1,30 @@
+opam-version: "2.0"
+synopsis:
+  "PPX rewriter to derive bin_there serializers from type definitions"
+description: """\
+ppx_bin_there is a PPX rewriter that automatically derives Bthere_<type> modules
+with serialize and deserialize functions compatible with the bin_there library
+from OCaml type definitions, using [@@deriving bthere]."""
+maintainer: "David 'Yoric' Teller yteller@gitlab.com"
+authors: "David 'Yoric' Teller yteller@gitlab.com"
+license: "MIT"
+homepage: "https://gitlab.com/yteller/binthere"
+bug-reports: "https://gitlab.com/yteller/binthere/-/work_items"
+depends: [
+  "ocaml" {>= "4.14"}
+  "dune" {>= "3.8"}
+  "ppxlib" {>= "0.28.0"}
+  "bin_there" {= version}
+  "alcotest" {with-test}
+]
+build: ["dune" "build" "-p" name "-j" jobs]
+run-test: ["dune" "runtest" "-p" name "-j" jobs]
+dev-repo: "git+https://gitlab.com/yteller/binthere.git"
+url {
+  src:
+    "https://gitlab.com/api/v4/projects/81089450/packages/generic/ppx_bin_there/0.2.1a2/ppx_bin_there-0.2.1a2.tar.gz"
+  checksum: [
+    "md5=50058a2a033c42e6482a8353a0dac37e"
+    "sha512=3038665322a53bcc53a1d387f2b80068f776a992a2751c168dc80dc58c3f99beca45b2cce48503399e55db8c8db957c0ade42190945b0468e525e7df55da2e82"
+  ]
+}


### PR DESCRIPTION
This pull-request concerns:
- `bin_there.0.2.1a2`: Serialization/deserialization with support for shared values
- `ppx_bin_there.0.2.1a2`: PPX rewriter to derive bin_there serializers from type definitions



---
* Homepage: https://gitlab.com/yteller/binthere
* Source repo: git+https://gitlab.com/yteller/binthere.git
* Bug tracker: https://gitlab.com/yteller/binthere/-/work_items

---
:camel: Pull-request generated by opam-publish v3.0.0