### PR TITLE
[new release] dune (18 packages) (3.23.0~alpha0)

### DIFF
--- a/packages/chrome-trace/chrome-trace.3.23.0~alpha0/opam
+++ b/packages/chrome-trace/chrome-trace.3.23.0~alpha0/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+synopsis: "Chrome trace event generation library"
+description:
+  "This library offers no backwards compatibility guarantees. Use at your own risk."
+maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+license: "MIT"
+homepage: "https://github.com/ocaml/dune"
+doc: "https://dune.readthedocs.io/"
+bug-reports: "https://github.com/ocaml/dune/issues"
+depends: [
+  "dune" {>= "3.23"}
+  "ocaml" {>= "4.14"}
+  "odoc" {with-doc}
+]
+dev-repo: "git+https://github.com/ocaml/dune.git"
+x-maintenance-intent: ["(latest)"]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src:
+    "https://github.com/ocaml/dune/releases/download/3.23.0_alpha0/dune-3.23.0.alpha0.tbz"
+  checksum: [
+    "sha256=b4fa3ab20da9f76a9115cd233c667ed45ce006b03922b17d8aee4b0604686900"
+    "sha512=24dc6c40bccc76304171283cf70cb8c618c74ff85bea3db362ab85206a423db02bdd1e0f895b2c494072c847e71ba40c1631c3fdc3106346dbcc108846e6f01a"
+  ]
+}
+x-commit-hash: "81b53bb22ce218fc1d5a5b32586e903a165cf11d"

--- a/packages/dune-action-plugin/dune-action-plugin.3.23.0~alpha0/opam
+++ b/packages/dune-action-plugin/dune-action-plugin.3.23.0~alpha0/opam
@@ -1,0 +1,52 @@
+opam-version: "2.0"
+synopsis: "[experimental] API for writing dynamic Dune actions"
+description: """
+
+This library is experimental. No backwards compatibility is implied.
+
+dune-action-plugin provides an API for writing dynamic Dune actions.
+Dynamic dune actions do not need to declare their dependencies
+upfront; they are instead discovered automatically during the
+execution of the action.
+"""
+maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+license: "MIT"
+homepage: "https://github.com/ocaml/dune"
+doc: "https://dune.readthedocs.io/"
+bug-reports: "https://github.com/ocaml/dune/issues"
+depends: [
+  "dune" {>= "3.23"}
+  "dune-glob" {= version}
+  "csexp" {>= "1.5.0"}
+  "ppx_expect" {with-test}
+  "stdune" {= version}
+  "dune-private-libs" {= version}
+  "dune-rpc" {= version}
+  "base-unix"
+  "odoc" {with-doc}
+]
+dev-repo: "git+https://github.com/ocaml/dune.git"
+x-maintenance-intent: ["(latest)"]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src:
+    "https://github.com/ocaml/dune/releases/download/3.23.0_alpha0/dune-3.23.0.alpha0.tbz"
+  checksum: [
+    "sha256=b4fa3ab20da9f76a9115cd233c667ed45ce006b03922b17d8aee4b0604686900"
+    "sha512=24dc6c40bccc76304171283cf70cb8c618c74ff85bea3db362ab85206a423db02bdd1e0f895b2c494072c847e71ba40c1631c3fdc3106346dbcc108846e6f01a"
+  ]
+}
+x-commit-hash: "81b53bb22ce218fc1d5a5b32586e903a165cf11d"

--- a/packages/dune-action-trace/dune-action-trace.3.23.0~alpha0/opam
+++ b/packages/dune-action-trace/dune-action-trace.3.23.0~alpha0/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+synopsis: "Dune Action Traces"
+description: "Produce trace events from dune actions"
+maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+license: "MIT"
+homepage: "https://github.com/ocaml/dune"
+doc: "https://dune.readthedocs.io/"
+bug-reports: "https://github.com/ocaml/dune/issues"
+depends: [
+  "dune" {>= "3.23"}
+  "csexp" {>= "1.5.0"}
+  "ocaml" {>= "4.14"}
+  "odoc" {with-doc}
+]
+dev-repo: "git+https://github.com/ocaml/dune.git"
+x-maintenance-intent: ["none"]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src:
+    "https://github.com/ocaml/dune/releases/download/3.23.0_alpha0/dune-3.23.0.alpha0.tbz"
+  checksum: [
+    "sha256=b4fa3ab20da9f76a9115cd233c667ed45ce006b03922b17d8aee4b0604686900"
+    "sha512=24dc6c40bccc76304171283cf70cb8c618c74ff85bea3db362ab85206a423db02bdd1e0f895b2c494072c847e71ba40c1631c3fdc3106346dbcc108846e6f01a"
+  ]
+}
+x-commit-hash: "81b53bb22ce218fc1d5a5b32586e903a165cf11d"

