### PR TITLE
[new release] ppx_deriving_jsonschema (0.0.7)

### DIFF
--- a/packages/ppx_deriving_jsonschema/ppx_deriving_jsonschema.0.0.7/opam
+++ b/packages/ppx_deriving_jsonschema/ppx_deriving_jsonschema.0.0.7/opam
@@ -1,0 +1,57 @@
+opam-version: "2.0"
+synopsis: "Jsonschema generator for ppx_deriving"
+description:
+  "ppx_deriving_jsonschema is a ppx rewriter that generates jsonschema from ocaml types"
+maintainer: [
+  "Louis Roché <louis.roche@ahrefs.com>"
+  "Koonwen Lee <koonwen.lee@ahrefs.com>"
+  "Ahrefs <github@ahrefs.com>"
+]
+authors: [
+  "Louis Roché <louis.roche@ahrefs.com>" "Ahrefs <github@ahrefs.com>"
+]
+license: "MIT"
+tags: ["jsonschema" "org:ahrefs" "syntax"]
+homepage: "https://github.com/ahrefs/ppx_deriving_jsonschema"
+doc: "https://ahrefs.github.io/ppx_deriving_jsonschema/"
+bug-reports: "https://github.com/ahrefs/ppx_deriving_jsonschema/issues"
+depends: [
+  "ocaml" {>= "5.0.0"}
+  "dune" {>= "3.16"}
+  "ppxlib" {> "0.36.0"}
+  "melange" {>= "4.0.0"}
+  "server-reason-react" {>= "0.4.1"}
+  "melange-json" {>= "2.0.0" & with-test}
+  "melange-json-native" {>= "2.0.0" & with-test}
+  "yojson" {with-test}
+  "conf-npm" {with-test}
+  "conf-python-3" {with-test}
+  "ocamlformat" {= "0.29.0" & with-dev-setup}
+  "ocaml-lsp-server" {with-dev-setup}
+  "odoc-driver" {with-doc}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/ahrefs/ppx_deriving_jsonschema.git"
+url {
+  src:
+    "https://github.com/ahrefs/ppx_deriving_jsonschema/releases/download/0.0.7/ppx_deriving_jsonschema-0.0.7.tbz"
+  checksum: [
+    "sha256=5bb0bf3f1febb3153a41f11434bbcd1a63059ed8ef18d758e7af7ce6947506dc"
+    "sha512=5a7a8f64fcdbd3554aa7af21b5d4e420f90bc43f232fe769c00d0bd928529bada2b469f80cac8fbd30ecbddbba4de1b3d455b6463773e77e4b34a54360bce648"
+  ]
+}
+x-commit-hash: "baa074b90191e0e22b1d0da0cc1b9c9217b4ccfd"


### PR DESCRIPTION
Jsonschema generator for ppx_deriving

- Project page: <a href="https://github.com/ahrefs/ppx_deriving_jsonschema">https://github.com/ahrefs/ppx_deriving_jsonschema</a>
- Documentation: <a href="https://ahrefs.github.io/ppx_deriving_jsonschema/">https://ahrefs.github.io/ppx_deriving_jsonschema/</a>

##### CHANGES:

- add `[@@jsonschema.compact_variants]` attribute on variant type declarations to render unit constructors as plain string constants (`{ "const": "Name" }`) instead of single-element tuple arrays; constructors with arguments keep the tuple array encoding
- add `[@@jsonschema.format]` attribute to add a format to a type or a field; now also supported on core types (e.g. variant payloads: `A of (string[@jsonschema.format "date-time"])`); validated to only apply to `string` and `bytes` types
- add `[@@jsonschema.description]` attribute to add a description to a type or a field; now also supported on core types (e.g. variant payloads and inline type annotations) and on polymorphic variant tags
- add `~ocaml_doc` flag on `[@@deriving jsonschema]` to use `ocaml.doc` attributes (i.e. `(** ... *)` doc comments) as a fallback for `[@@jsonschema.description]` when the explicit annotation is absent; off by default
- add `[@jsonschema.attrs]` composite attribute to bundle multiple schema annotations in a single record expression (e.g. `[@jsonschema.attrs { maximum = 100; minimum = 0; description = "Score out of 100" }]`); supported on core types, label declarations, and type declarations
- add `[@jsonschema.default <value>]` attribute on record fields to set a JSON Schema `"default"` value; fields with a default are excluded from `required`; primitive literals (`int`, `int32`, `nativeint`, `float`, `string`, `bytes`, `bool`, and their `option`, `list`, `array` variants) are serialized automatically; non-primitive types (custom variants, records, etc.) require a `<type>_to_json : <type> -> Yojson.Basic.t` function to be in scope (e.g. via `[@@deriving json]`); also accepts the `[@default]` shorthand for compatibility with melange-json
- make option types nullable in generated JSON Schema (e.g. `int option` → `{"type":["integer","null"]}`); add `[@@jsonschema.option]` attribute to opt a field out of `required` without making its type nullable
- fix schema generation for parametric recursive types (e.g. `type 'a t = ... | B of 'a t`)
- fix broken `$ref` scoping when a recursive type uses a parametric recursive type with itself as a type argument (e.g. `type t = ... | N of t wrapper` where `wrapper` is also recursive); inner `$defs` are now hoisted into the root schema's `$defs` namespace
- refactor runtime using `server-reason-react`'s `browser_only` ppx to share more code between the native and melange runtimes
- raise lower bounds to match what the code now requires: `ocaml >= 5.0.0`, `ppxlib > 0.36.0`, `melange-json >= 2.0.0`, `melange-json-native >= 2.0.0`; declare `conf-npm` and `conf-python-3` as test dependencies so the melange cram test can run in the opam sandbox
