### PR TITLE
rocq-stdlib 9.1.0 package (moved from rocq-specific repo)

### DIFF
--- a/packages/rocq-stdlib/rocq-stdlib.9.1.0/opam
+++ b/packages/rocq-stdlib/rocq-stdlib.9.1.0/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+synopsis: "The Rocq Proof Assistant -- Standard Library"
+description: """
+Rocq is a formal proof management system. It provides
+a formal language to write mathematical definitions, executable
+algorithms and theorems together with an environment for
+semi-interactive development of machine-checked proofs.
+
+Typical applications include the certification of properties of
+programming languages (e.g. the CompCert compiler certification
+project, or the Bedrock verified low-level programming library), the
+formalization of mathematics (e.g. the full formalization of the
+Feit-Thompson theorem or homotopy type theory) and teaching.
+
+This package includes the Rocq Standard Library, that is to say, the
+set of modules usually bound to the Stdlib.* namespace."""
+maintainer: ["The Rocq standard library development team"]
+authors: ["The Rocq development team, INRIA, CNRS, and contributors"]
+license: "LGPL-2.1-only"
+homepage: "https://rocq-prover.org"
+doc: "https://coq.github.io/doc/"
+bug-reports: "https://github.com/coq/stdlib/issues"
+dev-repo: "git+https://github.com/coq/stdlib.git"
+depends: [
+  "rocq-runtime"
+  "rocq-core" {>= "9.0"}
+]
+build: [
+  [make "-j" jobs]
+]
+install: [
+  [make "install"]
+]
+
+url {
+  src:
+    "https://github.com/coq/stdlib/releases/download/V9.1.0/stdlib-9.1.0.tar.gz"
+  checksum: "sha512=5a6c01496917b8f23017d9e94af567be68850155a4545bddb067da83eed97237e34d617345942a708b6a4231e00f9bfc8311cd978bf397bb1ef2ea7c25b1a0a3"
+}


### PR DESCRIPTION
This moves back rocq-stdlib package from the rocq-specific repo to the main opam repo (https://github.com/rocq-prover/stdlib/issues/256), avoiding surprising solutions using a less recent rocq-stdlib. 