--- a/packages/dune-build-info/dune-build-info.3.23.0~alpha0/opam
+++ b/packages/dune-build-info/dune-build-info.3.23.0~alpha0/opam
@@ -1,0 +1,45 @@
+opam-version: "2.0"
+synopsis: "Embed build information inside executable"
+description: """
+The build-info library allows to access information about how the
+executable was built, such as the version of the project at which it
+was built or the list of statically linked libraries with their
+versions.  It supports reporting the version from the version control
+system during development to get an precise reference of when the
+executable was built.
+"""
+maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+license: "MIT"
+homepage: "https://github.com/ocaml/dune"
+doc: "https://dune.readthedocs.io/"
+bug-reports: "https://github.com/ocaml/dune/issues"
+depends: [
+  "dune" {>= "3.23"}
+  "ocaml" {>= "4.08"}
+  "odoc" {with-doc}
+]
+dev-repo: "git+https://github.com/ocaml/dune.git"
+x-maintenance-intent: ["(latest)"]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src:
+    "https://github.com/ocaml/dune/releases/download/3.23.0_alpha0/dune-3.23.0.alpha0.tbz"
+  checksum: [
+    "sha256=b4fa3ab20da9f76a9115cd233c667ed45ce006b03922b17d8aee4b0604686900"
+    "sha512=24dc6c40bccc76304171283cf70cb8c618c74ff85bea3db362ab85206a423db02bdd1e0f895b2c494072c847e71ba40c1631c3fdc3106346dbcc108846e6f01a"
+  ]
+}
+x-commit-hash: "81b53bb22ce218fc1d5a5b32586e903a165cf11d"

--- a/packages/dune-configurator/dune-configurator.3.23.0~alpha0/opam
+++ b/packages/dune-configurator/dune-configurator.3.23.0~alpha0/opam
@@ -1,0 +1,49 @@
+opam-version: "2.0"
+synopsis: "Helper library for gathering system configuration"
+description: """
+dune-configurator is a small library that helps writing OCaml scripts that
+test features available on the system, in order to generate config.h
+files for instance.
+Among other things, dune-configurator allows one to:
+- test if a C program compiles
+- query pkg-config
+- import #define from OCaml header files
+- generate config.h file
+"""
+maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+license: "MIT"
+homepage: "https://github.com/ocaml/dune"
+doc: "https://dune.readthedocs.io/"
+bug-reports: "https://github.com/ocaml/dune/issues"
+depends: [
+  "dune" {>= "3.23"}
+  "ocaml" {>= "4.08.0"}
+  "base-unix"
+  "csexp" {>= "1.5.0"}
+  "odoc" {with-doc}
+]
+dev-repo: "git+https://github.com/ocaml/dune.git"
+x-maintenance-intent: ["(latest)"]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src:
+    "https://github.com/ocaml/dune/releases/download/3.23.0_alpha0/dune-3.23.0.alpha0.tbz"
+  checksum: [
+    "sha256=b4fa3ab20da9f76a9115cd233c667ed45ce006b03922b17d8aee4b0604686900"
+    "sha512=24dc6c40bccc76304171283cf70cb8c618c74ff85bea3db362ab85206a423db02bdd1e0f895b2c494072c847e71ba40c1631c3fdc3106346dbcc108846e6f01a"
+  ]
+}
+x-commit-hash: "81b53bb22ce218fc1d5a5b32586e903a165cf11d"

--- a/packages/dune-glob/dune-glob.3.23.0~alpha0/opam
+++ b/packages/dune-glob/dune-glob.3.23.0~alpha0/opam
@@ -1,0 +1,42 @@
+opam-version: "2.0"
+synopsis: "Glob string matching language supported by dune"
+description:
+  "dune-glob provides a parser and interpreter for globs as understood by dune language."
+maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+license: "MIT"
+homepage: "https://github.com/ocaml/dune"
+doc: "https://dune.readthedocs.io/"
+bug-reports: "https://github.com/ocaml/dune/issues"
+depends: [
+  "dune" {>= "3.23"}
+  "stdune" {= version}
+  "dyn"
+  "re"
+  "ordering"
+  "odoc" {with-doc}
+]
+dev-repo: "git+https://github.com/ocaml/dune.git"
+x-maintenance-intent: ["(latest)"]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src:
+    "https://github.com/ocaml/dune/releases/download/3.23.0_alpha0/dune-3.23.0.alpha0.tbz"
+  checksum: [
+    "sha256=b4fa3ab20da9f76a9115cd233c667ed45ce006b03922b17d8aee4b0604686900"
+    "sha512=24dc6c40bccc76304171283cf70cb8c618c74ff85bea3db362ab85206a423db02bdd1e0f895b2c494072c847e71ba40c1631c3fdc3106346dbcc108846e6f01a"
+  ]
+}
+x-commit-hash: "81b53bb22ce218fc1d5a5b32586e903a165cf11d"

