### PR TITLE
[new release] ppx_deriving_jsonschema (0.07)

### DIFF
--- a/packages/ppx_deriving_jsonschema/ppx_deriving_jsonschema.0.07/opam
+++ b/packages/ppx_deriving_jsonschema/ppx_deriving_jsonschema.0.07/opam
@@ -1,0 +1,54 @@
+opam-version: "2.0"
+synopsis: "Jsonschema generator for ppx_deriving"
+description:
+  "ppx_deriving_jsonschema is a ppx rewriter that generates jsonschema from ocaml types"
+maintainer: [
+  "Louis Roché <louis.roche@ahrefs.com>"
+  "Koonwen Lee <koonwen.lee@ahrefs.com>"
+  "Ahrefs <github@ahrefs.com>"
+]
+authors: [
+  "Louis Roché <louis.roche@ahrefs.com>" "Ahrefs <github@ahrefs.com>"
+]
+license: "MIT"
+tags: ["jsonschema" "org:ahrefs" "syntax"]
+homepage: "https://github.com/ahrefs/ppx_deriving_jsonschema"
+doc: "https://ahrefs.github.io/ppx_deriving_jsonschema/"
+bug-reports: "https://github.com/ahrefs/ppx_deriving_jsonschema/issues"
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "3.16"}
+  "ppxlib" {>= "0.24.0"}
+  "melange" {>= "4.0.0"}
+  "melange-json" {with-test}
+  "melange-json-native" {with-test}
+  "yojson" {with-test}
+  "ocamlformat" {= "0.29.0" & with-dev-setup}
+  "ocaml-lsp-server" {with-dev-setup}
+  "odoc-driver" {with-doc}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/ahrefs/ppx_deriving_jsonschema.git"
+url {
+  src:
+    "https://github.com/ahrefs/ppx_deriving_jsonschema/releases/download/0.07/ppx_deriving_jsonschema-0.07.tbz"
+  checksum: [
+    "sha256=70f2aeadcb9184e02c5a5adca4635480ac7c87e95fc62b4a7dcbe6103a116bd5"
+    "sha512=1060ddbee2117a289f690da5581f2a61a22f47b6152e935e7ba4b0f88dc017402768012c28a4695fe479d0cce76d16b49e901159bcecdf6eb8652b922ff4709f"
+  ]
+}
+x-commit-hash: "0170d4ffa5d51d6d948b2aff64779c30d1cb87cd"


### PR DESCRIPTION
Jsonschema generator for ppx_deriving

- Project page: <a href="https://github.com/ahrefs/ppx_deriving_jsonschema">https://github.com/ahrefs/ppx_deriving_jsonschema</a>
- Documentation: <a href="https://ahrefs.github.io/ppx_deriving_jsonschema/">https://ahrefs.github.io/ppx_deriving_jsonschema/</a>

##### CHANGES:

- add `[@@jsonschema.compact_variants]` attribute on variant type declarations to render unit constructors as plain string constants (`{ "const": "Name" }`) instead of single-element tuple arrays; constructors with arguments keep the tuple array encoding
- add `[@@jsonschema.format]` attribute to add a format to a type or a field; now also supported on core types (e.g. variant payloads: `A of (string[@jsonschema.format "date-time"])`); validated to only apply to `string` and `bytes` types
- add `[@@jsonschema.description]` attribute to add a description to a type or a field; now also supported on core types (e.g. variant payloads and inline type annotations) and on polymorphic variant tags
- add `~ocaml_doc` flag on `[@@deriving jsonschema]` to use `ocaml.doc` attributes (i.e. `(** ... *)` doc comments) as a fallback for `[@@jsonschema.description]` when the explicit annotation is absent; off by default
- add `[@jsonschema.attrs]` composite attribute to bundle multiple schema annotations in a single record expression (e.g. `[@jsonschema.attrs { maximum = 100; minimum = 0; description = "Score out of 100" }]`); supported on core types, label declarations, and type declarations
- add `[@jsonschema.default <value>]` attribute on record fields to set a JSON Schema `"default"` value; fields with a default are excluded from `required`; primitive literals (`int`, `int32`, `nativeint`, `float`, `string`, `bytes`, `bool`, and their `option`, `list`, `array` variants) are serialized automatically; non-primitive types (custom variants, records, etc.) require a `<type>_to_json : <type> -> Yojson.Basic.t` function to be in scope (e.g. via `[@@deriving json]`); also accepts the `[@default]` shorthand for compatibility with melange-json
- make option types nullable in generated JSON Schema (e.g. `int option` → `{"type":["integer","null"]}`); add `[@@jsonschema.option]` attribute to opt a field out of `required` without making its type nullable
- fix schema generation for parametric recursive types (e.g. `type 'a t = ... | B of 'a t`)
- fix broken `$ref` scoping when a recursive type uses a parametric recursive type with itself as a type argument (e.g. `type t = ... | N of t wrapper` where `wrapper` is also recursive); inner `$defs` are now hoisted into the root schema's `$defs` namespace
