### PR TITLE
[new release] vif (2 packages) (0.0.1~beta3)

### DIFF
--- a/packages/vif/vif.0.0.1~beta3/opam
+++ b/packages/vif/vif.0.0.1~beta3/opam
@@ -1,0 +1,56 @@
+opam-version: "2.0"
+maintainer: "Robur <team@robur.coop>"
+authors: ["Robur <team@robur.coop>"]
+homepage: "https://github.com/robur-coop/vif"
+dev-repo: "git+https://github.com/robur-coop/vif.git"
+bug-reports: "https://github.com/robur-coop/vif/issues"
+license: "MIT"
+
+depends: [
+  "ocaml" {>= "5.3.0"}
+  "dune" {>= "3.0.0"}
+  "uri" {>= "4.4.0"}
+  "fmt" {>= "0.11.0"}
+  "bos" {>= "0.2.1"}
+  "logs" {>= "0.9.0"}
+  "fpath" {>= "0.7.3"}
+  "bytesrw"
+  "flux" {>= "0.0.1~beta5"}
+  "fluxt" {>= "0.0.1~beta2"}
+  "jsont" {>= "0.2.0"}
+  "cmdliner" {>= "1.3.0"}
+  "httpcats" {>= "0.3.0"}
+  "tyre" {>= "1.0"}
+  "mirage-crypto-rng-miou-unix"
+  "decompress" {>= "1.5.0"}
+  "conan-unix" {>= "0.0.6"}
+  "conan-database"
+  "multipart_form-miou"
+  "hmap"
+  "tyxml" {>= "4.6.0"}
+  "hurl" {>= "0.0.1~beta2" & with-test}
+  "jws" {with-test}
+  "caqti" {with-test & >= "2.3.0"}
+  "caqti-miou" {with-test}
+  "caqti-driver-sqlite3" {with-test}
+  "brr" {with-test}
+]
+conflicts: [ "result" {< "1.5"} ]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+run-test: [
+  [ "dune" "runtest" "-p" name "-j1" ] {arch != "s390x"}
+]
+synopsis: "A simple web framework for OCaml 5"
+x-ci-accept-failures: ["debian-11"]
+url {
+  src:
+    "https://github.com/robur-coop/vif/releases/download/v0.0.1_beta3/vif-0.0.1.beta3.tbz"
+  checksum: [
+    "sha256=4da176d4f20bc5d2dc6f8960ece626c7815f5281680bbf99af3487bbb4419c2c"
+    "sha512=e225e6b977f92a243e900b4b6a728ef07b9469e17557c21457fe24e21c06be9bb176bc5f5847df64c702efb8f86538a0dac7bde09d8a68193c348aa3eec62748"
+  ]
+}
+x-commit-hash: "96b70a39d6a455ef8a290a515e275f4ce0f51c40"

--- a/packages/vifu/vifu.0.0.1~beta3/opam
+++ b/packages/vifu/vifu.0.0.1~beta3/opam
@@ -1,0 +1,35 @@
+opam-version: "2.0"
+maintainer: "Robur <team@robur.coop>"
+authors: ["Robur <team@robur.coop>"]
+homepage: "https://github.com/robur-coop/vif"
+dev-repo: "git+https://github.com/robur-coop/vif.git"
+bug-reports: "https://github.com/robur-coop/vif/issues"
+license: "MIT"
+
+depends: [
+  "ocaml" {>= "5.3.0"}
+  "dune" {>= "3.0.0"}
+  "vif" {= version}
+  "mhttp" {>= "0.0.2"}
+  "mhttp-server"
+  "mirage-crypto-rng-mkernel"
+]
+conflicts: [ "result" {< "1.5"} ]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+run-test: [
+  [ "dune" "runtest" "-p" name "-j1" ] {arch != "s390x"}
+]
+synopsis: "A simple web framework for OCaml 5"
+x-ci-accept-failures: ["debian-11"]
+url {
+  src:
+    "https://github.com/robur-coop/vif/releases/download/v0.0.1_beta3/vif-0.0.1.beta3.tbz"
+  checksum: [
+    "sha256=4da176d4f20bc5d2dc6f8960ece626c7815f5281680bbf99af3487bbb4419c2c"
+    "sha512=e225e6b977f92a243e900b4b6a728ef07b9469e17557c21457fe24e21c06be9bb176bc5f5847df64c702efb8f86538a0dac7bde09d8a68193c348aa3eec62748"
+  ]
+}
+x-commit-hash: "96b70a39d6a455ef8a290a515e275f4ce0f51c40"


### PR DESCRIPTION
A simple web framework for OCaml 5

- Project page: <a href="https://github.com/robur-coop/vif">https://github.com/robur-coop/vif</a>

##### CHANGES:

- Delete `mirage-crypto-rng-miou-unix` dependency for `vif.core`\
  (@dinosaure, 3fb86c5)
- Improve performances, when we handle requests without body, we executed them
  directly instead of transferring the handler into a new domain
  (@dinosaure, robur-coop/vif#25, [!51][51])
- Catch exceptions raised by `jsont` (@dinosaure, [!52][52])
- Use `jws` instead of `jwto` (@dinosaure, [!53][53])
- Handle TLS flow with `vifu` (@dinosaure, [!54][54])
- Expose `Vifu.Uri.{execp,extract}` (@swrup, robur-coop/vif#26)
- Use `Flux.Source.with_buffered_formatter` (instead of `with_formatter`)
  (@reynir, [!55][55])
- Fix the compilation with `caqti.2.3.0` (@dinosaure, [!57][57])
- Get ride of `rresult` (@reynir, [!58][58])
- Depends on `flux.0.0.1~beta5` (@reynir, [!59][59])
- Be able to stop a Vif server (as we do for `httpcats`)
  (@theAlexes, @dinosaure, robur-coop/vif#29)
- Be able to specify a UNIX domain socket as our listener for our webserver
  (@theAlexes, @dinosaure, @reynir, robur-coop/vif#30, robur-coop/vif#31)
- Use `httpcats.0.3.0` and shutdown our connection at the end
  (@dinosaure, [!60][60])
- Add `OPTIONS` method for our routes (@voodoos, robur-coop/vif#33)
- Revert [!60][60] and fix unexpected closed connection (see robur-coop/vif#32) and when we
  would like to transmit big file ([!61][61], spotted by @voodoos, @dinosaure,
  @theAlexes)
- Don't emit `application/octet-stream` for unrecognized files
  (spotted by @n-osborne, @dinosaure, robur-coop/vif#27, robur-coop/vif#28)

[51]: https://git.robur.coop/robur/vif/pulls/51
[52]: https://git.robur.coop/robur/vif/pulls/52
[53]: https://git.robur.coop/robur/vif/pulls/53
[54]: https://git.robur.coop/robur/vif/pulls/54
[55]: https://git.robur.coop/robur/vif/pulls/55
[57]: https://git.robur.coop/robur/vif/pulls/57
[58]: https://git.robur.coop/robur/vif/pulls/58
[59]: https://git.robur.coop/robur/vif/pulls/59
[60]: https://git.robur.coop/robur/vif/pulls/60
[61]: https://git.robur.coop/robur/vif/pulls/61
