### PR TITLE
[new release] testo (4 packages) (0.5.0)

### DIFF
--- a/packages/testo-diff/testo-diff.0.5.0/opam
+++ b/packages/testo-diff/testo-diff.0.5.0/opam
@@ -1,0 +1,44 @@
+opam-version: "2.0"
+synopsis: "Pure-OCaml diff implementation"
+description: """
+This is a pure-OCaml implementation for computing line-by-line diffs.
+The current implementation uses an algorithm similar to gestalt pattern
+matching ported to OCaml by Gabriel Jaldon from Paul Butler's
+Python implementation.
+See https://github.com/paulgb/simplediff"""
+maintainer: ["Martin Jambon <martin@mjambon.com>"]
+authors: ["Martin Jambon" "Gabriel Jaldon"]
+license: "ISC"
+homepage: "https://github.com/mjambon/testo"
+bug-reports: "https://github.com/mjambon/testo/issues"
+depends: [
+  "dune" {>= "3.18"}
+  "ocaml" {>= "4.08.0"}
+  "ppx_deriving"
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/mjambon/testo.git"
+x-maintenance-intent: ["(latest)"]
+url {
+  src:
+    "https://github.com/mjambon/testo/releases/download/0.5.0/testo-0.5.0.tbz"
+  checksum: [
+    "sha256=f7919d9f9fa4571c5b1ad627dfa8c05e4d79f8654745a6beb333b95b459611b1"
+    "sha512=83c7531e5c190e105b67579475d0b24f2a397feee71961d0acfa93c6ddb06b902f9156ba7e08acb24be6ee317d822b44d0cf825ea0f3374c9405ae65bcea8e79"
+  ]
+}
+x-commit-hash: "b21728a5bf55466c60d049dbca7a89faaa74a735"

--- a/packages/testo-lwt/testo-lwt.0.5.0/opam
+++ b/packages/testo-lwt/testo-lwt.0.5.0/opam
@@ -1,0 +1,46 @@
+opam-version: "2.0"
+synopsis: "Test framework for OCaml, Lwt variant"
+description: """
+Use this if the tests return Lwt promises and you can't make them synchronous
+because 'Lwt_main.run' is not supported by your platform e.g. JavaScript."""
+maintainer: ["Martin Jambon <martin@mjambon.com>"]
+authors: ["Martin Jambon" "Gabriel Jaldon"]
+license: "ISC"
+homepage: "https://github.com/mjambon/testo"
+bug-reports: "https://github.com/mjambon/testo/issues"
+depends: [
+  "dune" {>= "3.18"}
+  "lwt" {>= "5.6.0"}
+  "ocaml" {>= "4.08.0"}
+  "alcotest" {with-test}
+  "cmdliner" {>= "1.1.0"}
+  "fpath"
+  "re" {>= "1.10.0"}
+  "testo-util" {= version}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/mjambon/testo.git"
+x-maintenance-intent: ["(latest)"]
+url {
+  src:
+    "https://github.com/mjambon/testo/releases/download/0.5.0/testo-0.5.0.tbz"
+  checksum: [
+    "sha256=f7919d9f9fa4571c5b1ad627dfa8c05e4d79f8654745a6beb333b95b459611b1"
+    "sha512=83c7531e5c190e105b67579475d0b24f2a397feee71961d0acfa93c6ddb06b902f9156ba7e08acb24be6ee317d822b44d0cf825ea0f3374c9405ae65bcea8e79"
+  ]
+}
+x-commit-hash: "b21728a5bf55466c60d049dbca7a89faaa74a735"

--- a/packages/testo-util/testo-util.0.5.0/opam
+++ b/packages/testo-util/testo-util.0.5.0/opam
@@ -1,0 +1,42 @@
+opam-version: "2.0"
+synopsis: "Modules shared by testo, testo-lwt, etc"
+description: "Testo is a test framework for OCaml."
+maintainer: ["Martin Jambon <martin@mjambon.com>"]
+authors: ["Martin Jambon" "Gabriel Jaldon"]
+license: "ISC"
+homepage: "https://github.com/mjambon/testo"
+bug-reports: "https://github.com/mjambon/testo/issues"
+depends: [
+  "dune" {>= "3.18"}
+  "ocaml" {>= "4.08.0"}
+  "fpath"
+  "re" {>= "1.10.0"}
+  "ppx_deriving"
+  "testo-diff" {= version}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/mjambon/testo.git"
+x-maintenance-intent: ["(latest)"]
+url {
+  src:
+    "https://github.com/mjambon/testo/releases/download/0.5.0/testo-0.5.0.tbz"
+  checksum: [
+    "sha256=f7919d9f9fa4571c5b1ad627dfa8c05e4d79f8654745a6beb333b95b459611b1"
+    "sha512=83c7531e5c190e105b67579475d0b24f2a397feee71961d0acfa93c6ddb06b902f9156ba7e08acb24be6ee317d822b44d0cf825ea0f3374c9405ae65bcea8e79"
+  ]
+}
+x-commit-hash: "b21728a5bf55466c60d049dbca7a89faaa74a735"

--- a/packages/testo/testo.0.5.0/opam
+++ b/packages/testo/testo.0.5.0/opam
@@ -1,0 +1,47 @@
+opam-version: "2.0"
+synopsis: "Test framework for OCaml"
+description: """
+Testo is a test framework for OCaml providing new subcommands for capturing,
+checking, and approving the output of tests."""
+maintainer: ["Martin Jambon <martin@mjambon.com>"]
+authors: ["Martin Jambon" "Gabriel Jaldon"]
+license: "ISC"
+homepage: "https://github.com/mjambon/testo"
+bug-reports: "https://github.com/mjambon/testo/issues"
+depends: [
+  "dune" {>= "3.18"}
+  "ocaml" {>= "4.08.0"}
+  "alcotest" {with-test}
+  "cmdliner" {>= "1.1.0"}
+  "fpath"
+  "odoc" {>= "3.1.0" & with-doc}
+  "re" {>= "1.10.0"}
+  "testo-util" {= version}
+  "ocamlformat" {>= "0.28.0" & < "0.29.0" & with-dev-setup}
+  "utop" {with-dev-setup}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/mjambon/testo.git"
+x-maintenance-intent: ["(latest)"]
+url {
+  src:
+    "https://github.com/mjambon/testo/releases/download/0.5.0/testo-0.5.0.tbz"
+  checksum: [
+    "sha256=f7919d9f9fa4571c5b1ad627dfa8c05e4d79f8654745a6beb333b95b459611b1"
+    "sha512=83c7531e5c190e105b67579475d0b24f2a397feee71961d0acfa93c6ddb06b902f9156ba7e08acb24be6ee317d822b44d0cf825ea0f3374c9405ae65bcea8e79"
+  ]
+}
+x-commit-hash: "b21728a5bf55466c60d049dbca7a89faaa74a735"


### PR DESCRIPTION
Test framework for OCaml

- Project page: <a href="https://github.com/mjambon/testo">https://github.com/mjambon/testo</a>

##### CHANGES:

- Fix: `--autoclean` was silently ignored by the `status` subcommand when using the default compact output style ([mjambon/testo#171](https://github.com/mjambon/testo/issues/171), [mjambon/testo#190](https://github.com/mjambon/testo/pull/190)).
- Fix: backtrace truncation was incorrectly applied to the exception message itself, cutting off legitimate output that happened to be longer than 5 lines. Truncation now only applies to lines that are recognized as OCaml backtrace lines (`Raised at ...`, `Called from ...`, etc.) ([mjambon/testo#188](https://github.com/mjambon/testo/pull/188)).