--- a/packages/dune-private-libs/dune-private-libs.3.23.0~alpha0/opam
+++ b/packages/dune-private-libs/dune-private-libs.3.23.0~alpha0/opam
@@ -1,0 +1,50 @@
+opam-version: "2.0"
+synopsis: "Private libraries of Dune"
+description: """
+!!!!!!!!!!!!!!!!!!!!!!
+!!!!! DO NOT USE !!!!!
+!!!!!!!!!!!!!!!!!!!!!!
+
+This package contains code that is shared between various dune-xxx
+packages. However, it is not meant for public consumption and provides
+no stability guarantee.
+"""
+maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+license: "MIT"
+homepage: "https://github.com/ocaml/dune"
+doc: "https://dune.readthedocs.io/"
+bug-reports: "https://github.com/ocaml/dune/issues"
+depends: [
+  "dune" {>= "3.23"}
+  "csexp" {>= "1.5.0"}
+  "pp" {>= "1.1.0"}
+  "dyn" {= version}
+  "stdune" {= version}
+  "ocaml" {>= "4.14"}
+  "odoc" {with-doc}
+]
+dev-repo: "git+https://github.com/ocaml/dune.git"
+x-maintenance-intent: ["none"]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src:
+    "https://github.com/ocaml/dune/releases/download/3.23.0_alpha0/dune-3.23.0.alpha0.tbz"
+  checksum: [
+    "sha256=b4fa3ab20da9f76a9115cd233c667ed45ce006b03922b17d8aee4b0604686900"
+    "sha512=24dc6c40bccc76304171283cf70cb8c618c74ff85bea3db362ab85206a423db02bdd1e0f895b2c494072c847e71ba40c1631c3fdc3106346dbcc108846e6f01a"
+  ]
+}
+x-commit-hash: "81b53bb22ce218fc1d5a5b32586e903a165cf11d"

--- a/packages/dune-rpc-lwt/dune-rpc-lwt.3.23.0~alpha0/opam
+++ b/packages/dune-rpc-lwt/dune-rpc-lwt.3.23.0~alpha0/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+synopsis: "Communicate with dune using rpc and Lwt"
+description: "Specialization of dune-rpc to Lwt"
+maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+license: "MIT"
+homepage: "https://github.com/ocaml/dune"
+doc: "https://dune.readthedocs.io/"
+bug-reports: "https://github.com/ocaml/dune/issues"
+depends: [
+  "dune" {>= "3.23"}
+  "dune-rpc" {= version}
+  "csexp" {>= "1.5.0"}
+  "lwt" {>= "5.6.0"}
+  "base-unix"
+  "odoc" {with-doc}
+]
+dev-repo: "git+https://github.com/ocaml/dune.git"
+x-maintenance-intent: ["(latest)"]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src:
+    "https://github.com/ocaml/dune/releases/download/3.23.0_alpha0/dune-3.23.0.alpha0.tbz"
+  checksum: [
+    "sha256=b4fa3ab20da9f76a9115cd233c667ed45ce006b03922b17d8aee4b0604686900"
+    "sha512=24dc6c40bccc76304171283cf70cb8c618c74ff85bea3db362ab85206a423db02bdd1e0f895b2c494072c847e71ba40c1631c3fdc3106346dbcc108846e6f01a"
+  ]
+}
+x-commit-hash: "81b53bb22ce218fc1d5a5b32586e903a165cf11d"

--- a/packages/dune-rpc/dune-rpc.3.23.0~alpha0/opam
+++ b/packages/dune-rpc/dune-rpc.3.23.0~alpha0/opam
@@ -1,0 +1,44 @@
+opam-version: "2.0"
+synopsis: "Communicate with dune using rpc"
+description: "Library to connect and control a running dune instance"
+maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+license: "MIT"
+homepage: "https://github.com/ocaml/dune"
+doc: "https://dune.readthedocs.io/"
+bug-reports: "https://github.com/ocaml/dune/issues"
+depends: [
+  "dune" {>= "3.23"}
+  "ocamlc-loc"
+  "csexp"
+  "ordering"
+  "dyn"
+  "xdg"
+  "stdune" {= version}
+  "pp" {>= "1.1.0"}
+  "odoc" {with-doc}
+]
+dev-repo: "git+https://github.com/ocaml/dune.git"
+x-maintenance-intent: ["(latest)"]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src:
+    "https://github.com/ocaml/dune/releases/download/3.23.0_alpha0/dune-3.23.0.alpha0.tbz"
+  checksum: [
+    "sha256=b4fa3ab20da9f76a9115cd233c667ed45ce006b03922b17d8aee4b0604686900"
+    "sha512=24dc6c40bccc76304171283cf70cb8c618c74ff85bea3db362ab85206a423db02bdd1e0f895b2c494072c847e71ba40c1631c3fdc3106346dbcc108846e6f01a"
+  ]
+}
+x-commit-hash: "81b53bb22ce218fc1d5a5b32586e903a165cf11d"

