### PR TITLE
[new release] dmarc (2 packages) (0.0.2)

### DIFF
--- a/packages/dmarc/dmarc.0.0.2/opam
+++ b/packages/dmarc/dmarc.0.0.2/opam
@@ -12,7 +12,7 @@ depends: [
   "mrmime" {>= "0.5.0"}
   "uspf" {>= "0.2.0"}
   "dkim" {>= "0.9.0"}
-  "public-suffix"
+  "public-suffix" {= version}
   "logs" {>= "0.7.0"}
   "dune" {>= "2.9.0"}
   "lwt" {>= "5.4.2"}

--- a/packages/dmarc/dmarc.0.0.2/opam
+++ b/packages/dmarc/dmarc.0.0.2/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+synopsis: "DMARC support in OCaml"
+description: "DMARC implementation in OCaml"
+maintainer: "Romain Calascibetta <romain.calascibetta@gmail.com>"
+authors: "Romain Calascibetta <romain.calascibetta@gmail.com>"
+license: "MIT"
+homepage: "https://github.com/dinosaure/ocaml-dmarc"
+doc: "https://dinosaure.github.io/ocaml-dmarc/"
+bug-reports: "https://github.com/dinosaure/ocaml-dmarc/issues"
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "mrmime" {>= "0.5.0"}
+  "uspf" {>= "0.2.0"}
+  "dkim" {>= "0.9.0"}
+  "public-suffix"
+  "logs" {>= "0.7.0"}
+  "dune" {>= "2.9.0"}
+  "lwt" {>= "5.4.2"}
+  "uri" {>= "4.2.0"}
+  "alcotest" {>= "1.4.0" & with-test}
+  "dns" {>= "6.1.3"}
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/dinosaure/ocaml-dmarc.git"
+x-maintenance-intent: [ "(latest)" ]
+url {
+  src:
+    "https://github.com/dinosaure/ocaml-dmarc/releases/download/v0.0.2/dmarc-0.0.2.tbz"
+  checksum: [
+    "sha256=02f7043f7b97e51cb3cd9c1eb82ea3a53ddb4c14948c8366e669d1dd4fe2d728"
+    "sha512=b7642ffa583e2af53388bc434082f3068fb7e3408b4abd0a34616006749967ae63b695e797e6c529563ff9194a9f34353e415c4f2fed3ec71d2e862ba53f164c"
+  ]
+}
+x-commit-hash: "c5daebd05338a2c30e661b9dfe431e2c7a5d9100"

--- a/packages/public-suffix/public-suffix.0.0.2/opam
+++ b/packages/public-suffix/public-suffix.0.0.2/opam
@@ -1,0 +1,32 @@
+opam-version: "2.0"
+synopsis: "Public suffix of domain name suffixes in OCaml"
+description: "Public suffix of domain name suffixes in OCaml"
+maintainer: "Romain Calascibetta <romain.calascibetta@gmail.com>"
+authors: "Romain Calascibetta <romain.calascibetta@gmail.com>"
+license: "MIT"
+homepage: "https://github.com/dinosaure/ocaml-dmarc"
+doc: "https://dinosaure.github.io/ocaml-dmarc/"
+bug-reports: "https://github.com/dinosaure/ocaml-dmarc/issues"
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "domain-name"
+  "curl"
+  "dune" {>= "3.20.0"}
+  "alcotest" {>= "1.4.0" & with-test}
+  "dmarc" {= version & with-test}
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/dinosaure/ocaml-dmarc.git"
+x-maintenance-intent: [ "(latest)" ]
+url {
+  src:
+    "https://github.com/dinosaure/ocaml-dmarc/releases/download/v0.0.2/dmarc-0.0.2.tbz"
+  checksum: [
+    "sha256=02f7043f7b97e51cb3cd9c1eb82ea3a53ddb4c14948c8366e669d1dd4fe2d728"
+    "sha512=b7642ffa583e2af53388bc434082f3068fb7e3408b4abd0a34616006749967ae63b695e797e6c529563ff9194a9f34353e415c4f2fed3ec71d2e862ba53f164c"
+  ]
+}
+x-commit-hash: "c5daebd05338a2c30e661b9dfe431e2c7a5d9100"


### PR DESCRIPTION
DMARC support in OCaml

- Project page: <a href="https://github.com/dinosaure/ocaml-dmarc">https://github.com/dinosaure/ocaml-dmarc</a>
- Documentation: <a href="https://dinosaure.github.io/ocaml-dmarc/">https://dinosaure.github.io/ocaml-dmarc/</a>

##### CHANGES:

- Update our `public_suffix_list.dat` (@dinosaure, dinosaure/ocaml-dmarc#19)
