### PR TITLE
Fix port name of GNU Guile on OpenBSD, RHEL

### DIFF
--- a/packages/conf-guile/conf-guile.1/opam
+++ b/packages/conf-guile/conf-guile.1/opam
@@ -16,8 +16,8 @@ depexts: [
   ["guile-3.0-dev"] {os-family = "debian" | os-family = "ubuntu"}
   ["guile3"] {os = "freebsd"}
   ["lang/guile3"] {os = "openbsd"}
-  ["guile-devel"] {os-distribution = "centos"}
-  ["guile-devel"] {os-distribution = "rhel"}
+  ["guile30-devel"] {os-distribution = "centos"}
+  ["guile30-devel"] {os-distribution = "rhel"}
   ["guile30-devel"] {os-family = "fedora"}
   ["guile-devel"] {os-distribution = "ol"}
   ["guile-dev"] {os-distribution = "alpine"}

--- a/packages/conf-guile/conf-guile.1/opam
+++ b/packages/conf-guile/conf-guile.1/opam
@@ -15,7 +15,7 @@ bug-reports: "https://github.com/ocaml/opam-repository/issues"
 depexts: [
   ["guile-3.0-dev"] {os-family = "debian" | os-family = "ubuntu"}
   ["guile3"] {os = "freebsd"}
-  ["database/guile"] {os = "openbsd"}
+  ["lang/guile3"] {os = "openbsd"}
   ["guile-devel"] {os-distribution = "centos"}
   ["guile-devel"] {os-distribution = "rhel"}
   ["guile30-devel"] {os-family = "fedora"}


### PR DESCRIPTION
While looking on how to specify depexts on OpenBSD in #29871 I noticed that the guile package on OpenBSD is in a strange category, `database` (bit weird for it to be there and the category seems to be named `databases` in any case). 

The ports have [Guile 1.8.8](https://openports.pl/path/lang/guile), [Guile 2.2.7](https://openports.pl/path/lang/guile2) and [Guile 3.0.9](https://openports.pl/path/lang/guile3). This package requires Guile 3, so that's what I picked.