--- a/packages/dune-site/dune-site.3.23.0~alpha0/opam
+++ b/packages/dune-site/dune-site.3.23.0~alpha0/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+synopsis: "Embed locations information inside executable and libraries"
+maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+license: "MIT"
+homepage: "https://github.com/ocaml/dune"
+doc: "https://dune.readthedocs.io/"
+bug-reports: "https://github.com/ocaml/dune/issues"
+depends: [
+  "dune" {>= "3.23"}
+  "dune-private-libs" {= version}
+  "odoc" {with-doc}
+]
+dev-repo: "git+https://github.com/ocaml/dune.git"
+x-maintenance-intent: ["(latest)"]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src:
+    "https://github.com/ocaml/dune/releases/download/3.23.0_alpha0/dune-3.23.0.alpha0.tbz"
+  checksum: [
+    "sha256=b4fa3ab20da9f76a9115cd233c667ed45ce006b03922b17d8aee4b0604686900"
+    "sha512=24dc6c40bccc76304171283cf70cb8c618c74ff85bea3db362ab85206a423db02bdd1e0f895b2c494072c847e71ba40c1631c3fdc3106346dbcc108846e6f01a"
+  ]
+}
+x-commit-hash: "81b53bb22ce218fc1d5a5b32586e903a165cf11d"

--- a/packages/dune/dune.3.23.0~alpha0/opam
+++ b/packages/dune/dune.3.23.0~alpha0/opam
@@ -1,0 +1,80 @@
+opam-version: "2.0"
+synopsis: "Fast, portable, and opinionated build system"
+description: """
+
+Dune is a build system that was designed to simplify the release of
+Jane Street packages. It reads metadata from "dune" files following a
+very simple s-expression syntax.
+
+Dune is fast, has very low-overhead, and supports parallel builds on
+all platforms. It has no system dependencies; all you need to build
+dune or packages using dune is OCaml. You don't need make or bash
+as long as the packages themselves don't use bash explicitly.
+
+Dune is composable; supporting multi-package development by simply
+dropping multiple repositories into the same directory.
+
+Dune also supports multi-context builds, such as building against
+several opam roots/switches simultaneously. This helps maintaining
+packages across several versions of OCaml and gives cross-compilation
+for free.
+"""
+maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+license: "MIT"
+homepage: "https://github.com/ocaml/dune"
+doc: "https://dune.readthedocs.io/"
+bug-reports: "https://github.com/ocaml/dune/issues"
+conflicts: [
+  "merlin" {< "3.4.0"}
+  "ocaml-lsp-server" {< "1.3.0"}
+  "dune-configurator" {< "2.3.0"}
+  "odoc" {< "2.0.1"}
+  "dune-release" {< "2.0.0"}
+  "js_of_ocaml-compiler" {< "3.6.0"}
+  "jbuilder" {= "transition"}
+]
+dev-repo: "git+https://github.com/ocaml/dune.git"
+x-maintenance-intent: ["(latest)"]
+build: [
+  ["ocaml" "boot/bootstrap.ml" "-j" jobs]
+  ["./_boot/dune.exe" "build" "dune.install" "--release" "--profile" "dune-bootstrap" "-j" jobs]
+]
+depends: [
+  # Please keep the lower bound in sync with .github/workflows/workflow.yml,
+  # dune-project and min_ocaml_version in bootstrap.ml
+  "ocaml" {>= "4.14"}
+  "base-unix"
+  "base-threads"
+  "lwt" { with-dev-setup & os != "win32" }
+  "cinaps" { with-dev-setup }
+  "csexp" { with-dev-setup & >= "1.3.0" }
+  "js_of_ocaml" { with-dev-setup & >= "6.1.0" & os != "win32" }
+  "js_of_ocaml-compiler" { with-dev-setup & >= "6.1.0" & os != "win32" }
+  "mdx" { with-dev-setup & >= "2.3.0" & os != "win32" }
+  "menhir" { with-dev-setup & os != "win32" }
+  "ocamlfind" { with-dev-setup & os != "win32" }
+  "odoc" { with-dev-setup & >= "2.4.0" & os != "win32" }
+  "ppx_expect" { with-dev-setup & >= "v0.17" & os != "win32" }
+  "spawn" { with-dev-setup }
+  "ppx_inline_test" { with-dev-setup & os != "win32" }
+  "ppxlib" { with-dev-setup & >= "0.37.0" & os != "win32" }
+  "ctypes" { with-dev-setup & os != "win32" }
+  "utop" { with-dev-setup & >= "2.6.0" & os != "win32" }
+  "melange" { with-dev-setup & >= "5.1.0-51" & os != "win32" }
+  "uutf" { with-dev-setup }
+]
+depexts: [
+  # the rev store negotiation test launches a git daemon, needs it to be
+  # installed, which is not the case on Fedora by default
+  ["git-daemon"] { with-test & os-family = "fedora" }
+]
+url {
+  src:
+    "https://github.com/ocaml/dune/releases/download/3.23.0_alpha0/dune-3.23.0.alpha0.tbz"
+  checksum: [
+    "sha256=b4fa3ab20da9f76a9115cd233c667ed45ce006b03922b17d8aee4b0604686900"
+    "sha512=24dc6c40bccc76304171283cf70cb8c618c74ff85bea3db362ab85206a423db02bdd1e0f895b2c494072c847e71ba40c1631c3fdc3106346dbcc108846e6f01a"
+  ]
+}
+x-commit-hash: "81b53bb22ce218fc1d5a5b32586e903a165cf11d"

