### PR TITLE
[new release] ca-certs (1.0.2)

### DIFF
--- a/packages/ca-certs/ca-certs.1.0.2/opam
+++ b/packages/ca-certs/ca-certs.1.0.2/opam
@@ -1,0 +1,61 @@
+opam-version: "2.0"
+synopsis: "Detect root CA certificates from the operating system"
+description: """
+TLS requires a set of root anchors (Certificate Authorities) to
+authenticate servers. This library exposes this list so that it can be
+registered with ocaml-tls.
+"""
+maintainer: ["Etienne Millon <me@emillon.org>"]
+authors: [
+  "Etienne Millon <me@emillon.org>, Hannes Mehnert <hannes@mehnert.org>"
+]
+license: "ISC"
+homepage: "https://github.com/mirage/ca-certs"
+doc: "https://mirage.github.io/ca-certs/doc"
+bug-reports: "https://github.com/mirage/ca-certs/issues"
+depends: [
+  "dune" {>= "2.0"}
+  "bos"
+  "fpath"
+  "ptime"
+  "logs"
+  "digestif" {>= "1.2.0"}
+  "mirage-crypto" {>= "1.0.0"}
+  "x509" {>= "1.0.0"}
+  "ocaml" {>= "4.13.0"}
+  "ohex" {>= "0.2.0"}
+  "alcotest" {with-test}
+  "fmt" {with-test & >= "0.8.7"}
+]
+conflicts: [
+  "result" {< "1.5"}
+]
+dev-repo: "git+https://github.com/mirage/ca-certs.git"
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test & os != "macos"} # the opam sandbox on macos leads to test failures (ocaml/opam#4389)
+    "@doc" {with-doc}
+  ]
+]
+tags: ["org:mirage"]
+depexts: [
+  ["ca_root_nss"] {os = "freebsd" | os = "dragonfly"}
+]
+x-maintenance-intent: [ "(latest)" ]
+url {
+  src:
+    "https://github.com/mirage/ca-certs/releases/download/v1.0.2/ca-certs-1.0.2.tbz"
+  checksum: [
+    "sha256=521f21814fd916b596e9a81bf41f1221269102ec1c8b0c83a01e86c6d8863dad"
+    "sha512=e483de21c4b083b268f4c4a4d25e8596bd47c0a39f60548e6486edd0d27d42e890ecc058eaa1157f7d18d0cf9a61c7ba3e27fb63c28d013b020409897122d3dc"
+  ]
+}
+x-commit-hash: "26ff017e7efd605c8e96eaf5b9f115324fec9020"


### PR DESCRIPTION
Detect root CA certificates from the operating system

- Project page: <a href="https://github.com/mirage/ca-certs">https://github.com/mirage/ca-certs</a>
- Documentation: <a href="https://mirage.github.io/ca-certs/doc">https://mirage.github.io/ca-certs/doc</a>

##### CHANGES:

* Support DragonFlyBSD (mirage/ca-certs#39 @mneumann)
