### PR TITLE
[new release] mirage (2 packages) (4.11.0)

### DIFF
--- a/packages/mirage-runtime/mirage-runtime.4.11.0/opam
+++ b/packages/mirage-runtime/mirage-runtime.4.11.0/opam
@@ -1,0 +1,46 @@
+opam-version: "2.0"
+maintainer:   ["anil@recoil.org" "thomas@gazagnaire.org"]
+authors:      ["Thomas Gazagnaire" "Anil Madhavapeddy" "Gabriel Radanne"
+               "Mindy Preston" "Thomas Leonard" "Nicolas Ojeda Bar"
+               "Dave Scott" "David Kaloper" "Hannes Mehnert" "Richard Mortier"]
+homepage:     "https://github.com/mirage/mirage"
+bug-reports:  "https://github.com/mirage/mirage/issues/"
+dev-repo:     "git+https://github.com/mirage/mirage.git"
+license:      "ISC"
+tags:         ["org:mirage" "org:xapi-project"]
+doc:          "https://mirage.github.io/mirage/"
+available: opam-version >= "2.1.0"
+
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+depends: [
+  "ocaml" {>= "4.13.0"}
+  "dune" {>= "2.9.0"}
+  "logs" {>= "0.7.0"}
+  "lwt" {>= "4.0.0"}
+  "dune" {>= "3.22"} | "lwt" {< "6"}
+  "ipaddr" {>= "5.5.0"}
+  "cmdliner" {>= "1.2.0"}
+]
+conflicts: [
+  "result" {< "1.5"}
+  "ppxlib" {= "0.29.0"} #0.29.0 provides a vendored ppx_sexp_conv
+]
+synopsis: "The base MirageOS runtime library, part of every MirageOS unikernel"
+description: """
+A bundle of useful runtime functions for applications built with MirageOS
+"""
+x-maintenance-intent: [ "(latest)" ]
+url {
+  src:
+    "https://github.com/mirage/mirage/releases/download/v4.11.0/mirage-4.11.0.tbz"
+  checksum: [
+    "sha256=18a84ddf9d210745d8b6e9cb2cbb8ce3cb696e2898a54749027e9d85992bfe5c"
+    "sha512=d7cca5ae480fc7ee8c4db28c70d2868c2bc95075796c177df442f10883e1777ba3e51d248bd2feeffbc3b0cbe99d77bc61e62d794102c469cc646f63e4b65dcb"
+  ]
+}
+x-commit-hash: "4a4b3978e789cb7f7710059d2d3456a68c3d85a9"