--- a/packages/dyn/dyn.3.23.0~alpha0/opam
+++ b/packages/dyn/dyn.3.23.0~alpha0/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+synopsis: "Dynamic type"
+description: "Dynamic type"
+maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+license: "MIT"
+homepage: "https://github.com/ocaml/dune"
+doc: "https://dune.readthedocs.io/"
+bug-reports: "https://github.com/ocaml/dune/issues"
+depends: [
+  "dune" {>= "3.23"}
+  "ocaml" {>= "4.14"}
+  "ordering" {= version}
+  "pp" {>= "1.1.0"}
+  "odoc" {with-doc}
+]
+dev-repo: "git+https://github.com/ocaml/dune.git"
+x-maintenance-intent: ["none"]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src:
+    "https://github.com/ocaml/dune/releases/download/3.23.0_alpha0/dune-3.23.0.alpha0.tbz"
+  checksum: [
+    "sha256=b4fa3ab20da9f76a9115cd233c667ed45ce006b03922b17d8aee4b0604686900"
+    "sha512=24dc6c40bccc76304171283cf70cb8c618c74ff85bea3db362ab85206a423db02bdd1e0f895b2c494072c847e71ba40c1631c3fdc3106346dbcc108846e6f01a"
+  ]
+}
+x-commit-hash: "81b53bb22ce218fc1d5a5b32586e903a165cf11d"

--- a/packages/fs-io/fs-io.3.23.0~alpha0/opam
+++ b/packages/fs-io/fs-io.3.23.0~alpha0/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+synopsis: "File System Operations"
+description: "Misc. Collection of File System Operations"
+maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+license: "MIT"
+homepage: "https://github.com/ocaml/dune"
+doc: "https://dune.readthedocs.io/"
+bug-reports: "https://github.com/ocaml/dune/issues"
+depends: [
+  "dune" {>= "3.23"}
+  "base-unix"
+  "ocaml" {>= "4.14"}
+  "odoc" {with-doc}
+]
+dev-repo: "git+https://github.com/ocaml/dune.git"
+x-maintenance-intent: ["none"]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src:
+    "https://github.com/ocaml/dune/releases/download/3.23.0_alpha0/dune-3.23.0.alpha0.tbz"
+  checksum: [
+    "sha256=b4fa3ab20da9f76a9115cd233c667ed45ce006b03922b17d8aee4b0604686900"
+    "sha512=24dc6c40bccc76304171283cf70cb8c618c74ff85bea3db362ab85206a423db02bdd1e0f895b2c494072c847e71ba40c1631c3fdc3106346dbcc108846e6f01a"
+  ]
+}
+x-commit-hash: "81b53bb22ce218fc1d5a5b32586e903a165cf11d"

--- a/packages/ocamlc-loc/ocamlc-loc.3.23.0~alpha0/opam
+++ b/packages/ocamlc-loc/ocamlc-loc.3.23.0~alpha0/opam
@@ -1,0 +1,43 @@
+opam-version: "2.0"
+synopsis: "Parse ocaml compiler output into structured form"
+description:
+  "This library offers no backwards compatibility guarantees. Use at your own risk."
+maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+license: "MIT"
+homepage: "https://github.com/ocaml/dune"
+doc: "https://dune.readthedocs.io/"
+bug-reports: "https://github.com/ocaml/dune/issues"
+depends: [
+  "dune" {>= "3.23"}
+  "ocaml" {>= "4.14"}
+  "dyn" {= version}
+  "odoc" {with-doc}
+]
+conflicts: [
+  "ocaml-lsp-server" {< "1.17.0"}
+]
+dev-repo: "git+https://github.com/ocaml/dune.git"
+x-maintenance-intent: ["none"]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src:
+    "https://github.com/ocaml/dune/releases/download/3.23.0_alpha0/dune-3.23.0.alpha0.tbz"
+  checksum: [
+    "sha256=b4fa3ab20da9f76a9115cd233c667ed45ce006b03922b17d8aee4b0604686900"
+    "sha512=24dc6c40bccc76304171283cf70cb8c618c74ff85bea3db362ab85206a423db02bdd1e0f895b2c494072c847e71ba40c1631c3fdc3106346dbcc108846e6f01a"
+  ]
+}
+x-commit-hash: "81b53bb22ce218fc1d5a5b32586e903a165cf11d"

