### PR TITLE
[new release] mnet (5 packages) (0.0.2)

### DIFF
--- a/packages/mnet-cli/mnet-cli.0.0.2/opam
+++ b/packages/mnet-cli/mnet-cli.0.0.2/opam
@@ -14,7 +14,7 @@ depends: [
   "duration"
   "dns"
   "tls"
-  "cmdliner"
+  "cmdliner" {>= "2.0.0"}
   "ca-certs-nss" {>= "3.118"}
   "mirage-ptime" {>= "5.2.0"}
 ]

--- a/packages/mnet-cli/mnet-cli.0.0.2/opam
+++ b/packages/mnet-cli/mnet-cli.0.0.2/opam
@@ -1,0 +1,36 @@
+opam-version: "2.0"
+maintainer: "Robur <team@robur.coop>"
+authors: ["Robur <team@robur.coop>"]
+homepage: "https://github.com/robur-coop/mnet"
+dev-repo: "git+https://github.com/robur-coop/mnet.git"
+bug-reports: "https://github.com/robur-coop/mnet/issues"
+license: "MIT"
+
+depends: [
+  "ocaml" {>= "5.0.0"}
+  "utcp"
+  "dune" {>= "2.7.0"}
+  "mnet" {= version}
+  "duration"
+  "dns"
+  "tls"
+  "cmdliner"
+  "ca-certs-nss" {>= "3.118"}
+  "mirage-ptime" {>= "5.2.0"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+synopsis: "A library for defining the options required by a unikernel to configure its TCP/IP stack"
+url {
+  src:
+    "https://github.com/robur-coop/mnet/releases/download/v0.0.2/mnet-0.0.2.tbz"
+  checksum: [
+    "sha256=92b1cfec8487423090ed7abedee824ca20db86f1a7af7e308b4118bc0f774e03"
+    "sha512=ce7685c363581121c7d8ae0c33d7dff30ee2dd9dcd29d56f451ac3261b84a91d35a2fa65b31f1f321ddc4b5984e21840459c63614e81ee814f47ac24376bf018"
+  ]
+}
+x-commit-hash: "a36148577823ffbb2e30e5e2d3885490c33e8572"

--- a/packages/mnet-dns/mnet-dns.0.0.2/opam
+++ b/packages/mnet-dns/mnet-dns.0.0.2/opam
@@ -1,0 +1,34 @@
+opam-version: "2.0"
+maintainer: "Robur <team@robur.coop>"
+authors: ["Robur <team@robur.coop>"]
+homepage: "https://github.com/robur-coop/mnet"
+dev-repo: "git+https://github.com/robur-coop/mnet.git"
+bug-reports: "https://github.com/robur-coop/mnet/issues"
+license: "MIT"
+
+depends: [
+  "ocaml" {>= "5.0.0"}
+  "utcp"
+  "dune" {>= "2.7.0"}
+  "mnet" {= version}
+  "mnet-tls" {= version}
+  "mnet-happy-eyeballs" {= version}
+  "dns"
+  "dns-client"
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+synopsis: "An implementation of DNS in OCaml for Miou & Solo5"
+url {
+  src:
+    "https://github.com/robur-coop/mnet/releases/download/v0.0.2/mnet-0.0.2.tbz"
+  checksum: [
+    "sha256=92b1cfec8487423090ed7abedee824ca20db86f1a7af7e308b4118bc0f774e03"
+    "sha512=ce7685c363581121c7d8ae0c33d7dff30ee2dd9dcd29d56f451ac3261b84a91d35a2fa65b31f1f321ddc4b5984e21840459c63614e81ee814f47ac24376bf018"
+  ]
+}
+x-commit-hash: "a36148577823ffbb2e30e5e2d3885490c33e8572"

--- a/packages/mnet-happy-eyeballs/mnet-happy-eyeballs.0.0.2/opam
+++ b/packages/mnet-happy-eyeballs/mnet-happy-eyeballs.0.0.2/opam
@@ -11,7 +11,7 @@ depends: [
   "utcp"
   "dune" {>= "2.7.0"}
   "mnet" {= version}
-  "happy-eyeballs"
+  "happy-eyeballs" {>= "2.0.0"}
 ]
 build: [
   ["dune" "subst"] {dev}

--- a/packages/mnet-happy-eyeballs/mnet-happy-eyeballs.0.0.2/opam
+++ b/packages/mnet-happy-eyeballs/mnet-happy-eyeballs.0.0.2/opam
@@ -1,0 +1,31 @@
+opam-version: "2.0"
+maintainer: "Robur <team@robur.coop>"
+authors: ["Robur <team@robur.coop>"]
+homepage: "https://github.com/robur-coop/mnet"
+dev-repo: "git+https://github.com/robur-coop/mnet.git"
+bug-reports: "https://github.com/robur-coop/mnet/issues"
+license: "MIT"
+
+depends: [
+  "ocaml" {>= "5.0.0"}
+  "utcp"
+  "dune" {>= "2.7.0"}
+  "mnet" {= version}
+  "happy-eyeballs"
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+synopsis: "Connecting to a remote host via IP version 4 or 6 using mnet"
+url {
+  src:
+    "https://github.com/robur-coop/mnet/releases/download/v0.0.2/mnet-0.0.2.tbz"
+  checksum: [
+    "sha256=92b1cfec8487423090ed7abedee824ca20db86f1a7af7e308b4118bc0f774e03"
+    "sha512=ce7685c363581121c7d8ae0c33d7dff30ee2dd9dcd29d56f451ac3261b84a91d35a2fa65b31f1f321ddc4b5984e21840459c63614e81ee814f47ac24376bf018"
+  ]
+}
+x-commit-hash: "a36148577823ffbb2e30e5e2d3885490c33e8572"

--- a/packages/mnet-tls/mnet-tls.0.0.2/opam
+++ b/packages/mnet-tls/mnet-tls.0.0.2/opam
@@ -1,0 +1,31 @@
+opam-version: "2.0"
+maintainer: "Robur <team@robur.coop>"
+authors: ["Robur <team@robur.coop>"]
+homepage: "https://github.com/robur-coop/mnet"
+dev-repo: "git+https://github.com/robur-coop/mnet.git"
+bug-reports: "https://github.com/robur-coop/mnet/issues"
+license: "MIT"
+
+depends: [
+  "ocaml" {>= "5.0.0"}
+  "utcp"
+  "dune" {>= "2.7.0"}
+  "mnet" {= version}
+  "tls"
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+synopsis: "An implementation of TLS in OCaml for Miou & Solo5"
+url {
+  src:
+    "https://github.com/robur-coop/mnet/releases/download/v0.0.2/mnet-0.0.2.tbz"
+  checksum: [
+    "sha256=92b1cfec8487423090ed7abedee824ca20db86f1a7af7e308b4118bc0f774e03"
+    "sha512=ce7685c363581121c7d8ae0c33d7dff30ee2dd9dcd29d56f451ac3261b84a91d35a2fa65b31f1f321ddc4b5984e21840459c63614e81ee814f47ac24376bf018"
+  ]
+}
+x-commit-hash: "a36148577823ffbb2e30e5e2d3885490c33e8572"

--- a/packages/mnet/mnet.0.0.2/opam
+++ b/packages/mnet/mnet.0.0.2/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+maintainer: "Robur <team@robur.coop>"
+authors: ["Robur <team@robur.coop>"]
+homepage: "https://github.com/robur-coop/mnet"
+dev-repo: "git+https://github.com/robur-coop/mnet.git"
+bug-reports: "https://github.com/robur-coop/mnet/issues"
+license: "MIT"
+
+depends: [
+  "ocaml" {>= "5.0.0"}
+  "utcp"
+  "dune" {>= "2.7.0"}
+  "bstr" {>= "0.0.4"}
+  "bin"
+  "slice"
+  "mkernel"
+  "mirage-crypto-rng"
+  "duration"
+  "fmt"
+  "ipaddr"
+  "macaddr"
+  "hxd"
+  "tls"
+  "happy-eyeballs"
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+synopsis: "An implementation of TCP (Transmission Control Protocol) in OCaml for Miou & Solo5"
+url {
+  src:
+    "https://github.com/robur-coop/mnet/releases/download/v0.0.2/mnet-0.0.2.tbz"
+  checksum: [
+    "sha256=92b1cfec8487423090ed7abedee824ca20db86f1a7af7e308b4118bc0f774e03"
+    "sha512=ce7685c363581121c7d8ae0c33d7dff30ee2dd9dcd29d56f451ac3261b84a91d35a2fa65b31f1f321ddc4b5984e21840459c63614e81ee814f47ac24376bf018"
+  ]
+}
+x-commit-hash: "a36148577823ffbb2e30e5e2d3885490c33e8572"


### PR DESCRIPTION
An implementation of TCP (Transmission Control Protocol) in OCaml for Miou & Solo5

- Project page: <a href="https://github.com/robur-coop/mnet">https://github.com/robur-coop/mnet</a>

##### CHANGES:

- Improve our unikernel example and our resolver, it's able to take a
  domain-name as an argument (@hannesm, [!14][14])
- Improve our IPv4 routing (@hannes, @reynir, @dinosaure, [!16][16])
- Improve `mnet-cli` and add titles for some options (@dinosaure, [!17][17])
- Catch exceptions when we read on TCP and/or TLS connections for DNS packets
  (@dinosaure, [!18][18])
- Fix how we try to instantiate a connection to nameservers (@dinosaure,
  @hannesm, [!19][19])
- Fix how we push new happy-eyeballs actions (@dinosaure, [!20][20])
- Add options for happy-eyeballs (@dinosaure, [!22][22])
- Fix our `mnet-tls` implementation and pass a flow after its handshake even if
  the flow was closed (on read and write side) (@dinosaure, [!23][23])
- Try to send TCP packets from our TCP timer directly without interruptions
  instead of push it into our queue (@dinosaure, [!24][24])
- Be able to resolve domain-name into our happy-eyeballs implementation
  (@dinosaure, [!25][25])
- Fix our `mnet-dns` implementation:
  + we fix how we read DNS packet from TCP and/or TLS connections
  + we fix how we try to instantiate a new connection to nameservers

  (@dinosaure, [!26][26])

[14]: https://git.robur.coop/robur/mnet/pulls/14
[16]: https://git.robur.coop/robur/mnet/pulls/16
[17]: https://git.robur.coop/robur/mnet/pulls/17
[18]: https://git.robur.coop/robur/mnet/pulls/18
[19]: https://git.robur.coop/robur/mnet/pulls/19
[20]: https://git.robur.coop/robur/mnet/pulls/20
[22]: https://git.robur.coop/robur/mnet/pulls/22
[23]: https://git.robur.coop/robur/mnet/pulls/23
[24]: https://git.robur.coop/robur/mnet/pulls/24
[25]: https://git.robur.coop/robur/mnet/pulls/25
[26]: https://git.robur.coop/robur/mnet/pulls/26
