### PR TITLE
Add package name for `jq` on OpenBSD

### DIFF
--- a/packages/conf-jq/conf-jq.1/opam
+++ b/packages/conf-jq/conf-jq.1/opam
@@ -16,6 +16,7 @@ depexts: [
   ["jq"] {os-distribution = "ol"}
   ["jq"] {os-distribution = "arch"}
   ["jq"] {os = "freebsd"}
+  ["textproc/jq"] {os = "openbsd"}
   ["jq"] {os = "macos" & os-distribution = "homebrew"}
   ["system:jq"] {os = "win32" & os-distribution = "cygwinports"}
   ["jq"] {os-distribution = "cygwin"}


### PR DESCRIPTION
While working on odoc in https://github.com/ocaml/odoc/pull/1422 I noticed that the OpenBSD build is failing on `jq` not being installable. `jq` being a fairly common package should have a port in OpenBSD and it turns out it does. This PR extends the `conf-jq` package accordingly.

Package name source from from https://openports.pl/path/textproc/jq