### PR TITLE
[new release] lstar-rocq (1.0)

### DIFF
--- a/packages/lstar-rocq/lstar-rocq.1.0/opam
+++ b/packages/lstar-rocq/lstar-rocq.1.0/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+synopsis: "Formally-verified L* implemented in Rocq"
+description: "A formally-verified implementation of the L* algorithm in Rocq"
+maintainer: ["Charles Averill <charlesaverill20@gmail.com>"]
+authors: ["Charles Averill <charlesaverill20@gmail.com>"]
+license: "MIT"
+homepage: "https://github.com/CharlesAverill/lstar-rocq"
+doc: "https://github.com/CharlesAverill/lstar-rocq"
+bug-reports: "https://github.com/CharlesAverill/lstar-rocq/issues"
+depends: [
+  "dune" {>= "3.21" & >= "3.21.0"}
+  "rocq-prover" {>= "9.1.0"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/CharlesAverill/lstar-rocq.git"
+x-maintenance-intent: ["(latest)"]
+url {
+  src:
+    "https://github.com/CharlesAverill/lstar-rocq/releases/download/v1.0/lstar-rocq-1.0.tbz"
+  checksum: [
+    "sha256=dc824d8b7c09a89fb4d084e90741be70e99ebc8df595f0a2ac3a66c27a32457d"
+    "sha512=31584b33c6bbc5922a7d05fff147dbb5ad71c7773cc01e638a64cf3bcb3e2a978e7add95313d5073fcd6a382b7c0f8d7927c8ffe5c8787c842f774f5790d31b2"
+  ]
+}
+x-commit-hash: "6e5b8aa62db15829c40cdb4c265b46017fb5d2c5"


### PR DESCRIPTION
Formally-verified L* implemented in Rocq

- Project page: <a href="https://github.com/CharlesAverill/lstar-rocq">https://github.com/CharlesAverill/lstar-rocq</a>
- Documentation: <a href="https://github.com/CharlesAverill/lstar-rocq">https://github.com/CharlesAverill/lstar-rocq</a>

##### CHANGES:

Initial release
