### PR TITLE
[new release] ciao_lwt (0.2)

### DIFF
--- a/packages/ciao_lwt/ciao_lwt.0.2/opam
+++ b/packages/ciao_lwt/ciao_lwt.0.2/opam
@@ -1,0 +1,66 @@
+opam-version: "2.0"
+synopsis:
+  "A tool for migrating from Lwt to direct-style concurrency libraries"
+maintainer: [
+  "Jules Aguillon <jules@j3s.fr>"
+  "Nicolas Osborne <nicolas.osborne@tarides.com>"
+]
+authors: [
+  "Jules Aguillon <jules@j3s.fr>"
+  "Nicolas Osborne <nicolas.osborne@tarides.com>"
+]
+license: "MIT"
+homepage: "https://github.com/tarides/ciao-lwt"
+bug-reports: "https://github.com/tarides/ciao-lwt/issues"
+depends: [
+  "ocaml" {>= "5.3"}
+  "merlin-lib" {>= "5.5-503"}
+  "lwt" {with-test}
+  "lwt_log" {with-test}
+  "js_of_ocaml-lwt" {with-test}
+  "ocaml-index" {with-test}
+  "base" {>= "v0.12.0"}
+  "cmdliner" {>= "1.1.0"}
+  "dune" {>= "3.17"}
+  "dune-build-info"
+  "either"
+  "fix"
+  "fpath" {>= "0.7.3"}
+  "menhir" {>= "20201216"}
+  "menhirLib" {>= "20201216"}
+  "menhirSdk" {>= "20201216"}
+  "ocaml-version" {>= "3.5.0"}
+  "ocp-indent" {>= "1.8.0"}
+  "stdio"
+  "uuseg" {>= "10.0.0"}
+  "uutf" {>= "1.0.1"}
+  "csexp" {>= "1.4.0"}
+  "astring"
+  "camlp-streams"
+  "re" {>= "1.10.3"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/tarides/ciao-lwt.git"
+url {
+  src:
+    "https://github.com/tarides/ciao-lwt/releases/download/0.2/ciao_lwt-0.2.tbz"
+  checksum: [
+    "sha256=1ee830a5a6fec1adf4dc3fe3caae7cca769b49c1671fb0fcb4884778feb211c6"
+    "sha512=6ff296f22bfc254e96acf83465876843bbeabbfa11239528fd9a3d4f6cc1a7d0973a517b9dc0f5c1d7fe467c945ae686a4aa294788cda3d37035b4ab7928c5bf"
+  ]
+}
+x-commit-hash: "293b1def3841f135744066e99269b6d1204ee338"


### PR DESCRIPTION
A tool for migrating from Lwt to direct-style concurrency libraries

- Project page: <a href="https://github.com/tarides/ciao-lwt">https://github.com/tarides/ciao-lwt</a>

##### CHANGES:

- Compatibility with OCaml 5.4 and 5.5

- Generate `Promise.await` for bound expression that are not function
  applications.
  For example,
  ```ocaml
  let x = async_operation () in
  let* y = x in
  ..
  ```
  is transformed to:
  ```ocaml
  let x = async_operation () in
  let y = Promise.await x in
  ..
  ```
  This will likely result in a compiler error, that can easily be fixed instead
  of a silent change in the program behavior.