--- a/packages/ordering/ordering.3.23.0~alpha0/opam
+++ b/packages/ordering/ordering.3.23.0~alpha0/opam
@@ -1,0 +1,38 @@
+opam-version: "2.0"
+synopsis: "Element ordering"
+description: "Element ordering"
+maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+license: "MIT"
+homepage: "https://github.com/ocaml/dune"
+doc: "https://dune.readthedocs.io/"
+bug-reports: "https://github.com/ocaml/dune/issues"
+depends: [
+  "dune" {>= "3.23"}
+  "ocaml" {>= "4.14"}
+  "odoc" {with-doc}
+]
+dev-repo: "git+https://github.com/ocaml/dune.git"
+x-maintenance-intent: ["none"]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src:
+    "https://github.com/ocaml/dune/releases/download/3.23.0_alpha0/dune-3.23.0.alpha0.tbz"
+  checksum: [
+    "sha256=b4fa3ab20da9f76a9115cd233c667ed45ce006b03922b17d8aee4b0604686900"
+    "sha512=24dc6c40bccc76304171283cf70cb8c618c74ff85bea3db362ab85206a423db02bdd1e0f895b2c494072c847e71ba40c1631c3fdc3106346dbcc108846e6f01a"
+  ]
+}
+x-commit-hash: "81b53bb22ce218fc1d5a5b32586e903a165cf11d"

--- a/packages/stdune/stdune.3.23.0~alpha0/opam
+++ b/packages/stdune/stdune.3.23.0~alpha0/opam
@@ -1,0 +1,46 @@
+opam-version: "2.0"
+synopsis: "Dune's unstable standard library"
+description:
+  "This library offers no backwards compatibility guarantees. Use at your own risk."
+maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+license: "MIT"
+homepage: "https://github.com/ocaml/dune"
+doc: "https://dune.readthedocs.io/"
+bug-reports: "https://github.com/ocaml/dune/issues"
+depends: [
+  "dune" {>= "3.23"}
+  "ocaml" {>= "4.14"}
+  "base-unix"
+  "csexp" {>= "1.5.0"}
+  "dyn" {= version}
+  "fs-io" {= version}
+  "ordering" {= version}
+  "pp" {>= "2.0.0"}
+  "top-closure" {= version}
+  "odoc" {with-doc}
+]
+dev-repo: "git+https://github.com/ocaml/dune.git"
+x-maintenance-intent: ["none"]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src:
+    "https://github.com/ocaml/dune/releases/download/3.23.0_alpha0/dune-3.23.0.alpha0.tbz"
+  checksum: [
+    "sha256=b4fa3ab20da9f76a9115cd233c667ed45ce006b03922b17d8aee4b0604686900"
+    "sha512=24dc6c40bccc76304171283cf70cb8c618c74ff85bea3db362ab85206a423db02bdd1e0f895b2c494072c847e71ba40c1631c3fdc3106346dbcc108846e6f01a"
+  ]
+}
+x-commit-hash: "81b53bb22ce218fc1d5a5b32586e903a165cf11d"

--- a/packages/top-closure/top-closure.3.23.0~alpha0/opam
+++ b/packages/top-closure/top-closure.3.23.0~alpha0/opam
@@ -1,0 +1,38 @@
+opam-version: "2.0"
+synopsis: "Topological Closure"
+description: "Generic Topological Closure"
+maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+license: "MIT"
+homepage: "https://github.com/ocaml/dune"
+doc: "https://dune.readthedocs.io/"
+bug-reports: "https://github.com/ocaml/dune/issues"
+depends: [
+  "dune" {>= "3.23"}
+  "ocaml" {>= "4.14"}
+  "odoc" {with-doc}
+]
+dev-repo: "git+https://github.com/ocaml/dune.git"
+x-maintenance-intent: ["none"]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src:
+    "https://github.com/ocaml/dune/releases/download/3.23.0_alpha0/dune-3.23.0.alpha0.tbz"
+  checksum: [
+    "sha256=b4fa3ab20da9f76a9115cd233c667ed45ce006b03922b17d8aee4b0604686900"
+    "sha512=24dc6c40bccc76304171283cf70cb8c618c74ff85bea3db362ab85206a423db02bdd1e0f895b2c494072c847e71ba40c1631c3fdc3106346dbcc108846e6f01a"
+  ]
+}
+x-commit-hash: "81b53bb22ce218fc1d5a5b32586e903a165cf11d"

--- a/packages/xdg/xdg.3.23.0~alpha0/opam
+++ b/packages/xdg/xdg.3.23.0~alpha0/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+synopsis: "XDG Base Directory Specification"
+description:
+  "https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html"
+maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+license: "MIT"
+homepage: "https://github.com/ocaml/dune"
+doc: "https://dune.readthedocs.io/"
+bug-reports: "https://github.com/ocaml/dune/issues"
+depends: [
+  "dune" {>= "3.23"}
+  "ocaml" {>= "4.14"}
+  "odoc" {with-doc}
+]
+dev-repo: "git+https://github.com/ocaml/dune.git"
+x-maintenance-intent: ["(latest)"]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src:
+    "https://github.com/ocaml/dune/releases/download/3.23.0_alpha0/dune-3.23.0.alpha0.tbz"
+  checksum: [
+    "sha256=b4fa3ab20da9f76a9115cd233c667ed45ce006b03922b17d8aee4b0604686900"
+    "sha512=24dc6c40bccc76304171283cf70cb8c618c74ff85bea3db362ab85206a423db02bdd1e0f895b2c494072c847e71ba40c1631c3fdc3106346dbcc108846e6f01a"
+  ]
+}
+x-commit-hash: "81b53bb22ce218fc1d5a5b32586e903a165cf11d"


