### PR TITLE
Package ocaml_intrinsics_kernel.v0.17.2

### DIFF
--- a/packages/ocaml_intrinsics_kernel/ocaml_intrinsics_kernel.v0.17.2/opam
+++ b/packages/ocaml_intrinsics_kernel/ocaml_intrinsics_kernel.v0.17.2/opam
@@ -1,0 +1,30 @@
+opam-version: "2.0"
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
+homepage: "https://github.com/janestreet/ocaml_intrinsics_kernel"
+bug-reports: "https://github.com/janestreet/ocaml_intrinsics_kernel/issues"
+dev-repo: "git+https://github.com/janestreet/ocaml_intrinsics_kernel.git"
+doc: "https://ocaml.janestreet.com/ocaml-core/latest/doc/ocaml_intrinsics_kernel/index.html"
+license: "MIT"
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "ocaml" {>= "5.1.0"}
+  "dune" {>= "3.11.0"}
+]
+available: arch != "arm32" & arch != "x86_32"
+synopsis: "Intrinsics"
+description: "
+Provides functions to invoke amd64 instructions (such as cmov, min/maxsd, popcnt)
+     when available, or compatible software implementation on other targets.
+     See also ocaml_intrinsics library.
+"
+url {
+  src:
+    "https://github.com/janestreet/ocaml_intrinsics_kernel/archive/refs/tags/v0.17.2.tar.gz"
+  checksum: [
+    "md5=94d4734d6844417053e93ef0e3b26e33"
+    "sha512=21397340656d9fbe8dc079d5772bb4ca3e9c8c9c235fe2bddbbabe75fff7d38afc95f10d16f71ad0ab67f9e6fcb4ce08bece8b56cb2b37904c7210c45aa44bb5"
+  ]
+}


### PR DESCRIPTION
### `ocaml_intrinsics_kernel.v0.17.2`
Intrinsics
Provides functions to invoke amd64 instructions (such as cmov, min/maxsd, popcnt)
     when available, or compatible software implementation on other targets.
     See also ocaml_intrinsics library.



---
* Homepage: https://github.com/janestreet/ocaml_intrinsics_kernel
* Source repo: git+https://github.com/janestreet/ocaml_intrinsics_kernel.git
* Bug tracker: https://github.com/janestreet/ocaml_intrinsics_kernel/issues

---
:camel: Pull-request generated by opam-publish v3.0.0