### PR TITLE
3 packages from tangled.org/ryan.freumh.org/ocaml-wake-on-lan/archive/1.0.tar.gz

### DIFF
--- a/packages/wol-eio/wol-eio.1.0/opam
+++ b/packages/wol-eio/wol-eio.1.0/opam
@@ -14,6 +14,7 @@ depends: [
   "ocaml" {>= "5.2"}
   "wol" {= version}
   "eio" {>= "1.0"}
+  "eio_posix"
   "eio_main" {>= "1.0"}
   "cmdliner" {>= "1.1"}
   "odoc" {with-doc}

--- a/packages/wol-eio/wol-eio.1.0/opam
+++ b/packages/wol-eio/wol-eio.1.0/opam
@@ -1,0 +1,43 @@
+opam-version: "2.0"
+synopsis: "Wake-on-LAN for Eio"
+description:
+  "Send Wake-on-LAN magic packets using Eio. Includes the owol command-line tool."
+maintainer: "Ryan Gibb <ryan@freumh.org>"
+authors: [
+  "Ryan Gibb <ryan@freumh.org>" "Patrick Ferris <patrick@sirref.org>"
+]
+license: "MIT"
+homepage: "https://tangled.org/ryan.freumh.org/ocaml-wake-on-lan"
+bug-reports: "https://tangled.org/ryan.freumh.org/ocaml-wake-on-lan/issues"
+depends: [
+  "dune" {>= "3.10"}
+  "ocaml" {>= "5.2"}
+  "wol" {= version}
+  "eio" {>= "1.0"}
+  "eio_main" {>= "1.0"}
+  "cmdliner" {>= "1.1"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://tangled.org/ryan.freumh.org/ocaml-wake-on-lan"
+url {
+  src:
+    "https://tangled.org/ryan.freumh.org/ocaml-wake-on-lan/archive/1.0.tar.gz"
+  checksum: [
+    "md5=e7a5baecc01a778d3772ad52a5b597f0"
+    "sha512=a254cefa47360b7e60c875db254062645c629a95f063cd500955109e18ebd2918f1d977024747f17841ad02e8f2d911deb158552e85459b23d0c5772d52e5bb4"
+  ]
+}

--- a/packages/wol-mirage/wol-mirage.1.0/opam
+++ b/packages/wol-mirage/wol-mirage.1.0/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+synopsis: "Wake-on-LAN for MirageOS"
+description:
+  "Send Wake-on-LAN magic packets using the MirageOS network stack."
+maintainer: "Ryan Gibb <ryan@freumh.org>"
+authors: [
+  "Ryan Gibb <ryan@freumh.org>" "Patrick Ferris <patrick@sirref.org>"
+]
+license: "MIT"
+homepage: "https://tangled.org/ryan.freumh.org/ocaml-wake-on-lan"
+bug-reports: "https://tangled.org/ryan.freumh.org/ocaml-wake-on-lan/issues"
+depends: [
+  "dune" {>= "3.10"}
+  "ocaml" {>= "5.2"}
+  "wol" {= version}
+  "tcpip" {>= "8.0"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://tangled.org/ryan.freumh.org/ocaml-wake-on-lan"
+url {
+  src:
+    "https://tangled.org/ryan.freumh.org/ocaml-wake-on-lan/archive/1.0.tar.gz"
+  checksum: [
+    "md5=e7a5baecc01a778d3772ad52a5b597f0"
+    "sha512=a254cefa47360b7e60c875db254062645c629a95f063cd500955109e18ebd2918f1d977024747f17841ad02e8f2d911deb158552e85459b23d0c5772d52e5bb4"
+  ]
+}

--- a/packages/wol/wol.1.0/opam
+++ b/packages/wol/wol.1.0/opam
@@ -1,0 +1,42 @@
+opam-version: "2.0"
+synopsis: "Wake-on-LAN magic packet construction"
+description:
+  "A library for constructing Wake-on-LAN magic packets from MAC addresses. Provides a pure implementation with no IO dependencies."
+maintainer: "Ryan Gibb <ryan@freumh.org>"
+authors: [
+  "Ryan Gibb <ryan@freumh.org>" "Patrick Ferris <patrick@sirref.org>"
+]
+license: "MIT"
+homepage: "https://tangled.org/ryan.freumh.org/ocaml-wake-on-lan"
+bug-reports: "https://tangled.org/ryan.freumh.org/ocaml-wake-on-lan/issues"
+depends: [
+  "dune" {>= "3.10"}
+  "ocaml" {>= "5.2"}
+  "ipaddr" {>= "5.0"}
+  "macaddr" {>= "5.0"}
+  "cstruct" {>= "6.0"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://tangled.org/ryan.freumh.org/ocaml-wake-on-lan"
+url {
+  src:
+    "https://tangled.org/ryan.freumh.org/ocaml-wake-on-lan/archive/1.0.tar.gz"
+  checksum: [
+    "md5=e7a5baecc01a778d3772ad52a5b597f0"
+    "sha512=a254cefa47360b7e60c875db254062645c629a95f063cd500955109e18ebd2918f1d977024747f17841ad02e8f2d911deb158552e85459b23d0c5772d52e5bb4"
+  ]
+}


### PR DESCRIPTION
This pull-request concerns:
- `wol.1.0`: Wake-on-LAN magic packet construction
- `wol-eio.1.0`: Wake-on-LAN for Eio
- `wol-mirage.1.0`: Wake-on-LAN for MirageOS



---
* Homepage: https://tangled.org/ryan.freumh.org/ocaml-wake-on-lan
* Source repo: git+https://tangled.org/ryan.freumh.org/ocaml-wake-on-lan
* Bug tracker: https://tangled.org/ryan.freumh.org/ocaml-wake-on-lan/issues

---
:camel: Pull-request generated by opam-publish v2.6.0