### PR TITLE
[new release] httpcats (0.3.0)

### DIFF
--- a/packages/httpcats/httpcats.0.3.0/opam
+++ b/packages/httpcats/httpcats.0.3.0/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+maintainer: "Robur <team@robur.coop>"
+authors: ["Robur <team@robur.coop>"]
+homepage: "https://github.com/robur-coop/httpcats"
+dev-repo: "git+https://github.com/robur-coop/httpcats.git"
+bug-reports: "https://github.com/robur-coop/httpcats/issues"
+license: "BSD-3-clause"
+
+depends: [
+  "ocaml" {>= "5.0.0"}
+  "dune" {>= "2.8.0"}
+  "logs" {with-test}
+  "miou" {>= "0.6.0"}
+  "fmt" {>= "0.9.0" & with-test}
+  "h2" {>= "0.13.0"}
+  "h1" {>= "1.1.0"}
+  "ca-certs"
+  "bstr"
+  "tls-miou-unix" {>= "1.0.1"}
+  "dns-client-miou-unix" {>= "9.0.0"}
+  "happy-eyeballs-miou-unix"
+  "mirage-crypto-rng-miou-unix" {with-test & >= "1.1.0"}
+  "alcotest" {>= "1.8.0" & with-test}
+  "digestif" {with-test & >= "1.2.0"}
+]
+conflicts: [ "result" {< "1.5"} ]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+synopsis: "A simple HTTP client / server using h1, h2, and miou"
+available: [ arch != "x86_32" ]
+url {
+  src:
+    "https://github.com/robur-coop/httpcats/releases/download/v0.3.0/httpcats-0.3.0.tbz"
+  checksum: [
+    "sha256=ff77d72ec8a294632e99757d1ae1a96073e6fb282d1c0e1e514b47b19976959d"
+    "sha512=0efc177c18cc74a8e24e6405331f716aeb780b528176b15c64b1e698cab0113cc25e30e0c9a075b51c1eb780c844734c8c930f9d18e351e73706d9c3d3738b85"
+  ]
+}
+x-commit-hash: "35b468c5bd859dcb6a9aa648275d7089fe656225"


### PR DESCRIPTION
A simple HTTP client / server using h1, h2, and miou

- Project page: <a href="https://github.com/robur-coop/httpcats">https://github.com/robur-coop/httpcats</a>

##### CHANGES:

- Don't predate how we close underlying connection when we write something. It
  avoid a "double-close" (@dinosaure, robur-coop/httpcats#49)
- **breaking change** Be able to specify a UNIX domain socket for listening
  (@theAlexes, robur-coop/httpcats#51)
- Delete the `rresult` dependency on tests (@dinosaure, robur-coop/httpcats#54)
- Close only when (`httpcats`) we create and bind a socket (and don't do that
  when the user pass a socket for us) (@theAlexes, @dinosaure, robur-coop/httpcats#53, robur-coop/httpcats#57)
- Clean and fix our runtime (@dinosaure, robur-coop/httpcats#59, robur-coop/httpcats#61)

  Here we decided to trust the underlying state machine
  `H{1,2}.{Server,Client}_connection.t` to properly close a connection. When we
  close it, we `Miou.cancel` tasks (instead of `Miou.await` them). `httpcats`
  requires `miou.0.6.0` (which provides `Miou.take`). When the `Flow` raises
  an exception, we report this exception to the state machine & it should stop
  everything.

- **breaking change** Pass the `conn` value to the handler (@dinosaure, robur-coop/httpcats#60)
