### PR TITLE
[new release] miou (0.6.0)

### DIFF
--- a/packages/miou/miou.0.6.0/opam
+++ b/packages/miou/miou.0.6.0/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+maintainer:   "Romain Calascibetta <romain.calascibetta@gmail.com>"
+authors:      "Romain Calascibetta <romain.calascibetta@gmail.com>"
+homepage:     "https://github.com/robur-coop/miou"
+bug-reports:  "https://github.com/robur-coop/miou/issues"
+dev-repo:     "git+https://github.com/robur-coop/miou.git"
+doc:          "https://docs.osau.re/local/miou/"
+license:      "MIT"
+synopsis:     "Composable concurrency primitives for OCaml"
+
+build: [ "dune" "build" "-p" name "-j" jobs ]
+run-test: [ "dune" "runtest" "-p" name "-j" jobs ]
+
+depends: [
+  "ocaml"             {>= "5.1.0"}
+  "dune"              {>= "3.13.0"}
+  "dune-configurator"
+  "dscheck"           {with-test & >= "0.4.0"}
+  "digestif"          {with-test}
+  "happy-eyeballs"    {with-test & >= "0.6.0"}
+  "dns-client"        {with-test}
+  "hxd"               {with-test}
+  "mirage-crypto-rng" {with-test}
+  "ipaddr"            {with-test}
+  "logs"              {with-test & >= "0.7.0"}
+  "dns"               {with-test}
+  "dns-client"        {with-test}
+  "mtime"             {with-test & >= "2.0.0"}
+  "ocamlformat"       {with-dev-setup & = "0.27.0"}
+]
+x-maintenance-intent: [ "(latest)" ]
+url {
+  src:
+    "https://github.com/robur-coop/miou/releases/download/v0.6.0/miou-0.6.0.tbz"
+  checksum: [
+    "sha256=10a25801d46f83664095333394e7aec3745e494f0d634ef802c9fcf826ca7e9c"
+    "sha512=ce58e8926e7990f61f778841e1d1379a3d31bfe4534f044acb26182fb534480f63f585f39532a0e38af8af809489bcee7810694bdc57242f6d448fa4c454e97c"
+  ]
+}
+x-commit-hash: "1d2dd30958cb954544142fcb5899582b4609c8d0"


### PR DESCRIPTION
Composable concurrency primitives for OCaml

- Project page: <a href="https://github.com/robur-coop/miou">https://github.com/robur-coop/miou</a>
- Documentation: <a href="https://docs.osau.re/local/miou/">https://docs.osau.re/local/miou/</a>

##### CHANGES:

- Add `.git-blame-ignore-revs` (robur-coop/miou#55, @mbarbin)
- Fix documentation link (robur-coop/miou#107, @dinosaure)
- Allow creation of UNIX domain (robur-coop/miou#106, @theAlexes)
- Add trace system for Miou (robur-coop/miou#110, @dinosaure)

  A new module `Miou.Trace` is available and allows the user to register an
  event consumer. The sub-package `miou.runtime_events` is also avaible and use
  the OCaml runtime events system to emit Miou's events. Some tools are now
  available to record Miou's events, you can check them [here][mtbox]

- Add `Miou.take` (robur-coop/miou#113, @dinosaure)

  A new function `Miou.take` is available to consume tasks available from an
  `Miou.orphans`. By this way, the user is able to `Miou.cancel` tasks instead
  of just await them (with `Miou.await{,_exn}` and `Miou.care`).

- Internal function `handle` (which runs tasks) becomes indempotent (robur-coop/miou#112,
  @dinosaure)

[mtbox]: https://github.com/robur-coop/mtbox
