### PR TITLE
Package ocaml-doctor.0.1.0

### DIFF
--- a/packages/ocaml-doctor/ocaml-doctor.0.1.0/opam
+++ b/packages/ocaml-doctor/ocaml-doctor.0.1.0/opam
@@ -1,0 +1,43 @@
+opam-version: "2.0"
+synopsis: "Diagnostic CLI for OCaml development environments"
+description: """
+ocaml-doctor checks common OCaml development environment problems, including
+opam setup, active switches, dune, ocaml-lsp-server, ocamlformat, PATH issues,
+and editor integration hints.
+"""
+maintainer: "Thomas B. <29905917+funwithcthulhu@users.noreply.github.com>"
+authors: "Thomas B."
+license: "MIT"
+tags: [
+  "cli"
+  "diagnostics"
+  "developer-tools"
+  "opam"
+  "dune"
+  "lsp"
+  "windows"
+]
+homepage: "https://github.com/funwithcthulhu/ocaml-doctor"
+doc: "https://github.com/funwithcthulhu/ocaml-doctor#readme"
+bug-reports: "https://github.com/funwithcthulhu/ocaml-doctor/issues"
+dev-repo: "git+https://github.com/funwithcthulhu/ocaml-doctor.git"
+depends: [
+  "ocaml" {>= "5.1"}
+  "dune" {>= "3.11"}
+  "cmdliner" {>= "1.1.0"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+run-test: [
+  ["dune" "runtest" "-p" name "-j" jobs]
+]
+url {
+  src:
+    "https://github.com/funwithcthulhu/ocaml-doctor/archive/refs/tags/0.1.0.tar.gz"
+  checksum: [
+    "md5=6e548fc73dfde7b6635294edc47a0f92"
+    "sha512=628318646396760820b2d6f81633def7977a252b7601eb5c3a30b6e1e96dc1371b85a83d3d499a0f9991df7d3340270bfd8e06f24ee15ef95e83fe4a617afccd"
+  ]
+}


### PR DESCRIPTION
### `ocaml-doctor.0.1.0`
Diagnostic CLI for OCaml development environments
ocaml-doctor checks common OCaml development environment problems, including
opam setup, active switches, dune, ocaml-lsp-server, ocamlformat, PATH issues,
and editor integration hints.



---
* Homepage: https://github.com/funwithcthulhu/ocaml-doctor
* Source repo: git+https://github.com/funwithcthulhu/ocaml-doctor.git
* Bug tracker: https://github.com/funwithcthulhu/ocaml-doctor/issues

---
:camel: Pull-request generated by opam-publish v3.0.0