### PR TITLE
Add support for cmake on NixOS

### DIFF
--- a/packages/conf-cmake/conf-cmake.1/opam
+++ b/packages/conf-cmake/conf-cmake.1/opam
@@ -23,6 +23,7 @@ depexts: [
   ["devel/cmake"] {os = "dragonfly"}
   ["system:cmake"] {os-distribution = "cygwinports"}
   ["cmake"] {os-distribution = "cygwin"}
+  ["cmake"] {os-distribution = "nixos"}
 ]
 synopsis: "Virtual package relying on cmake"
 description:


### PR DESCRIPTION
For the opam depext nix integration from https://github.com/ocaml/opam/pull/5982.