--- a/packages/mirage/mirage.4.11.0/opam
+++ b/packages/mirage/mirage.4.11.0/opam
@@ -19,6 +19,7 @@ build: [
 
 depends: [
   "ocaml" {>= "4.13.0"}
+  "ocaml" {with-test & < "5"}
   "dune" {>= "2.9.0"}
   "astring"
   "cmdliner" {>= "2.0.0"}

--- a/packages/mirage/mirage.4.11.0/opam
+++ b/packages/mirage/mirage.4.11.0/opam
@@ -1,0 +1,64 @@
+opam-version: "2.0"
+maintainer:   ["anil@recoil.org" "thomas@gazagnaire.org"]
+authors:      ["Thomas Gazagnaire" "Anil Madhavapeddy" "Gabriel Radanne"
+               "Mindy Preston" "Thomas Leonard" "Nicolas Ojeda Bar"
+               "Dave Scott" "David Kaloper" "Hannes Mehnert" "Richard Mortier"]
+homepage:     "https://github.com/mirage/mirage"
+bug-reports:  "https://github.com/mirage/mirage/issues/"
+dev-repo:     "git+https://github.com/mirage/mirage.git"
+license:      "ISC"
+tags:         ["org:mirage" "org:xapi-project"]
+doc:          "https://mirage.github.io/mirage/"
+available: opam-version >= "2.1.0"
+
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+depends: [
+  "ocaml" {>= "4.13.0"}
+  "dune" {>= "2.9.0"}
+  "astring"
+  "cmdliner" {>= "2.0.0"}
+  "emile" {>= "1.1"}
+  "fmt" {>= "0.8.7"}
+  "ipaddr" {>= "5.0.0"}
+  "bos"
+  "fpath"
+  "rresult" {>= "0.7.0"}
+  "uri" {>= "4.2.0"}
+  "logs" {>= "0.7.0"}
+  "opam-monorepo" {>= "0.4.0"}
+  "alcotest" {with-test}
+  "mirage-runtime" {with-test & = version}
+  "dune" {with-test & != "3.20.0" & != "3.20.1"}
+]
+
+conflicts: [ "jbuilder" {with-test} ]
+
+synopsis: "The MirageOS library operating system"
+description: """
+MirageOS is a library operating system that constructs unikernels for
+secure, high-performance network applications across a variety of
+cloud computing and mobile platforms. Code can be developed on a
+normal OS such as Linux or MacOS X, and then compiled into a
+fully-standalone, specialised unikernel that runs under the Xen
+or KVM (or FreeBSD BHyve or OpenBSD VMM) hypervisor. It also runs
+on the Muen separation kernel.
+
+Since Xen powers most public cloud computing infrastructure such as
+Amazon EC2 or Rackspace, this lets your servers run more cheaply,
+securely and with finer control than with a full software stack.
+"""
+x-maintenance-intent: [ "(latest)" ]
+url {
+  src:
+    "https://github.com/mirage/mirage/releases/download/v4.11.0/mirage-4.11.0.tbz"
+  checksum: [
+    "sha256=18a84ddf9d210745d8b6e9cb2cbb8ce3cb696e2898a54749027e9d85992bfe5c"
+    "sha512=d7cca5ae480fc7ee8c4db28c70d2868c2bc95075796c177df442f10883e1777ba3e51d248bd2feeffbc3b0cbe99d77bc61e62d794102c469cc646f63e4b65dcb"
+  ]
+}
+x-commit-hash: "4a4b3978e789cb7f7710059d2d3456a68c3d85a9"


### PR DESCRIPTION
The MirageOS library operating system

- Project page: <a href="https://github.com/mirage/mirage">https://github.com/mirage/mirage</a>
- Documentation: <a href="https://mirage.github.io/mirage/">https://mirage.github.io/mirage/</a>

##### CHANGES:

- Introduce a "--utcp" configuration-time flag (and "--management-utcp")
  (mirage/mirage#1636 @hannesm @palainp)
- BREAKING: the "--dhcp" configuration-time argument is now a flag "--no-dhcp"
  (and "--management-no-dhcp") (mirage/mirage#1636 @hannesm)
- Mirage.{direct_tcp, direct_stackv4v6, generic_stackv4v6,
  generic_stackv4v6_with_lease}: remove ?tcp argument (mirage/mirage#1636 @hannesm)
- Mirage.direct_tcp has an optional ?group argument now (mirage/mirage#1636 @hannesm)
- Mirage.{generic_stackv4v6, generic_stackv4v6_with_lease}: remove ?dhcp_key
  and ?net_key argument, they are now always constructed (mirage/mirage#1636 @hannesm)
- BREAKING: remove deprecated Mirage_runtime.register (mirage/mirage#1638 @hannesm)
- BREAKING: use "-" instead of "_" in DNS and happy eyeballs boot arguments:
  dns-servers (was dns_servers),
  dns-timeout (was dns_timeout),
  dns-cache-size (was dns_cache_size),
  he-aaaa-timeout (was he_aaaa_timeout),
  he-connect-delay (was he_connect_delay),
  he-connect-timeout (was he_connect_timeout),
  he-resolve-timeout (was he_resolve_timeout),
  he-resolve-retries (was he_resolve_retries),
  he-timer-interval (was he_timer_interval)
  (mirage/mirage#1638 @hannesm)