### PR DESCRIPTION
Fast, portable, and opinionated build system

- Project page: <a href="https://github.com/ocaml/dune">https://github.com/ocaml/dune</a>
- Documentation: <a href="https://dune.readthedocs.io/">https://dune.readthedocs.io/</a>

##### CHANGES:

### Fixed

- Auto-inject `"menhir" {>= "20180523"}` into generated opam files when the
  menhir extension is used. Dune's menhir rules rely on `--infer-write-query`
  and `--infer-read-reply`, which require at least this version; without the
  lower bound, builds fail with older menhir installations.
  (ocaml/dune#10707, @robinbb)

- Fix `--display=quiet` not suppressing "Entering directory" and "Leaving
  directory" messages when using `--root`. These messages are now deferred
  until there is actual output, so silent builds produce no noise.
  (ocaml/dune#12974, fixes ocaml/dune#12854, @Alizter)

- Fix an internal error when a module is shared between a `rocq.theory` and
  `rocq.extraction` stanza. The error now includes a hint pointing to the
  conflicting stanza. (ocaml/dune#13733, @Durbatuluk1701)

- Fix cookies defined on `ppx_rewriter` being lost when that rewriter was used
  as a dependency of another `ppx_rewriter`. (ocaml/dune#13737, fixes ocaml/dune#3426, @Alizter)

- Improve opam file generation for packages that set `(dir ..)`. Such packages
  will now have a test target that is limited to this directory. (ocaml/dune#13778, @rgrinberg)

- Stop duplicating dune diagnostics to subscribers over RPC (ocaml/dune#13816,
  @rgrinberg)

- Fix dependency cycle when using the `package` with a library
  conditionally enabled via `enabled_if`. (ocaml/dune#13833, @toots)

- Fix underspecification of dependencies in the sandbox for modules with
  interfaces. (ocaml/dune#13842, @anmonteiro)

- Honor sandbox settings specified inside `(:include ..)` expressions in the `deps` field
  (ocaml/dune#13898, @rgrinberg)

- Fix `dune pkg lock` failing when a `pin` stanza contains a `file://` URL with
  a relative path outside the workspace (ocaml/dune#13915, fixes ocaml/dune#10254, @shunueda)

- Use all stat attributes to detect patch back source tree changes (ocaml/dune#13986, @rgrinberg)

- Use device and inode number for invalidating cached digests (ocaml/dune#13991, @rgrinberg)

- Stop trying to set SO_REUSEADDR on unix sockets when setting up dune rpc
  (ocaml/dune#14056, @rgrinberg)

- Fix autolocking to correctly detect changes to `(depends)` in watch mode
  (ocaml/dune#14066, fixes ocaml/dune#13234, @Alizter)

- Fix incremental builds for libraries using `(wrapped (transition ...))`.
  The compat shim modules were never recompiled when the inner module's
  interface changed, causing "inconsistent assumptions" errors.
  (ocaml/dune#14090, fixes ocaml/dune#14089, @Alizter)

- Fix Rocq configuration detection to use `rocq c --config` subcommand
  instead of `rocq --config` (ocaml/dune#14093, fixes ocaml/dune#13774, @Durbatuluk1701)

- Bump dune rpc's request pending request limit 10 to 100 (ocaml/dune#14094, @rginberg)

- Invalidate stale cached digests in all build commands (ocaml/dune#14126, @rgrinberg)

- Fix `root_module` generating duplicate module definitions when a
  findlib sub-package shares a directory with its parent (e.g.,
  `logs.lwt` alongside `logs`). (ocaml/dune#14135, fixes ocaml/dune#6148, @robinbb)

- Fix `dune subst` prepending a duplicate `version:` field to opam
  files that already contain one, instead of replacing it in place.
  (ocaml/dune#14136, fixes ocaml/dune#878, @robinbb)

- Fix `@ocaml-index` alias being generated for all contexts, causing build
  errors in multi-context workspaces where some libraries are disabled in
  non-default contexts. The alias is now only generated for the merlin context.
  (ocaml/dune#14137, fixes ocaml/dune#12007, @robinbb)

- Remove the warning about the deprecation of the coq stanza for
  dune lang before 3.21 since it has been introduced in this
  version (ocaml/dune#14187, @bobot)

- `$ dune init` now generates projects with correct .opam files (ocaml/dune#14192, @rgrinberg)

- Send SIGTERM before SIGKILL when cancelling child processes in watch
  mode, giving cleanup handlers a chance to run before escalating.
  (ocaml/dune#14224, ocaml/dune#14170, fixes ocaml/dune#2445, @robinbb)

- Correctly specify dependencies for `generate_runner` in inline tests (ocaml/dune#14276, @rgrinberg)

- Fix duplicate dune version bounds in generated opam files. When users
  declare `(dune (>= X.Y))` matching or exceeding the `(lang dune X.Y)`
  version, the generated opam `depends` no longer contains redundant
  constraints like `{>= "2.7" & >= "2.7"}`. (ocaml/dune#3916, ocaml/dune#11106, @robinbb)

- Fix inline tests not being executed for byte-only libraries. When a library
  has `(modes byte)`, the inline test runner is now linked in byte mode so the
  library's test code is included. (ocaml/dune#9757, @robinbb)

### Added

- Add support for `c_library_flags` in foreign_stubs (ocaml/dune#13484, @madroach)

- Move the management of Jsoo config details out of dune (ocaml/dune#13613, @vouillon)

- Js_of_ocaml: share standalone runtimes (ocaml/dune#13621, @vouillon)

- Allow multiple `(dirs ..)` stanzas in the same Dune file. Starting with
  `(lang dune 3.23)`, Dune takes the union of the specified directories
  (ocaml/dune#13734, fixes ocaml/dune#6249, @anmonteiro)

- Sandboxed rules are now allowed to produce diff promotions when `(corrections
  produce)` is set on the rules. Whenever such an action produces `foo.corrected`, it will
  be automatically registered as a promotion for `foo` (ocaml/dune#13813, @rgrinberg)

- `$ dune clean` now accepts arguments to only remove certain targets from the
  _build directory (ocaml/dune#13875, @rgrinberg)

- `$ dune promote` now promotes all paths that are a prefix of the path provided.
  For example, `$ dune promote foo` will promote `foo`, `foo/bar`, `foo/bar/baz`
  (but not `foobar`). (ocaml/dune#13876, @rgrinberg)

- Allow for the `diff` action to diff entire directories (ocaml/dune#13880, fixes ocaml/dune#3567, @rgrinberg)

- A hint is now emitted when trying to build a target inside a directory that
  was excluded by a `(dirs ...)` stanza (ocaml/dune#13919, @mefyl).

- Add --debug-backtraces to `$ dune {promote,trace,cache}` (ocaml/dune#13933, @rgrinberg)

- Actions are now able to observe their project directory via
  `DUNE_PROJECT_ROOT` (ocaml/dune#13934, @rgrinberg)

- Support hardlink sandboxing on Windows. (ocaml/dune#13987, addresses part of ocaml/dune#4362, @Alizter)

- `rocq.extraction`: Add `extracted_files` field in `(rocq 0.13)`, replacing
  `extracted_modules`, supporting extraction to languages other than OCaml
  (ocaml/dune#13997, @Durbatuluk1701).

- Infer source directories as dependencies when they're as reference
  directories in `diff` actions.

- Add trace events for build start/stop/restarts (ocaml/dune#14163, ocaml/dune#14166, @rgrinberg)

- Generate `compile_commands.json` for C/C++ foreign stubs when building
  `@check` with `(lang dune 3.23)`. This enables `clangd`, `ccls`, and other
  tools that consume compilation databases. (ocaml/dune#14185, fixes ocaml/dune#3531, @Alizter)

- Add `%{pkg:<package>:<section>:<path>}` pform for resolving package install
  files. Works with workspace packages, lock-file packages, and installed
  packages. (ocaml/dune#14200, fixes ocaml/dune#14193, fixes ocaml/dune#3378, @Alizter)

- Add trace events for accepting clients and shutting down RPC (ocaml/dune#14232, @rgrinberg)

- Back up the default trace file as `trace.csexp.old` before each build,
  preserving the previous trace for comparison. This does not apply when
  `--trace-file` is used. (ocaml/dune#14269, @Alizter)

### Changed

- Dune digests target files and directories in background threads (ocaml/dune#13341,
  @rgrinbreg)

- `Dyn.pp` now prints valid OCaml literals for more constructors:
  - `Char` is quoted (e.g., `'a'`)
  - `Int32`/`Int64`/`Nativeint` include literal suffixes (`l`/`L`/`n`)
  - `Float` handles `infinity`, `neg_infinity`, and `nan`
  (ocaml/dune#13394, grants ocaml/dune#13378, @Alizter)

- Bump the minimal OCaml version required to build Dune from 4.08 to 4.14.
  (ocaml/dune#13533, @Alizter)

- Starting from 3.23, user rules are sandboxed by default (ocaml/dune#13805, @rgrinberg)

- Dune will no longer stat paths in the _build directory. This was done as protection
  from user rules accidentally touching things in the _build directory. This is forbidden,
  and dune offers rule sandboxing to prevent this (ocaml/dune#13875, @rgrinberg)

- Improve mtime precision by no longer approximating them with floats (ocaml/dune#13962,
  @rgrinberg).

- Remove `--makefile` (or `-m`) in `$ dune rules`. The sexp output is the only
  supported way of reflecting dune rules (ocaml/dune#14069, @rgrinberg)

- Do not automatically promote files. Now, opam files must be manually
  promoted with `$ dune promote`. Their generation is triggered by `@install`,
  `@runtest`, and `@opam`. In release mode, .opam files aren't generated at all
  and whatever is in the source is used (ocaml/dune#14108, @rgrinberg)

- Inline test runner generation is now sandboxed (ocaml/dune#14257, @rgrinberg)
