### PR TITLE
[new release] arc (0.0.2)

### DIFF
--- a/packages/arc/arc.0.0.2/opam
+++ b/packages/arc/arc.0.0.2/opam
@@ -1,0 +1,38 @@
+opam-version: "2.0"
+synopsis: "ARC support in OCaml"
+description: "ARC implementation in OCaml"
+maintainer: "Romain Calascibetta <romain.calascibetta@gmail.com>"
+authors: "Romain Calascibetta <romain.calascibetta@gmail.com>"
+license: "MIT"
+homepage: "https://git.robur.coop/robur/ocaml-arc"
+doc: "https://robur-coop.github.io/ocaml-arc/"
+bug-reports: "https://git.robur.coop/robur/ocaml-arc"
+dev-repo: "git+https://github.com/robur-coop/ocaml-arc.git"
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "2.0.0"}
+  "dmarc"
+  "hxd"
+  "fmt"
+  "logs"
+  "dkim" {>= "0.11.0"}
+  "fpath"
+  "cmdliner"
+  "mirage-crypto-rng-miou-unix"
+  "dns-client-miou-unix"
+  "alcotest" {with-test}
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+x-maintenance-intent: [ "(latest)" ]
+url {
+  src:
+    "https://github.com/robur-coop/ocaml-arc/releases/download/v0.0.2/arc-0.0.2.tbz"
+  checksum: [
+    "sha256=cfd46f6049ca94405cbd854973c38a88b9788f565af10d2323dc722b5fdb9383"
+    "sha512=2bf000adfada5bfdeda47dbecc3c8d077ac6298d4fee8f6f51006ec7eae4cc1f29697304ebf52eab960490e8bb0ecb50555684b77733a028912630dd66f63c51"
+  ]
+}
+x-commit-hash: "91d4be5ebdd6d9bde42160214a354d8fb4d80d22"


### PR DESCRIPTION
ARC support in OCaml

- Project page: <a href="https://git.robur.coop/robur/ocaml-arc">https://git.robur.coop/robur/ocaml-arc</a>
- Documentation: <a href="https://robur-coop.github.io/ocaml-arc/">https://robur-coop.github.io/ocaml-arc/</a>

##### CHANGES:

- Be able to use an unverified chain when we sign an email (@dinosaure, [!3][3])
- Don't print v=1 on our ARC-Message-Signature (@dinosaure, c568290)

[3]: https://git.robur.coop/robur/ocaml-arc/pulls/3
