### PR TITLE
[new release] albatross (2.7.1)

### DIFF
--- a/packages/albatross/albatross.2.7.1/opam
+++ b/packages/albatross/albatross.2.7.1/opam
@@ -1,0 +1,71 @@
+opam-version: "2.0"
+maintainer: "Hannes Mehnert <hannes@mehnert.org>"
+authors: ["Hannes Mehnert <hannes@mehnert.org>"]
+homepage: "https://github.com/robur-coop/albatross"
+dev-repo: "git+https://github.com/robur-coop/albatross.git"
+bug-reports: "https://github.com/robur-coop/albatross/issues"
+license: "ISC"
+
+depends: [
+  "ocaml" {>= "4.14.0"}
+  "dune" {>= "2.7.0"}
+  "dune-configurator"
+  "conf-pkg-config" {build}
+  "conf-libnl3" {os = "linux"}
+  "conf-libev"
+  "lwt" {>= "3.0.0"}
+  "ipaddr" {>= "5.3.0"}
+  "logs"
+  "bos" {>= "0.2.0"}
+  "ptime" {>= "1.1.0"}
+  "cmdliner" {>= "1.1.0"}
+  "fmt" {>= "0.8.7"}
+  "x509" {>= "1.0.0"}
+  "tls" {>= "1.0.2"}
+  "tls-lwt" {>= "1.0.2"}
+  "asn1-combinators" {>= "0.3.0"}
+  "duration"
+  "decompress" {>= "1.3.0"}
+  "bigstringaf" {>= "0.2.0"}
+  "metrics" {>= "0.5.0"}
+  "metrics-lwt" {>= "0.2.0"}
+  "metrics-influx" {>= "0.2.0"}
+  "metrics-rusage"
+  "ohex" {>= "0.2.0"}
+  "http-lwt-client" {>= "0.3.0"}
+  "happy-eyeballs-lwt"
+  "solo5-elftool" {>= "0.4.0"}
+  "cachet" {>= "0.0.3"}
+  "bstr"
+  "fpath" {>= "0.7.3"}
+  "logs-syslog" {>= "0.4.1"}
+  "digestif" {>= "1.2.0"}
+  "alcotest" {with-test}
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+  ["sh" "-ex" "packaging/FreeBSD/create_package.sh"] {os = "freebsd"}
+  ["sh" "-ex" "packaging/debian/create_package.sh"] {os-family = "debian" | os-family = "ubuntu"}
+]
+available: os != "openbsd"
+synopsis: "Albatross - orchestrate and manage MirageOS unikernels with Solo5"
+description: """
+The goal of albatross is robust deployment of [MirageOS](https://mirage.io)
+unikernels using [Solo5](https://github.com/solo5/solo5). Resources managed
+by albatross are network interfaces of kind `tap`, which are connected to
+already existing bridges, block devices, memory, and CPU. Each unikernel is
+pinned (`cpuset` / `taskset`) to a specific core.
+"""
+depexts: ["linux-headers"] {os-family = "alpine"}
+x-maintenance-intent: [ "(latest)" ]
+url {
+  src:
+    "https://github.com/robur-coop/albatross/releases/download/v2.7.1/albatross-2.7.1.tbz"
+  checksum: [
+    "sha256=4771b652da92e2599568715b05422a348f4919d59d441e6a907dd0611077afdc"
+    "sha512=e6352532976447c26c45433d7d0530ce570b358148e66ee32ea844c35d4454384e2f26a1c93bfa97341ade695d9e9b7dfc8e0fa23d5a0030f1c0e4d890e124cc"
+  ]
+}
+x-commit-hash: "3b255a4bd3624604d2031f905855489ee24df496"


### PR DESCRIPTION
Albatross - orchestrate and manage MirageOS unikernels with Solo5

- Project page: <a href="https://github.com/robur-coop/albatross">https://github.com/robur-coop/albatross</a>

##### CHANGES:

* Albatross-daemon: dump state after destroy (robur-coop/albatross#269, fixes robur-coop/albatross#268 @hannesm)
  bug introduced in v2.7.0 "avoid dumping when a restart-on-failure unikernel is
  restarted"
