### PR TITLE
Add an upper ocaml bound to core.v0.17.1

### DIFF
--- a/packages/core/core.v0.17.1/opam
+++ b/packages/core/core.v0.17.1/opam
@@ -10,7 +10,7 @@ build: [
   ["dune" "build" "-p" name "-j" jobs]
 ]
 depends: [
-  "ocaml"               {>= "5.1.0"}
+  "ocaml"               {>= "5.1.0" & < "5.5"}
   "base"                {>= "v0.17" & < "v0.18~"}
   "base_bigstring"      {>= "v0.17" & < "v0.18~"}
   "base_quickcheck"     {>= "v0.17" & < "v0.18~"}


### PR DESCRIPTION
This PR adds an upper ocaml bound to core.v0.17.1 due to Gc.stat incompatible changes.

Spotted on #29816:
https://opam.ci.ocaml.org/github/ocaml/opam-repository/commit/535e7641c66478ad1a0c237baa08dc3b2065377d/variant/compilers,5.5~beta1,nats-client-async.0.0.10,lower-bounds
```
#=== ERROR while compiling core.v0.17.1 =======================================#
# context              2.5.1 | linux/x86_64 | ocaml-base-compiler.5.5.0~beta1 | file:///home/opam/opam-repository
# path                 ~/.opam/5.5~beta1/.opam-switch/build/core.v0.17.1
# command              ~/.opam/opam-init/hooks/sandbox.sh build dune build -p core -j 255
# exit-code            1
# env-file             ~/.opam/log/core-7-1a16a4.env
# output-file          ~/.opam/log/core-7-1a16a4.out
### output ###
# (cd _build/default && /home/opam/.opam/5.5~beta1/bin/ocamlc.opt -w -40 -g -bin-annot -bin-annot-occurrences -I core/src/.core.objs/byte -I /home/opam/.opam/5.5~beta1/lib/base -I /home/opam/.opam/5.5~beta1/lib/base/base_internalhash_types -I /home/opam/.opam/5.5~beta1/lib/base/md5 -I /home/opam/.opam/5.5~beta1/lib/base/shadow_stdlib -I /home/opam/.opam/5.5~beta1/lib/base_bigstring -I /home/opam/.opam/5.5~beta1/lib/base_quickcheck -I /home/opam/.opam/5.5~beta1/lib/base_quickcheck/ppx_quickcheck/runtime -I /home/opam/.opam/5.5~beta1/lib/bin_prot -I /home/opam/.opam/5.5~beta1/lib/bin_prot/shape -I /home/opam/.opam/5.5~beta1/lib/fieldslib -I /home/opam/.opam/5.5~beta1/lib/gel -I /home/opam/.opam/5.5~beta1/lib/int_repr -I /home/opam/.opam/5.5~beta1/lib/jane-street-headers -I /home/opam/.opam/5.5~beta1/lib/ocaml_intrinsics_kernel -I /home/opam/.opam/5.5~beta1/lib/parsexp -I /home/opam/.opam/5.5~beta1/lib/ppx_assert/runtime-lib -I /home/opam/.opam/5.5~beta1/lib/ppx_bench/runtime-lib -I /home/opam/.opam/5.5~beta1/lib/ppx_compare/runtime-lib -I /home/opam/.opam/5.5~beta1/lib/ppx_diff/diffable -I /home/opam/.opam/5.5~beta1/lib/ppx_diff/diffable_cinaps -I /home/opam/.opam/5.5~beta1/lib/ppx_enumerate/runtime-lib -I /home/opam/.opam/5.5~beta1/lib/ppx_expect/config -I /home/opam/.opam/5.5~beta1/lib/ppx_expect/config_types -I /home/opam/.opam/5.5~beta1/lib/ppx_expect/make_corrected_file -I /home/opam/.opam/5.5~beta1/lib/ppx_expect/runtime -I /home/opam/.opam/5.5~beta1/lib/ppx_hash/runtime-lib -I /home/opam/.opam/5.5~beta1/lib/ppx_here/runtime-lib -I /home/opam/.opam/5.5~beta1/lib/ppx_inline_test/config -I /home/opam/.opam/5.5~beta1/lib/ppx_inline_test/runtime-lib -I /home/opam/.opam/5.5~beta1/lib/ppx_log/syntax -I /home/opam/.opam/5.5~beta1/lib/ppx_log/types -I /home/opam/.opam/5.5~beta1/lib/ppx_module_timer/runtime -I /home/opam/.opam/5.5~beta1/lib/ppx_sexp_conv/runtime-lib -I /home/opam/.opam/5.5~beta1/lib/ppx_stable_witness/runtime -I /home/opam/.opam/5.5~beta1/lib/ppx_stable_witness/stable_witness -I /home/opam/.opam/5.5~beta1/lib/ppx_string/runtime -I /home/opam/.opam/5.5~beta1/lib/ppxlib/print_diff -I /home/opam/.opam/5.5~beta1/lib/sexplib -I /home/opam/.opam/5.5~beta1/lib/sexplib0 -I /home/opam/.opam/5.5~beta1/lib/splittable_random -I /home/opam/.opam/5.5~beta1/lib/stdio -I /home/opam/.opam/5.5~beta1/lib/time_now -I /home/opam/.opam/5.5~beta1/lib/typerep -I /home/opam/.opam/5.5~beta1/lib/variantslib -I base_for_tests/src/.base_for_tests.objs/byte -I command/src/.command.objs/byte -I filename_base/src/.filename_base.objs/byte -I heap_block/.heap_block.objs/byte -I univ_map/src/.univ_map.objs/byte -I validate/src/.validate.objs/byte -intf-suffix .ml -no-alias-deps -open Core__ -o core/src/.core.objs/byte/core__Perms.cmo -c -impl core/src/perms.pp.ml)
# File "core/src/perms.ml", lines 162-163, characters 4-78:
# 162 | ....type 'a perms = 'a V1.Upper_bound.t
# 163 |     [@@deriving bin_io, compare, equal, globalize, hash, sexp, stable_witness]
# Warning 20 [ignored-extra-argument]: this argument will not be used by the function.
# (cd _build/default && /home/opam/.opam/5.5~beta1/bin/ocamlopt.opt -w -40 -g -I core/src/.core.objs/byte -I core/src/.core.objs/native -I /home/opam/.opam/5.5~beta1/lib/base -I /home/opam/.opam/5.5~beta1/lib/base/base_internalhash_types -I /home/opam/.opam/5.5~beta1/lib/base/md5 -I /home/opam/.opam/5.5~beta1/lib/base/shadow_stdlib -I /home/opam/.opam/5.5~beta1/lib/base_bigstring -I /home/opam/.opam/5.5~beta1/lib/base_quickcheck -I /home/opam/.opam/5.5~beta1/lib/base_quickcheck/ppx_quickcheck/runtime -I /home/opam/.opam/5.5~beta1/lib/bin_prot -I /home/opam/.opam/5.5~beta1/lib/bin_prot/shape -I /home/opam/.opam/5.5~beta1/lib/fieldslib -I /home/opam/.opam/5.5~beta1/lib/gel -I /home/opam/.opam/5.5~beta1/lib/int_repr -I /home/opam/.opam/5.5~beta1/lib/jane-street-headers -I /home/opam/.opam/5.5~beta1/lib/ocaml_intrinsics_kernel -I /home/opam/.opam/5.5~beta1/lib/parsexp -I /home/opam/.opam/5.5~beta1/lib/ppx_assert/runtime-lib -I /home/opam/.opam/5.5~beta1/lib/ppx_bench/runtime-lib -I /home/opam/.opam/5.5~beta1/lib/ppx_compare/runtime-lib -I /home/opam/.opam/5.5~beta1/lib/ppx_diff/diffable -I /home/opam/.opam/5.5~beta1/lib/ppx_diff/diffable_cinaps -I /home/opam/.opam/5.5~beta1/lib/ppx_enumerate/runtime-lib -I /home/opam/.opam/5.5~beta1/lib/ppx_expect/config -I /home/opam/.opam/5.5~beta1/lib/ppx_expect/config_types -I /home/opam/.opam/5.5~beta1/lib/ppx_expect/make_corrected_file -I /home/opam/.opam/5.5~beta1/lib/ppx_expect/runtime -I /home/opam/.opam/5.5~beta1/lib/ppx_hash/runtime-lib -I /home/opam/.opam/5.5~beta1/lib/ppx_here/runtime-lib -I /home/opam/.opam/5.5~beta1/lib/ppx_inline_test/config -I /home/opam/.opam/5.5~beta1/lib/ppx_inline_test/runtime-lib -I /home/opam/.opam/5.5~beta1/lib/ppx_log/syntax -I /home/opam/.opam/5.5~beta1/lib/ppx_log/types -I /home/opam/.opam/5.5~beta1/lib/ppx_module_timer/runtime -I /home/opam/.opam/5.5~beta1/lib/ppx_sexp_conv/runtime-lib -I /home/opam/.opam/5.5~beta1/lib/ppx_stable_witness/runtime -I /home/opam/.opam/5.5~beta1/lib/ppx_stable_witness/stable_witness -I /home/opam/.opam/5.5~beta1/lib/ppx_string/runtime -I /home/opam/.opam/5.5~beta1/lib/ppxlib/print_diff -I /home/opam/.opam/5.5~beta1/lib/sexplib -I /home/opam/.opam/5.5~beta1/lib/sexplib0 -I /home/opam/.opam/5.5~beta1/lib/splittable_random -I /home/opam/.opam/5.5~beta1/lib/stdio -I /home/opam/.opam/5.5~beta1/lib/time_now -I /home/opam/.opam/5.5~beta1/lib/typerep -I /home/opam/.opam/5.5~beta1/lib/variantslib -I base_for_tests/src/.base_for_tests.objs/byte -I base_for_tests/src/.base_for_tests.objs/native -I command/src/.command.objs/byte -I command/src/.command.objs/native -I filename_base/src/.filename_base.objs/byte -I filename_base/src/.filename_base.objs/native -I heap_block/.heap_block.objs/byte -I heap_block/.heap_block.objs/native -I univ_map/src/.univ_map.objs/byte -I univ_map/src/.univ_map.objs/native -I validate/src/.validate.objs/byte -I validate/src/.validate.objs/native -intf-suffix .ml -no-alias-deps -open Core__ -o core/src/.core.objs/native/core__Perms.cmx -c -impl core/src/perms.pp.ml)
# File "core/src/perms.ml", lines 162-163, characters 4-78:
# 162 | ....type 'a perms = 'a V1.Upper_bound.t
# 163 |     [@@deriving bin_io, compare, equal, globalize, hash, sexp, stable_witness]
# Warning 20 [ignored-extra-argument]: this argument will not be used by the function.
# (cd _build/default && /home/opam/.opam/5.5~beta1/bin/ocamlc.opt -w -40 -g -bin-annot -bin-annot-occurrences -I core/src/.core.objs/byte -I /home/opam/.opam/5.5~beta1/lib/base -I /home/opam/.opam/5.5~beta1/lib/base/base_internalhash_types -I /home/opam/.opam/5.5~beta1/lib/base/md5 -I /home/opam/.opam/5.5~beta1/lib/base/shadow_stdlib -I /home/opam/.opam/5.5~beta1/lib/base_bigstring -I /home/opam/.opam/5.5~beta1/lib/base_quickcheck -I /home/opam/.opam/5.5~beta1/lib/base_quickcheck/ppx_quickcheck/runtime -I /home/opam/.opam/5.5~beta1/lib/bin_prot -I /home/opam/.opam/5.5~beta1/lib/bin_prot/shape -I /home/opam/.opam/5.5~beta1/lib/fieldslib -I /home/opam/.opam/5.5~beta1/lib/gel -I /home/opam/.opam/5.5~beta1/lib/int_repr -I /home/opam/.opam/5.5~beta1/lib/jane-street-headers -I /home/opam/.opam/5.5~beta1/lib/ocaml_intrinsics_kernel -I /home/opam/.opam/5.5~beta1/lib/parsexp -I /home/opam/.opam/5.5~beta1/lib/ppx_assert/runtime-lib -I /home/opam/.opam/5.5~beta1/lib/ppx_bench/runtime-lib -I /home/opam/.opam/5.5~beta1/lib/ppx_compare/runtime-lib -I /home/opam/.opam/5.5~beta1/lib/ppx_diff/diffable -I /home/opam/.opam/5.5~beta1/lib/ppx_diff/diffable_cinaps -I /home/opam/.opam/5.5~beta1/lib/ppx_enumerate/runtime-lib -I /home/opam/.opam/5.5~beta1/lib/ppx_expect/config -I /home/opam/.opam/5.5~beta1/lib/ppx_expect/config_types -I /home/opam/.opam/5.5~beta1/lib/ppx_expect/make_corrected_file -I /home/opam/.opam/5.5~beta1/lib/ppx_expect/runtime -I /home/opam/.opam/5.5~beta1/lib/ppx_hash/runtime-lib -I /home/opam/.opam/5.5~beta1/lib/ppx_here/runtime-lib -I /home/opam/.opam/5.5~beta1/lib/ppx_inline_test/config -I /home/opam/.opam/5.5~beta1/lib/ppx_inline_test/runtime-lib -I /home/opam/.opam/5.5~beta1/lib/ppx_log/syntax -I /home/opam/.opam/5.5~beta1/lib/ppx_log/types -I /home/opam/.opam/5.5~beta1/lib/ppx_module_timer/runtime -I /home/opam/.opam/5.5~beta1/lib/ppx_sexp_conv/runtime-lib -I /home/opam/.opam/5.5~beta1/lib/ppx_stable_witness/runtime -I /home/opam/.opam/5.5~beta1/lib/ppx_stable_witness/stable_witness -I /home/opam/.opam/5.5~beta1/lib/ppx_string/runtime -I /home/opam/.opam/5.5~beta1/lib/ppxlib/print_diff -I /home/opam/.opam/5.5~beta1/lib/sexplib -I /home/opam/.opam/5.5~beta1/lib/sexplib0 -I /home/opam/.opam/5.5~beta1/lib/splittable_random -I /home/opam/.opam/5.5~beta1/lib/stdio -I /home/opam/.opam/5.5~beta1/lib/time_now -I /home/opam/.opam/5.5~beta1/lib/typerep -I /home/opam/.opam/5.5~beta1/lib/variantslib -I base_for_tests/src/.base_for_tests.objs/byte -I command/src/.command.objs/byte -I filename_base/src/.filename_base.objs/byte -I heap_block/.heap_block.objs/byte -I univ_map/src/.univ_map.objs/byte -I validate/src/.validate.objs/byte -intf-suffix .ml -no-alias-deps -open Core__ -o core/src/.core.objs/byte/core__Gc.cmo -c -impl core/src/gc.pp.ml)
# File "core/src/gc.ml", lines 87-106, characters 6-69:
#  87 | ......type t = Stdlib.Gc.stat =
#  88 |         { minor_words : float
#  89 |         ; promoted_words : float
#  90 |         ; major_words : float
#  91 |         ; minor_collections : int
# ...
# 103 |         ; stack_size : int
# 104 |         ; forced_major_collections : int
# 105 |         }
# 106 |       [@@deriving bin_io, compare, equal, hash, sexp, stable_witness]
# Error: This variant or record definition does not match that of type Gc.stat
#        An extra field, live_stacks_words, is provided in the original definition.
# (cd _build/default && /home/opam/.opam/5.5~beta1/bin/ocamlopt.opt -w -40 -g -I core/src/.core.objs/byte -I core/src/.core.objs/native -I /home/opam/.opam/5.5~beta1/lib/base -I /home/opam/.opam/5.5~beta1/lib/base/base_internalhash_types -I /home/opam/.opam/5.5~beta1/lib/base/md5 -I /home/opam/.opam/5.5~beta1/lib/base/shadow_stdlib -I /home/opam/.opam/5.5~beta1/lib/base_bigstring -I /home/opam/.opam/5.5~beta1/lib/base_quickcheck -I /home/opam/.opam/5.5~beta1/lib/base_quickcheck/ppx_quickcheck/runtime -I /home/opam/.opam/5.5~beta1/lib/bin_prot -I /home/opam/.opam/5.5~beta1/lib/bin_prot/shape -I /home/opam/.opam/5.5~beta1/lib/fieldslib -I /home/opam/.opam/5.5~beta1/lib/gel -I /home/opam/.opam/5.5~beta1/lib/int_repr -I /home/opam/.opam/5.5~beta1/lib/jane-street-headers -I /home/opam/.opam/5.5~beta1/lib/ocaml_intrinsics_kernel -I /home/opam/.opam/5.5~beta1/lib/parsexp -I /home/opam/.opam/5.5~beta1/lib/ppx_assert/runtime-lib -I /home/opam/.opam/5.5~beta1/lib/ppx_bench/runtime-lib -I /home/opam/.opam/5.5~beta1/lib/ppx_compare/runtime-lib -I /home/opam/.opam/5.5~beta1/lib/ppx_diff/diffable -I /home/opam/.opam/5.5~beta1/lib/ppx_diff/diffable_cinaps -I /home/opam/.opam/5.5~beta1/lib/ppx_enumerate/runtime-lib -I /home/opam/.opam/5.5~beta1/lib/ppx_expect/config -I /home/opam/.opam/5.5~beta1/lib/ppx_expect/config_types -I /home/opam/.opam/5.5~beta1/lib/ppx_expect/make_corrected_file -I /home/opam/.opam/5.5~beta1/lib/ppx_expect/runtime -I /home/opam/.opam/5.5~beta1/lib/ppx_hash/runtime-lib -I /home/opam/.opam/5.5~beta1/lib/ppx_here/runtime-lib -I /home/opam/.opam/5.5~beta1/lib/ppx_inline_test/config -I /home/opam/.opam/5.5~beta1/lib/ppx_inline_test/runtime-lib -I /home/opam/.opam/5.5~beta1/lib/ppx_log/syntax -I /home/opam/.opam/5.5~beta1/lib/ppx_log/types -I /home/opam/.opam/5.5~beta1/lib/ppx_module_timer/runtime -I /home/opam/.opam/5.5~beta1/lib/ppx_sexp_conv/runtime-lib -I /home/opam/.opam/5.5~beta1/lib/ppx_stable_witness/runtime -I /home/opam/.opam/5.5~beta1/lib/ppx_stable_witness/stable_witness -I /home/opam/.opam/5.5~beta1/lib/ppx_string/runtime -I /home/opam/.opam/5.5~beta1/lib/ppxlib/print_diff -I /home/opam/.opam/5.5~beta1/lib/sexplib -I /home/opam/.opam/5.5~beta1/lib/sexplib0 -I /home/opam/.opam/5.5~beta1/lib/splittable_random -I /home/opam/.opam/5.5~beta1/lib/stdio -I /home/opam/.opam/5.5~beta1/lib/time_now -I /home/opam/.opam/5.5~beta1/lib/typerep -I /home/opam/.opam/5.5~beta1/lib/variantslib -I base_for_tests/src/.base_for_tests.objs/byte -I base_for_tests/src/.base_for_tests.objs/native -I command/src/.command.objs/byte -I command/src/.command.objs/native -I filename_base/src/.filename_base.objs/byte -I filename_base/src/.filename_base.objs/native -I heap_block/.heap_block.objs/byte -I heap_block/.heap_block.objs/native -I univ_map/src/.univ_map.objs/byte -I univ_map/src/.univ_map.objs/native -I validate/src/.validate.objs/byte -I validate/src/.validate.objs/native -intf-suffix .ml -no-alias-deps -open Core__ -o core/src/.core.objs/native/core__Gc.cmx -c -impl core/src/gc.pp.ml)
# File "core/src/gc.ml", lines 87-106, characters 6-69:
#  87 | ......type t = Stdlib.Gc.stat =
#  88 |         { minor_words : float
#  89 |         ; promoted_words : float
#  90 |         ; major_words : float
#  91 |         ; minor_collections : int
# ...
# 103 |         ; stack_size : int
# 104 |         ; forced_major_collections : int
# 105 |         }
# 106 |       [@@deriving bin_io, compare, equal, hash, sexp, stable_witness]
# Error: This variant or record definition does not match that of type Gc.stat
#        An extra field, live_stacks_words, is provided in the original definition.
```
