### PR TITLE
5 packages from mbarbin/cmdlang at 0.0.11

### DIFF
--- a/packages/cmdlang-stdlib-runner/cmdlang-stdlib-runner.0.0.11/opam
+++ b/packages/cmdlang-stdlib-runner/cmdlang-stdlib-runner.0.0.11/opam
@@ -1,0 +1,53 @@
+opam-version: "2.0"
+synopsis: "A basic execution runner for cmdlang based on stdlib.arg"
+maintainer: ["Mathieu Barbin <opensource@mbarbin.org>"]
+authors: ["Mathieu Barbin"]
+license: "MIT"
+homepage: "https://github.com/mbarbin/cmdlang"
+doc: "https://mbarbin.github.io/cmdlang/"
+bug-reports: "https://github.com/mbarbin/cmdlang/issues"
+depends: [
+  "dune" {>= "3.17"}
+  "ocaml" {>= "4.14"}
+  "cmdlang" {= version}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/mbarbin/cmdlang.git"
+description: """\
+
+[Cmdlang_stdlib_runner] is an execution engine for running command
+line programs specified with [cmdlang].
+
+It has no dependencies other than [cmdlang] and is implemented using
+the [Arg] module from the OCaml standard library.
+
+This package may be useful as a lightweight alternative to translating
+cmdlang parsers to more feature-rich libraries such as [cmdliner],
+[climate], or [core.command].
+
+"""
+tags: [ "cli" "cmdlang" "stdlib.arg" ]
+x-maintenance-intent: [ "(latest)" ]
+url {
+  src:
+    "https://github.com/mbarbin/cmdlang/releases/download/0.0.11/cmdlang-0.0.11.tbz"
+  checksum: [
+    "sha256=818cf017d4889b49121f36edf6c77b955105c2b2a79405592c5a51495cfbae4b"
+    "sha512=1179129fd7c65cb1767db5b7e2d2069454be8e16c0e9f010754b41b8af25e6e361ef5f0c3204fe7ee94e605cfdc3b406c41680664705dea53b488a3f727bcc2e"
+  ]
+}
+x-commit-hash: "5be4762e67cbb4c5c2e36fb8ea416407c8d27166"

--- a/packages/cmdlang-to-base/cmdlang-to-base.0.0.11/opam
+++ b/packages/cmdlang-to-base/cmdlang-to-base.0.0.11/opam
@@ -1,0 +1,50 @@
+opam-version: "2.0"
+synopsis: "Convert cmdlang Parsers to core.command"
+maintainer: ["Mathieu Barbin <opensource@mbarbin.org>"]
+authors: ["Mathieu Barbin"]
+license: "MIT"
+homepage: "https://github.com/mbarbin/cmdlang"
+doc: "https://mbarbin.github.io/cmdlang/"
+bug-reports: "https://github.com/mbarbin/cmdlang/issues"
+depends: [
+  "dune" {>= "3.17"}
+  "ocaml" {>= "5.2"}
+  "base" {>= "v0.17"}
+  "cmdlang" {= version}
+  "core" {>= "v0.17"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/mbarbin/cmdlang.git"
+description: """\
+
+[Cmdlang_to_base] allows translating command line programs specified
+with [cmdlang] into [core.command] commands suitable for execution.
+
+[core.command]: https://github.com/janestreet/core
+
+"""
+tags: [ "cli" "cmdlang" "core.command" ]
+x-maintenance-intent: [ "(latest)" ]
+url {
+  src:
+    "https://github.com/mbarbin/cmdlang/releases/download/0.0.11/cmdlang-0.0.11.tbz"
+  checksum: [
+    "sha256=818cf017d4889b49121f36edf6c77b955105c2b2a79405592c5a51495cfbae4b"
+    "sha512=1179129fd7c65cb1767db5b7e2d2069454be8e16c0e9f010754b41b8af25e6e361ef5f0c3204fe7ee94e605cfdc3b406c41680664705dea53b488a3f727bcc2e"
+  ]
+}
+x-commit-hash: "5be4762e67cbb4c5c2e36fb8ea416407c8d27166"

--- a/packages/cmdlang-to-climate/cmdlang-to-climate.0.0.11/opam
+++ b/packages/cmdlang-to-climate/cmdlang-to-climate.0.0.11/opam
@@ -1,0 +1,50 @@
+opam-version: "2.0"
+synopsis: "Convert cmdlang Parsers to climate"
+maintainer: ["Mathieu Barbin <opensource@mbarbin.org>"]
+authors: ["Mathieu Barbin"]
+license: "MIT"
+homepage: "https://github.com/mbarbin/cmdlang"
+doc: "https://mbarbin.github.io/cmdlang/"
+bug-reports: "https://github.com/mbarbin/cmdlang/issues"
+depends: [
+  "dune" {>= "3.17"}
+  "ocaml" {>= "4.14"}
+  "climate" {>= "0.8.0"}
+  "cmdlang" {= version}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/mbarbin/cmdlang.git"
+description: """\
+
+[Cmdlang_to_climate] allows translating command line programs
+specified with [cmdlang] into [climate] commands suitable for
+execution.
+
+[climate]: https://github.com/gridbugs/climate
+
+"""
+tags: [ "cli" "cmdlang" "climate" ]
+x-maintenance-intent: [ "(latest)" ]
+url {
+  src:
+    "https://github.com/mbarbin/cmdlang/releases/download/0.0.11/cmdlang-0.0.11.tbz"
+  checksum: [
+    "sha256=818cf017d4889b49121f36edf6c77b955105c2b2a79405592c5a51495cfbae4b"
+    "sha512=1179129fd7c65cb1767db5b7e2d2069454be8e16c0e9f010754b41b8af25e6e361ef5f0c3204fe7ee94e605cfdc3b406c41680664705dea53b488a3f727bcc2e"
+  ]
+}
+x-commit-hash: "5be4762e67cbb4c5c2e36fb8ea416407c8d27166"

--- a/packages/cmdlang-to-cmdliner/cmdlang-to-cmdliner.0.0.11/opam
+++ b/packages/cmdlang-to-cmdliner/cmdlang-to-cmdliner.0.0.11/opam
@@ -1,0 +1,50 @@
+opam-version: "2.0"
+synopsis: "Convert cmdlang Parsers to cmdliner"
+maintainer: ["Mathieu Barbin <opensource@mbarbin.org>"]
+authors: ["Mathieu Barbin"]
+license: "MIT"
+homepage: "https://github.com/mbarbin/cmdlang"
+doc: "https://mbarbin.github.io/cmdlang/"
+bug-reports: "https://github.com/mbarbin/cmdlang/issues"
+depends: [
+  "dune" {>= "3.17"}
+  "ocaml" {>= "4.14"}
+  "cmdlang" {= version}
+  "cmdliner" {>= "1.3.0"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/mbarbin/cmdlang.git"
+description: """\
+
+[Cmdlang_to_cmdliner] allows translating command line programs
+specified with [cmdlang] into [cmdliner] commands suitable for
+execution.
+
+[cmdliner]: https://github.com/dbuenzli/cmdliner
+
+"""
+tags: [ "cli" "cmdlang" "cmdliner" ]
+x-maintenance-intent: [ "(latest)" ]
+url {
+  src:
+    "https://github.com/mbarbin/cmdlang/releases/download/0.0.11/cmdlang-0.0.11.tbz"
+  checksum: [
+    "sha256=818cf017d4889b49121f36edf6c77b955105c2b2a79405592c5a51495cfbae4b"
+    "sha512=1179129fd7c65cb1767db5b7e2d2069454be8e16c0e9f010754b41b8af25e6e361ef5f0c3204fe7ee94e605cfdc3b406c41680664705dea53b488a3f727bcc2e"
+  ]
+}
+x-commit-hash: "5be4762e67cbb4c5c2e36fb8ea416407c8d27166"

--- a/packages/cmdlang/cmdlang.0.0.11/opam
+++ b/packages/cmdlang/cmdlang.0.0.11/opam
@@ -1,0 +1,54 @@
+opam-version: "2.0"
+synopsis: "Declarative Command-line Parsing for OCaml"
+maintainer: ["Mathieu Barbin <opensource@mbarbin.org>"]
+authors: ["Mathieu Barbin"]
+license: "MIT"
+homepage: "https://github.com/mbarbin/cmdlang"
+doc: "https://mbarbin.github.io/cmdlang/"
+bug-reports: "https://github.com/mbarbin/cmdlang/issues"
+depends: [
+  "dune" {>= "3.17"}
+  "ocaml" {>= "4.14"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/mbarbin/cmdlang.git"
+description: """\
+
+Cmdlang is a library for creating command-line parsers in OCaml.
+Implemented as an OCaml EDSL, its declarative specification language
+lives at the intersection of other well-established similar libraries.
+
+Cmdlang doesn't include an execution engine. Instead, Cmdlang parsers
+are automatically translated to [cmdliner], [core.command], or
+[climate] commands for execution.
+
+[cmdliner]: https://github.com/dbuenzli/cmdliner
+[climate]: https://github.com/gridbugs/climate
+[core.command]: https://github.com/janestreet/core
+
+"""
+tags: [ "cli" ]
+x-maintenance-intent: [ "(latest)" ]
+url {
+  src:
+    "https://github.com/mbarbin/cmdlang/releases/download/0.0.11/cmdlang-0.0.11.tbz"
+  checksum: [
+    "sha256=818cf017d4889b49121f36edf6c77b955105c2b2a79405592c5a51495cfbae4b"
+    "sha512=1179129fd7c65cb1767db5b7e2d2069454be8e16c0e9f010754b41b8af25e6e361ef5f0c3204fe7ee94e605cfdc3b406c41680664705dea53b488a3f727bcc2e"
+  ]
+}
+x-commit-hash: "5be4762e67cbb4c5c2e36fb8ea416407c8d27166"


### PR DESCRIPTION
This pull-request concerns:
- `cmdlang.0.0.11`: Declarative Command-line Parsing for OCaml
- `cmdlang-stdlib-runner.0.0.11`: A basic execution runner for cmdlang based on stdlib.arg
- `cmdlang-to-base.0.0.11`: Convert cmdlang Parsers to core.command
- `cmdlang-to-climate.0.0.11`: Convert cmdlang Parsers to climate
- `cmdlang-to-cmdliner.0.0.11`: Convert cmdlang Parsers to cmdliner



---
* Homepage: https://github.com/mbarbin/cmdlang
* Source repo: git+https://github.com/mbarbin/cmdlang.git
* Bug tracker: https://github.com/mbarbin/cmdlang/issues

---
## 0.0.11 (2026-05-08)

### Added

- Enabled OCaml 5.4 and 5.5 in CI ([#56](https://github.com/mbarbin/cmdlang/pull/56), 44fcd89, @mbarbin).

### Changed

- Simplify type definition of `Nonempty_list` to align it with other libs ([#54](https://github.com/mbarbin/cmdlang/pull/54), @mbarbin).
- Upgrade `ocamlformat` to `0.29.0` (@mbarbin).
- Improve `headache` configuration (@mbarbin).
- Upgrade `dunolint` and `crs` actions ([#41](https://github.com/mbarbin/cmdlang/pull/41), [#42](https://github.com/mbarbin/cmdlang/pull/42), [#51](https://github.com/mbarbin/cmdlang/pull/51), @mbarbin).
- Improvement to CI ([#34](https://github.com/mbarbin/cmdlang/pull/34), [#35](https://github.com/mbarbin/cmdlang/pull/35), [#44](https://github.com/mbarbin/cmdlang/pull/44), [#45](https://github.com/mbarbin/cmdlang/pull/45), [#46](https://github.com/mbarbin/cmdlang/pull/46), [#50](https://github.com/mbarbin/cmdlang/pull/50), @mbarbin).
- Use and enforce SHA pins in GitHub actions (@mbarbin).
- Improve selection of packages to build in CIs ([#43](https://github.com/mbarbin/cmdlang/pull/43), @mbarbin).
- Improve project pkg directory structure ([#40](https://github.com/mbarbin/cmdlang/pull/40), @mbarbin).

### Deprecated

- Deprecate `Param.create` and migrate it to `create_with_pp` ([#55](https://github.com/mbarbin/cmdlang/pull/55), @mbarbin).

### Fixed

- Fixes to satisfy the `unused-libs` dune build target ([#52](https://github.com/mbarbin/cmdlang/pull/52), @mbarbin).

### Removed

- Simplify and removed some unused or non-essential deps ([#57](https://github.com/mbarbin/cmdlang/pull/57), [#58](https://github.com/mbarbin/cmdlang/pull/58), @mbarbin).


---
:camel: Pull-request generated by opam-publish v3.0.0