### PR TITLE
[new release] mhttp (3 packages) (0.0.2)

### DIFF
--- a/packages/mhttp-client/mhttp-client.0.0.2/opam
+++ b/packages/mhttp-client/mhttp-client.0.0.2/opam
@@ -1,0 +1,32 @@
+opam-version: "2.0"
+maintainer: "Robur <team@robur.coop>"
+authors: ["Robur <team@robur.coop>"]
+homepage: "https://github.com/robur-coop/mhttp"
+dev-repo: "git+https://github.com/robur-coop/mhttp.git"
+bug-reports: "https://github.com/robur-coop/mhttp/issues"
+license: "MIT"
+
+depends: [
+  "ocaml" {>= "5.0.0"}
+  "dune" {>= "2.7.0"}
+  "mhttp" {= version}
+  "mnet-happy-eyeballs"
+  "mirage-ptime" {>= "5.2.0"}
+  "ca-certs-nss" {>= "3.118"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+synopsis: "An implementation of HTTP client in OCaml for unikernels"
+url {
+  src:
+    "https://github.com/robur-coop/mhttp/releases/download/v0.0.2/mhttp-0.0.2.tbz"
+  checksum: [
+    "sha256=205d0b35a69172dbf97f6ff7c7e437436d157235a5bfb42cf550f57d1e9f9679"
+    "sha512=48e37fe6a1b7a09035798ec32e9f154837b797beb4112b50f75abfad3bc0fa4e4478394a74c71db115a151e16e2cc2d03a7d2e29d6e463172e3787ae100fc524"
+  ]
+}
+x-commit-hash: "64a6151fba8b9de0a676a65e55129fdd1c12735d"

--- a/packages/mhttp-server/mhttp-server.0.0.2/opam
+++ b/packages/mhttp-server/mhttp-server.0.0.2/opam
@@ -1,0 +1,30 @@
+opam-version: "2.0"
+maintainer: "Robur <team@robur.coop>"
+authors: ["Robur <team@robur.coop>"]
+homepage: "https://github.com/robur-coop/mhttp"
+dev-repo: "git+https://github.com/robur-coop/mhttp.git"
+bug-reports: "https://github.com/robur-coop/mhttp/issues"
+license: "MIT"
+
+depends: [
+  "ocaml" {>= "5.0.0"}
+  "dune" {>= "2.7.0"}
+  "mhttp" {= version}
+  "mnet-tls"
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+synopsis: "An implementation of an HTTP server in OCaml for unikernels"
+url {
+  src:
+    "https://github.com/robur-coop/mhttp/releases/download/v0.0.2/mhttp-0.0.2.tbz"
+  checksum: [
+    "sha256=205d0b35a69172dbf97f6ff7c7e437436d157235a5bfb42cf550f57d1e9f9679"
+    "sha512=48e37fe6a1b7a09035798ec32e9f154837b797beb4112b50f75abfad3bc0fa4e4478394a74c71db115a151e16e2cc2d03a7d2e29d6e463172e3787ae100fc524"
+  ]
+}
+x-commit-hash: "64a6151fba8b9de0a676a65e55129fdd1c12735d"

--- a/packages/mhttp/mhttp.0.0.2/opam
+++ b/packages/mhttp/mhttp.0.0.2/opam
@@ -1,0 +1,32 @@
+opam-version: "2.0"
+maintainer: "Robur <team@robur.coop>"
+authors: ["Robur <team@robur.coop>"]
+homepage: "https://github.com/robur-coop/mhttp"
+dev-repo: "git+https://github.com/robur-coop/mhttp.git"
+bug-reports: "https://github.com/robur-coop/mhttp/issues"
+license: "MIT"
+
+depends: [
+  "ocaml" {>= "5.0.0"}
+  "dune" {>= "2.7.0"}
+  "mnet"
+  "mnet-tls"
+  "mirage-crypto-rng"
+  "httpcats" {>= "0.3.0"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+synopsis: "An implementation of HTTP in OCaml for unikernels"
+url {
+  src:
+    "https://github.com/robur-coop/mhttp/releases/download/v0.0.2/mhttp-0.0.2.tbz"
+  checksum: [
+    "sha256=205d0b35a69172dbf97f6ff7c7e437436d157235a5bfb42cf550f57d1e9f9679"
+    "sha512=48e37fe6a1b7a09035798ec32e9f154837b797beb4112b50f75abfad3bc0fa4e4478394a74c71db115a151e16e2cc2d03a7d2e29d6e463172e3787ae100fc524"
+  ]
+}
+x-commit-hash: "64a6151fba8b9de0a676a65e55129fdd1c12735d"


### PR DESCRIPTION
An implementation of HTTP in OCaml for unikernels

- Project page: <a href="https://github.com/robur-coop/mhttp">https://github.com/robur-coop/mhttp</a>

##### CHANGES:

- Improve our `mhttp` implementation with the new version of `mnet` and
  `ocaml-h2` (@dinosaure, robur-coop/mhttp#2)
- Use the latest version of `httpcats` (@dinosaure, robur-coop/mhttp#3)
