### PR TITLE
[new release] utcp (0.0.3)

### DIFF
--- a/packages/utcp/utcp.0.0.3/opam
+++ b/packages/utcp/utcp.0.0.3/opam
@@ -1,0 +1,73 @@
+opam-version: "2.0"
+maintainer: "Robur <team@robur.coop>"
+authors: ["Robur <team@robur.coop>"]
+homepage: "https://github.com/robur-coop/utcp"
+dev-repo: "git+https://github.com/robur-coop/utcp.git"
+bug-reports: "https://github.com/robur-coop/utcp/issues"
+available: [ arch != "arm32" & arch != "x86_32" ] # see #35
+license: "ISC"
+depends: [
+  "ocaml" {>= "4.13.0"}
+  "dune" {>= "2.7.0"}
+  "cstruct" {>= "6.0.1"}
+  "duration" {>= "0.2.0"}
+  "fmt" {>= "0.8.7"}
+  "ipaddr" {>= "5.2.0"}
+  "ipaddr-cstruct" {>= "5.2.0"}
+  "logs" {>= "0.7.0"}
+  "randomconv" {>= "0.2.0"}
+  "mtime" {>= "1.4.0"}
+  "metrics" {>= "0.4.1"}
+  "mirage-crypto-rng" {>= "1.2.0"}
+  "base64" {>= "3.5.1"} #only used for tracing
+  #for mirage sublibrary
+  "lwt" {>= "5.4.2"}
+  "mirage-sleep" {>= "4.0.0"}
+  "mirage-mtime" {>= "5.0.0"}
+  "tcpip" {>= "9.0.0"}
+  #for testing
+  "alcotest" {>= "1.5.0" & with-test}
+  "crowbar" {>= "0.2.1" & with-test}
+  "ohex" {with-test}
+  "bechamel" {with-test}
+  "bechamel-js" {with-test}
+  #for apps
+  "cmdliner" {>= "1.1.0" & dev}
+  "mirage-net-unix" {>= "2.8.0" & dev}
+  "ethernet" {>= "2.2.1" & dev}
+  "arp" {>= "4.0.0" & dev}
+  "mirage-unix" {>= "5.0.0" & dev}
+  "pcap-format" {>= "0.6.0" & dev}
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+synopsis: "An implementation of TCP (Transmission Control Protocol) in OCaml"
+description: """
+µTCP is an implementation of the Transmission Control
+Protocol (RFC 793) in OCaml. TCP is widely used on the Internet today.
+
+This implementation is based on the research project Network Semantics
+(https://www.cl.cam.ac.uk/~pes20/Netsem/) which developed a rigorous test
+oracle specification and validation for TCP/IP and the Sockets API (also see
+the JACM paper http://www.cl.cam.ac.uk/~pes20/Netsem/paper3.pdf) in HOL4. The
+implementation does not adhere to the specification, since some features of TCP
+that are rarely used are not implemented (such as the urgent flag and urgent
+pointers).
+
+The target of this opam package is the MirageOS (https://mirageos.org) unikernel
+operating system.
+"""
+x-maintenance-intent: [ "(latest)" ]
+url {
+  src:
+    "https://github.com/robur-coop/utcp/releases/download/0.0.3/utcp-0.0.3.tbz"
+  checksum: [
+    "sha256=bd512cae636929d817d20d8287f7aad44d04d1610437ac46544543ba8bd2807c"
+    "sha512=c6b154798644702a86a15fc6d00324d8f345ee2b9ea60142f1135fbe6936fd1581984dc8387641bace030abd168e1f29677f50e954f2e272a48845acc01726f7"
+  ]
+}
+x-commit-hash: "b64d2a19f7f75bee808654881b9dc88a02baabf6"


### PR DESCRIPTION
An implementation of TCP (Transmission Control Protocol) in OCaml

- Project page: <a href="https://github.com/robur-coop/utcp">https://github.com/robur-coop/utcp</a>

##### CHANGES:

* Fix sequence number arithmetics, stick to unsigned int32 with "serial number
  arithmetics" (RFC 1982) for comparison (robur-coop/utcp#68 @dinosaure)
