### PR TITLE
[new release] Caqti 2.3.1 (caqti-miou package only)

### DIFF
--- a/packages/caqti-miou/caqti-miou.2.3.1/opam
+++ b/packages/caqti-miou/caqti-miou.2.3.1/opam
@@ -1,0 +1,36 @@
+opam-version: "2.0"
+maintainer: "Petter A. Urkedal <paurkedal@gmail.com>"
+x-maintenance-intent: ["(latest)"]
+authors: "Romain Calascibetta <romain.calascibetta@gmail.com>"
+license: "LGPL-3.0-or-later WITH LGPL-3.0-linking-exception"
+homepage: "https://github.com/paurkedal/ocaml-caqti/"
+doc: "https://paurkedal.github.io/ocaml-caqti/index.html"
+bug-reports: "https://github.com/paurkedal/ocaml-caqti/issues"
+depends: [
+  "caqti" {>= "2.2.3" & < "2.4.0~"}
+  "dune" {>= "3.9"}
+  "miou" {>= "0.3.0"}
+  "logs"
+  "ocaml" {>= "5.0.0~"}
+  "alcotest" {with-test & >= "1.5.0"}
+  "caqti-driver-sqlite3" {with-test}
+  "cmdliner" {with-test & >= "1.1.0"}
+  "mirage-crypto-rng-miou-unix" {with-test}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+  ["dune" "build" "@doc" "-p" name "-j" jobs] {with-doc}
+]
+dev-repo: "git+https://github.com/paurkedal/ocaml-caqti.git"
+synopsis: "Miou support for Caqti"
+url {
+  src:
+    "https://github.com/paurkedal/ocaml-caqti/releases/download/v2.3.1/caqti-v2.3.1.tbz"
+  checksum: [
+    "sha256=036380a0f1a67e09d002cc47f2cb1c52ebf4f7cc9b89ea5b70cec3b389ce298d"
+    "sha512=8d8e12e6101bb9b61b805e68236375f685c63400fefe3de422a24990e16b16ef2eeaebc66171b8dbe498be3e3d394445ee49c9a93b5b0b3e9d9d43b9fcf1acdc"
+  ]
+}
+x-commit-hash: "03637f374f042bf7e73dfcce767487edab95b3c9"


### PR DESCRIPTION
This avoids exhaustiveness check failure discovered by OCaml 5.5 beta.