### PR TITLE
[new release] mkernel (0.0.2)

### DIFF
--- a/packages/mkernel/mkernel.0.0.2/opam
+++ b/packages/mkernel/mkernel.0.0.2/opam
@@ -1,0 +1,38 @@
+opam-version: "2.0"
+maintainer:   "romain.calascibetta@gmail.com"
+homepage:     "https://git.robur.coop/robur/mkernel"
+bug-reports:  "https://git.robur.coop/robur/mkernel/issues"
+dev-repo:     "git+https://github.com/robur-coop/mkernel.git"
+doc:          "https://git.robur.coop/robur/mkernel"
+license:      "MIT"
+authors:      [ "Romain Calascibetta <romain.calascibetta@gmail.com>" ]
+build:        [
+  [ "dune" "subst" ] {dev}
+  [ "dune" "build" "-p" name "-j" jobs ]
+  [ "dune" "runtest" "-p" name ] {with-test}
+]
+run-test: [ "dune" "runtest" "-p" name "-j" jobs ]
+synopsis: "An unikernel with Miou in OCaml to provide I/O for Solo5/Unikraft"
+depends: [
+  "ocaml" {>= "5.2.1"}
+  "dune"  {>= "3.0"}
+  "bstr"
+  "miou"  {>= "0.5.2"}
+  "solo5"
+  "logs"
+  "jsont"
+  "bytesrw"
+  "ocaml-solo5"
+  "hxd" {with-test}
+  "fmt" {with-test}
+  "cachet" {with-test}
+]
+url {
+  src:
+    "https://github.com/robur-coop/mkernel/releases/download/v0.0.2/mkernel-0.0.2.tbz"
+  checksum: [
+    "sha256=4a91344346ac8908be7e508197803ca8ce57e7bf50bb12fcd0527c21ea3a73f6"
+    "sha512=464c0f320a4f08c6b3e2c9bf248f9d0f0cf36883a560a4bb4642553bb5d185dc9a13176040bb505a97404fa7a9fe2822da1f3591dbeea960f0bfe670dc8f8829"
+  ]
+}
+x-commit-hash: "6aeafaa48a4e7e3765fd2f2ac130606f0cb29d65"


### PR DESCRIPTION
An unikernel with Miou in OCaml to provide I/O for Solo5/Unikraft

- Project page: <a href="https://git.robur.coop/robur/mkernel">https://git.robur.coop/robur/mkernel</a>
- Documentation: <a href="https://git.robur.coop/robur/mkernel">https://git.robur.coop/robur/mkernel</a>

##### CHANGES:

- Precise nanoseconds for `clock_{monotonic,wall}` (@hannesm, [!14][14])
- Run `solo5_yield` every 100ms to catch possible events even if we don't have
  (yet) syscalls to consume them and tasks to run (@dinosaure, [!15][15])

[14]: https://git.robur.coop/robur/mkernel/pulls/14
[15]: https://git.robur.coop/robur/mkernel/pulls/15
