### PR TITLE
cohttp-async 6.1.0 and 6.2.1 are compatible with ocaml >= 5.3

### DIFF
--- a/packages/cohttp-async/cohttp-async.6.1.0/opam
+++ b/packages/cohttp-async/cohttp-async.6.1.0/opam
@@ -24,7 +24,7 @@ doc: "https://mirage.github.io/ocaml-cohttp/"
 bug-reports: "https://github.com/mirage/ocaml-cohttp/issues"
 depends: [
   "dune" {>= "3.8"}
-  "ocaml" {>= "4.14" & < "5.3.0"}
+  "ocaml" {>= "4.14"}
   "http" {= version}
   "cohttp" {= version}
   "async_kernel" {>= "v0.16.0"}

--- a/packages/cohttp-async/cohttp-async.6.2.1/opam
+++ b/packages/cohttp-async/cohttp-async.6.2.1/opam
@@ -24,7 +24,7 @@ doc: "https://mirage.github.io/ocaml-cohttp/"
 bug-reports: "https://github.com/mirage/ocaml-cohttp/issues"
 depends: [
   "dune" {>= "3.8"}
-  "ocaml" {>= "4.14" & < "5.3.0"}
+  "ocaml" {>= "4.14"}
   "http" {= version}
   "cohttp" {= version}
   "async_kernel" {>= "v0.17.0"}


### PR DESCRIPTION
ref #28138
cc @samoht 