### PR TITLE
Prepare release of httpcats.0.3.0

### DIFF
--- a/packages/hurl/hurl.0.0.1~beta1/opam
+++ b/packages/hurl/hurl.0.0.1~beta1/opam
@@ -9,7 +9,7 @@ license: "BSD-3-clause"
 depends: [
   "ocaml" {>= "5.1.0"}
   "dune" {>= "2.8.0"}
-  "httpcats" {>= "0.1.0"}
+  "httpcats" {>= "0.1.0" & < "0.3.0"}
   "mirage-crypto-rng-miou-unix"
   "hxd" {>= "0.3.4"}
   "multipart_form" {>= "0.6.0"}

--- a/packages/mhttp/mhttp.0.0.1/opam
+++ b/packages/mhttp/mhttp.0.0.1/opam
@@ -12,7 +12,7 @@ depends: [
   "mnet"
   "mnet-tls"
   "mirage-crypto-rng"
-  "httpcats" {>= "0.2.0"}
+  "httpcats" {>= "0.2.0" & < "0.3.0"}
 ]
 build: [
   ["dune" "subst"] {dev}

--- a/packages/vif/vif.0.0.1~beta1/opam
+++ b/packages/vif/vif.0.0.1~beta1/opam
@@ -17,7 +17,7 @@ depends: [
   "bytesrw"
   "jsont" {>= "0.2.0"}
   "cmdliner" {>= "1.3.0"}
-  "httpcats" {>= "0.1.0"}
+  "httpcats" {>= "0.1.0" & < "0.3.0"}
   "tyre" {>= "0.5" & < "1.0"}
   "mirage-crypto-rng-miou-unix"
   "jsonm" {>= "1.0.2"}

--- a/packages/vif/vif.0.0.1~beta2/opam
+++ b/packages/vif/vif.0.0.1~beta2/opam
@@ -19,7 +19,7 @@ depends: [
   "fluxt" {>= "0.0.1~beta2"}
   "jsont" {>= "0.2.0"}
   "cmdliner" {>= "1.3.0"}
-  "httpcats" {>= "0.2.0"}
+  "httpcats" {>= "0.2.0" & < "0.3.0"}
   "tyre" {>= "1.0"}
   "mirage-crypto-rng-miou-unix"
   "decompress" {>= "1.5.0"}

--- a/packages/yocaml_unix/yocaml_unix.2.0.0/opam
+++ b/packages/yocaml_unix/yocaml_unix.2.0.0/opam
@@ -10,7 +10,7 @@ depends: [
   "dune" {>= "3.14" & >= "3.0.0"}
   "ppx_expect"
   "mdx" {with-test & = "2.4.1"}
-  "httpcats" {>= "0.0.1"}
+  "httpcats" {>= "0.0.1" & < "0.3.0"}
   "yocaml" {= version}
   "yocaml_runtime" {= version}
   "odoc" {with-doc}

--- a/packages/yocaml_unix/yocaml_unix.2.1.0/opam
+++ b/packages/yocaml_unix/yocaml_unix.2.1.0/opam
@@ -10,7 +10,7 @@ depends: [
   "ocaml" {>= "5.1.1"}
   "ppx_expect"
   "mdx" {with-test & = "2.5.0"}
-  "httpcats" {>= "0.0.1"}
+  "httpcats" {>= "0.0.1" & < "0.3.0"}
   "yocaml" {= version}
   "yocaml_runtime" {= version}
   "odoc" {with-doc}

--- a/packages/yocaml_unix/yocaml_unix.2.2.0/opam
+++ b/packages/yocaml_unix/yocaml_unix.2.2.0/opam
@@ -10,7 +10,7 @@ depends: [
   "ocaml" {>= "5.1.1"}
   "ppx_expect"
   "mdx" {with-test & = "2.5.0"}
-  "httpcats" {>= "0.0.1"}
+  "httpcats" {>= "0.0.1" & < "0.3.0"}
   "yocaml" {= version}
   "yocaml_runtime" {= version}
   "odoc" {with-doc}

--- a/packages/yocaml_unix/yocaml_unix.2.3.0/opam
+++ b/packages/yocaml_unix/yocaml_unix.2.3.0/opam
@@ -10,7 +10,7 @@ depends: [
   "ocaml" {>= "5.1.1"}
   "ppx_expect"
   "mdx" {with-test & >= "2.5.0"}
-  "httpcats" {>= "0.0.1"}
+  "httpcats" {>= "0.0.1" & < "0.3.0"}
   "yocaml" {= version}
   "yocaml_runtime" {= version}
   "odoc" {with-doc}

--- a/packages/yocaml_unix/yocaml_unix.2.4.0/opam
+++ b/packages/yocaml_unix/yocaml_unix.2.4.0/opam
@@ -10,7 +10,7 @@ depends: [
   "ocaml" {>= "5.1.1"}
   "ppx_expect"
   "mdx" {with-test & >= "2.5.0"}
-  "httpcats" {>= "0.0.1"}
+  "httpcats" {>= "0.0.1" & < "0.3.0"}
   "yocaml" {= version}
   "yocaml_runtime" {= version}
   "odoc" {with-doc}

--- a/packages/yocaml_unix/yocaml_unix.2.4.1/opam
+++ b/packages/yocaml_unix/yocaml_unix.2.4.1/opam
@@ -10,7 +10,7 @@ depends: [
   "ocaml" {>= "5.1.1"}
   "ppx_expect"
   "mdx" {with-test & >= "2.5.0"}
-  "httpcats" {>= "0.0.1"}
+  "httpcats" {>= "0.0.1" & < "0.3.0"}
   "yocaml" {= version}
   "yocaml_runtime" {= version}
   "odoc" {with-doc}

--- a/packages/yocaml_unix/yocaml_unix.2.5.0/opam
+++ b/packages/yocaml_unix/yocaml_unix.2.5.0/opam
@@ -10,7 +10,7 @@ depends: [
   "ocaml" {>= "5.1.1"}
   "ppx_expect"
   "mdx" {with-test & >= "2.5.0"}
-  "httpcats" {>= "0.0.1"}
+  "httpcats" {>= "0.0.1" & < "0.3.0"}
   "yocaml" {= version}
   "yocaml_runtime" {= version}
   "odoc" {with-doc}

--- a/packages/yocaml_unix/yocaml_unix.2.6.0/opam
+++ b/packages/yocaml_unix/yocaml_unix.2.6.0/opam
@@ -10,7 +10,7 @@ depends: [
   "ocaml" {>= "5.1.1"}
   "ppx_expect"
   "mdx" {with-test & >= "2.5.0"}
-  "httpcats" {>= "0.0.1"}
+  "httpcats" {>= "0.0.1" & < "0.3.0"}
   "yocaml" {= version}
   "yocaml_runtime" {= version}
   "odoc" {with-doc}

--- a/packages/yocaml_unix/yocaml_unix.2.7.0/opam
+++ b/packages/yocaml_unix/yocaml_unix.2.7.0/opam
@@ -10,7 +10,7 @@ depends: [
   "ocaml" {>= "5.1.1"}
   "ppx_expect"
   "mdx" {with-test & >= "2.5.0"}
-  "httpcats" {>= "0.0.1"}
+  "httpcats" {>= "0.0.1" & < "0.3.0"}
   "yocaml" {= version}
   "yocaml_runtime" {= version}
   "odoc" {with-doc}

--- a/packages/yocaml_unix/yocaml_unix.2.8.0/opam
+++ b/packages/yocaml_unix/yocaml_unix.2.8.0/opam
@@ -10,7 +10,7 @@ depends: [
   "ocaml" {>= "5.1.1"}
   "ppx_expect"
   "mdx" {with-test & >= "2.5.0"}
-  "httpcats" {>= "0.0.1"}
+  "httpcats" {>= "0.0.1" & < "0.3.0"}
   "yocaml" {= version}
   "yocaml_runtime" {= version}
   "odoc" {with-doc}

--- a/packages/yocaml_unix/yocaml_unix.3.0.0/opam
+++ b/packages/yocaml_unix/yocaml_unix.3.0.0/opam
@@ -10,7 +10,7 @@ depends: [
   "ocaml" {>= "5.1.1"}
   "ppx_expect"
   "mdx" {with-test & >= "2.5.0"}
-  "httpcats" {>= "0.0.1"}
+  "httpcats" {>= "0.0.1" & < "0.3.0"}
   "yocaml" {= version}
   "yocaml_runtime" {= version}
   "odoc" {with-doc}


### PR DESCRIPTION
`httpcats.0.3.0` will break the API, this PR prepare the revdeps.