### PR TITLE
Mark BER MetaOCaml with avoid-version

### DIFF
--- a/packages/ocaml-variants/ocaml-variants.5.3.0+BER/opam
+++ b/packages/ocaml-variants/ocaml-variants.5.3.0+BER/opam
@@ -87,4 +87,3 @@ conflicts: [
   "relocatable"
 ]
 available: os != "win32"
-tags: [ avoid-version ]

--- a/packages/ocaml-variants/ocaml-variants.5.3.0+BER/opam
+++ b/packages/ocaml-variants/ocaml-variants.5.3.0+BER/opam
@@ -87,3 +87,4 @@ conflicts: [
   "relocatable"
 ]
 available: os != "win32"
+tags: [ avoid-version ]

--- a/packages/ocaml-variants/ocaml-variants.5.3.0+BER/opam
+++ b/packages/ocaml-variants/ocaml-variants.5.3.0+BER/opam
@@ -22,7 +22,7 @@ depends: [
   "ocaml-option-bytecode-only" {arch != "arm64" & arch != "x86_64" & arch != "s390x" & arch != "riscv64" & arch != "ppc64"}
 ]
 conflict-class: "ocaml-core-compiler"
-flags: compiler
+flags: [ compiler avoid-version]
 setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
 build: [
   [


### PR DESCRIPTION
This is an attempt to fix #28249, but it doesn’t seem to work yet:

```
$ opam switch create tmp ocaml-option-tsan --repositories=test=path:///home/olivier/ocaml/opam-repository,default

<><> Installing new switch packages <><><><><><><><><><><><><><><><><><><><><><>
Switch invariant: ["ocaml-option-tsan"]

The following system packages will first need to be installed:
    pkg-config

<><> Handling external dependencies <><><><><><><><><><><><><><><><><><><><><><>

opam believes some required external dependencies are missing. opam can:
> 1. Run nix-build to install them (may need root/sudo access)
  2. Display the recommended nix-build command and wait while you run it manually (e.g. in another
     terminal)
  3. Continue anyway, and, upon success, permanently register that this external dependency is present, but
     not detectable
  4. Abort the installation

[1/2/3/4] 3

[NOTE] Run 'opam option depext=false' if you wish to permanently disable handling of system packages.


<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
⬇ retrieved base-metaocaml-ocamlfind.base  (cached)
⬇ retrieved ocaml-config.3  (cached)
∗ installed base-bigarray.base
∗ installed base-threads.base
∗ installed base-unix.base
⬇ retrieved ocaml-variants.5.3.0+BER  (cached)
∗ installed conf-pkg-config.4
[NOTE] Requirement for system package pkg-config overridden in this switch. Use `opam option
       'depext-bypass-="pkg-config"'' to revert.
∗ installed conf-unwind.0
∗ installed ocaml-option-tsan.1
[ERROR] User interruption
```

Am I missing something?