### PR TITLE
[new release] nats-client (2 packages) (0.0.10)

### DIFF
--- a/packages/nats-client-async/nats-client-async.0.0.10/opam
+++ b/packages/nats-client-async/nats-client-async.0.0.10/opam
@@ -1,0 +1,46 @@
+opam-version: "2.0"
+synopsis: "Lean OCaml Async NATS client"
+description: "Async-based OCaml NATS client"
+maintainer: ["Hebilicious"]
+authors: ["Hebilicious"]
+license: "MIT"
+homepage: "https://github.com/hebilicious/nats-ml"
+bug-reports: "https://github.com/hebilicious/nats-ml/issues"
+depends: [
+  "ocaml" {>= "4.14.0"}
+  "dune" {>= "3.19"}
+  "core"
+  "async"
+  "async_unix"
+  "uri"
+  "yojson" {>= "1.7.0"}
+  "nats-client" {= version}
+  "odoc" {with-doc}
+]
+dev-repo: "git+https://github.com/hebilicious/nats-ml.git"
+x-maintenance-intent: ["(latest)"]
+available: [ os-distribution != "alpine" & arch != "riscv64" ]
+
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test & opam-version >= "2.1" & arch != "x86_32" & arch != "arm32" & arch != "ppc64" & arch != "s390x"}
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src:
+    "https://github.com/hebilicious/nats-ml/releases/download/v0.0.10/nats-client-0.0.10.tbz"
+  checksum: [
+    "sha256=3f73132bc4b39e0b8f6960085b74868f6f4e2bd7a55528fc2a22f90caedd1ec8"
+    "sha512=4f6e6dfa0aa3029c178fbb1b266a3ea604f2c51579267d1e7ab2e7382a70335f6c05a463a851b860accdeee6eb78eca735ec887a1d4c944716d514aa63fefdfd"
+  ]
+}
+x-commit-hash: "f873738734f2cd9322ffdde787d1ca793a5f16b1"

--- a/packages/nats-client/nats-client.0.0.10/opam
+++ b/packages/nats-client/nats-client.0.0.10/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+synopsis: "Lean OCaml NATS protocol client"
+description: "Runtime-independent OCaml NATS protocol primitives"
+maintainer: ["Hebilicious"]
+authors: ["Hebilicious"]
+license: "MIT"
+homepage: "https://github.com/hebilicious/nats-ml"
+bug-reports: "https://github.com/hebilicious/nats-ml/issues"
+depends: [
+  "ocaml" {>= "4.14.0"}
+  "dune" {>= "3.19"}
+  "yojson"
+  "odoc" {with-doc}
+]
+dev-repo: "git+https://github.com/hebilicious/nats-ml.git"
+x-maintenance-intent: ["(latest)"]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test & opam-version >= "2.1"}
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src:
+    "https://github.com/hebilicious/nats-ml/releases/download/v0.0.10/nats-client-0.0.10.tbz"
+  checksum: [
+    "sha256=3f73132bc4b39e0b8f6960085b74868f6f4e2bd7a55528fc2a22f90caedd1ec8"
+    "sha512=4f6e6dfa0aa3029c178fbb1b266a3ea604f2c51579267d1e7ab2e7382a70335f6c05a463a851b860accdeee6eb78eca735ec887a1d4c944716d514aa63fefdfd"
+  ]
+}
+x-commit-hash: "f873738734f2cd9322ffdde787d1ca793a5f16b1"


### PR DESCRIPTION
Lean OCaml NATS protocol client

- Project page: <a href="https://github.com/hebilicious/nats-ml">https://github.com/hebilicious/nats-ml</a>

##### CHANGES:


- Make `nats-client-async` depend on the matching `nats-client` version in generated opam metadata.
