### PR TITLE
[new release] hurl (0.0.1~beta2)

### DIFF
--- a/packages/hurl/hurl.0.0.1~beta2/opam
+++ b/packages/hurl/hurl.0.0.1~beta2/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+maintainer: "Robur <team@robur.coop>"
+authors: ["Robur <team@robur.coop>"]
+homepage: "https://github.com/robur-coop/hurl"
+dev-repo: "git+https://github.com/robur-coop/hurl.git"
+bug-reports: "https://github.com/robur-coop/hurl/issues"
+license: "BSD-3-clause"
+
+depends: [
+  "ocaml" {>= "5.1.0"}
+  "dune" {>= "2.8.0"}
+  "httpcats" {>= "0.3.0"}
+  "mirage-crypto-rng-miou-unix"
+  "hxd" {>= "0.3.4"}
+  "multipart_form" {>= "0.6.0"}
+  "cmdliner" {>= "1.3.0"}
+  "jsonm"
+  "decompress" {>= "1.5.0"}
+  "bstr" {>= "0.0.2"}
+]
+conflicts: [ "result" {< "1.5"} ]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+run-test: [ "dune" "runtest" "-p" name "-j1" ]
+synopsis: "Hurl, a simple command-line HTTP client"
+x-ci-accept-failures: ["debian-11"]
+url {
+  src:
+    "https://github.com/robur-coop/hurl/releases/download/v0.0.1_beta2/hurl-0.0.1.beta2.tbz"
+  checksum: [
+    "sha256=f83854c1d3ab0174dadb080969cc54db3d44573211090e7301d390a87dc9b1d5"
+    "sha512=f74ea888796fce8a96287df2919bf882fa6b506d63be773a56b0cad1e78bea4b504aee9ef64f3498a1de34775627d1c8b1a0fb7c0ee6e1a0ba1a7a9a32011eb1"
+  ]
+}
+x-commit-hash: "e65aafd37d33e6c5aca4f5601eb673dc166ba8bd"


### PR DESCRIPTION
Hurl, a simple command-line HTTP client

- Project page: <a href="https://github.com/robur-coop/hurl">https://github.com/robur-coop/hurl</a>

##### CHANGES:

- Use `-p` instead of `--printers` (@dinosaure, 1b864f1, d0c7aad)
- Fix `-o` option (spotted by @kit-ty-kate, 4b76377)
- Update with the last version of `httpcats` (@theAlexes, robur-coop/hurl#7)
