### PR TITLE
RFC: add a virtual package for OxCaml dependency

### DIFF
--- a/packages/oxcaml/oxcaml.action-required/opam
+++ b/packages/oxcaml/oxcaml.action-required/opam
@@ -1,0 +1,30 @@
+opam-version: "2.0"
+license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
+synopsis: "Virtual package indicating dependency on OxCaml"
+description:
+"Virtual package whose installation always fails and displays the instructions
+for activating OxCaml's opam-repository overlay.
+
+The recommended method for creating new OxCaml switches is:
+
+opam switch create oxcaml oxcaml-compiler --repos ox=git+https://github.com/oxcaml/opam-repository.git,default
+
+Please see https://oxcaml.org/get-oxcaml/ for more information"
+maintainer: "Jane Street <opensource-contacts@janestreet.com>"
+authors: "Xavier Leroy and many contributors"
+homepage: "https://oxcaml.org"
+bug-reports: "https://github.com/oxcaml/oxcaml/issues"
+messages: ["OxCaml opam repository required - see https://oxcaml.org/get-oxcaml"]
+build: ["false" "- oxcaml/opam-repository is required"]
+post-messages: [
+"You appear to have tried to install a package which requires OxCaml without
+first adding/enabling the opam package repository for OxCaml. This repository
+can be added to your current switch with:
+
+opam repository add ox git+https://github.com/oxcaml/opam-repository.git
+
+Please see https://oxcaml.org/get-oxcaml/ for more information"]
+# This package will be replaced by either oxcaml.archived or oxcaml.latest when
+# oxcaml/opam-repository is enabled.
+conflicts: "oxcaml-compiler"
+flags: avoid-version


### PR DESCRIPTION
This PR is an idea to allow OxCaml dependency to be indicated in opam-repository packages and stems from https://github.com/oxcaml/opam-repository/issues/35. While I'm not sure whether packages which depend on OxCaml definitely want to be released to opam-repository, it might make sense for packages in opam-repository to be able to have parts of build recipes and filters which refer to the presence of OxCaml.

As of last week, we have changed the packaging in [oxcaml/opam-repository](https://github.com/oxcaml/opam-repository) so that the compiler itself lives in [`oxcaml-compiler`])(https://github.com/oxcaml/opam-repository/tree/main/packages/oxcaml-compiler) and includes more precise version information than [previously](https://github.com/oxcaml/opam-repository/tree/main/packages/ocaml-variants). We also added a virtual/signalling package called [`oxcaml`](https://github.com/oxcaml/opam-repository/tree/main/packages/oxcaml). This latter package serves two purposes. Firstly, it provides a generic way to `opam install oxcaml` which by default provides the latest release of OxCaml. Secondly, it provides a concrete package which can be depended on or conflicted in other opam files (`oxcaml-compiler` can also be used for this; I anticipated being able to use `oxcaml {= "latest"}` as a switch invariant being useful, though, as a way of forcing one's switch to remain on the very latest release, even if some things were broken).

So far, so what's living in our repo [over there](https://github.com/oxcaml/opam-repository). I'm suggesting we include a third version of `oxcaml` in opam-repository for two reasons. Firstly, it means that packages in opam-repository can refer to `oxcaml`, and know that we're talking about the same package and thus allow, for example, things like:
```opam
build: [
  ["./configure" "--enable-oxcaml-features" {oxcaml:installed}]
]
```

Secondly, it provides an opportunity for a more helpful error message if someone attempts to install OxCaml (or something which depends on OxCaml) but fails to set up their opam remotes correctly. This is very similar to what we already do with the old [`ocaml-beta`](https://github.com/ocaml/opam-repository/tree/master/packages/ocaml-beta) package, with a default "not working" version in opam-repository and the the working version in [another repository](https://github.com/ocaml/ocaml-beta-repository/tree/master/packages/ocaml-beta).

If oxcaml/opam-repository has _not_ been enabled for a switch, one would now see:
```console
$ opam install oxcaml
The following actions will be performed:
=== install 1 package
  - install oxcaml action-required  OxCaml opam repository required - see
                                    https://oxcaml.org/get-oxcaml
```

followed by:

```console
<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
[ERROR] The compilation of oxcaml.action-required failed at "false - oxcaml/opam-repository is
        required".
```

and at the end:
```console
<><> Error report <><><><><><><><><><><><><><><><><><><><><><><><><><><><><><><>
+- The following actions failed
| - build oxcaml action-required
+-
- No changes have been performed

<><> oxcaml.action-required troubleshooting <><><><><><><><><><><><><><><><><><>
=> You appear to have tried to install a package which requires OxCaml without
   first adding/enabling the opam package repository for OxCaml. This repository
   can be added to your current switch with:

   opam repository add ox git+https://github.com/oxcaml/opam-repository.git

   Please see https://oxcaml.org/get-oxcaml/ for more information
```

The version numbers have been linguistically engineered such that `action-required` < `archived` < `latest` which means that `opam upgrade` doesn't complain about being unable to upgrade the package. oxcaml/opam-repository would include an overridden version `oxcaml.action-required` with `available: false` (see https://github.com/oxcaml/opam-repository/pull/40).