### PR TITLE
release Camlp5 8.04.01 w/bugfixes for labeled tuple support

### DIFF
--- a/packages/camlp5/camlp5.8.04.01/opam
+++ b/packages/camlp5/camlp5.8.04.01/opam
@@ -1,0 +1,72 @@
+
+opam-version: "2.0"
+synopsis: "Preprocessor-pretty-printer of OCaml"
+description: """
+Camlp5 is a preprocessor and pretty-printer for OCaml programs. It also provides parsing and printing tools.
+
+As a preprocessor, it allows to:
+
+extend the syntax of OCaml,
+redefine the whole syntax of the language.
+As a pretty printer, it allows to:
+
+display OCaml programs in an elegant way,
+convert from one syntax to another,
+check the results of syntax extensions.
+Camlp5 also provides some parsing and pretty printing tools:
+
+extensible grammars
+extensible printers
+stream parsers and lexers
+pretty print module
+It works as a shell command and can also be used in the OCaml toplevel."""
+x-maintenance-intent: [ "(latest)" ]
+maintainer: ["Chet Murthy <chetsky@gmail.com>"]
+authors: ["Daniel de Rauglaudre" "Chet Murthy"]
+license: "BSD-3-Clause"
+homepage: "https://camlp5.github.io"
+doc: "https://camlp5.github.io/doc/html"
+bug-reports: "https://github.com/camlp5/camlp5/issues"
+depends: [
+  "ocaml" {>= "4.10" & < "5.05.0" }
+  "ocamlfind"
+  "camlp-streams" { >= "5.0" }
+  "conf-perl"
+  "conf-bash"
+  "camlp5-buildscripts" { >= "0.06" }
+  "conf-diffutils" { with-test & (os-distribution = "alpine" | os-distribution = "freebsd") }
+  "re" { >= "1.11.0" }
+  "ounit2" { with-test }
+  "pcre2" { >= "8.0.3" }
+  "rresult"
+  "bos"
+  "fmt"
+  "mdx" {>= "2.3.0" & with-test}
+]
+build: [
+  ["./configure" "--prefix" prefix "-libdir" lib "-mandir" man "-oversion" ocaml:version]
+  [make "-j%{jobs}%" "DEBUG=-g" "world.opt"]
+  [make "-j%{jobs}%" "DEBUG=-g" "all"]
+  [make "-C" "testsuite" "clean" "all-tests"] { with-test }
+  [make "-C" "test" "clean" "all"] { with-test & os != "macos" & os != "opensuse-tumbleweed" }
+  [make "-C" "mdx-tests" "clean" "all"] { with-test & os != "macos" & os != "opensuse-tumbleweed" }
+#  [make "-C" "scripts" "clean" "test"] { with-test }
+]
+install: [make "install"]
+conflicts: [
+   "ocaml-option-bytecode-only"
+   "frama-clang" { <= "0.0.18" }
+   "GT" { <= "0.5.4" }
+   "hol_light" { <= "3.1.0" }
+   "lablgl" { <= "1.07" }
+   "p5scm" { <= "0.4.0" }
+   "pa_ppx" { <= "0.20" }
+]
+x-ci-accept-failures: [ "freebsd" "opensuse-tumbleweed" ]
+dev-repo: "git+https://github.com/camlp5/camlp5.git"
+url {
+  src: "https://github.com/camlp5/camlp5/archive/refs/tags/8.04.01.tar.gz"
+  checksum: [
+    "sha512=7f91f5d1c5cfd7923f859459ab317eff7ed4269014d3fe479b021399b17b4cd305ba56d95f5143d20c8426f1dd69210782df3d10db7848d753624acd73a55441"
+  ]
+}

--- a/packages/camlp5/camlp5.8.04.01/opam
+++ b/packages/camlp5/camlp5.8.04.01/opam
@@ -28,7 +28,7 @@ homepage: "https://camlp5.github.io"
 doc: "https://camlp5.github.io/doc/html"
 bug-reports: "https://github.com/camlp5/camlp5/issues"
 depends: [
-  "ocaml" {>= "4.10" & < "5.05.0" }
+  "ocaml" {>= "4.10" & < "5.5.0" }
   "ocamlfind"
   "camlp-streams" { >= "5.0" }
   "conf-perl"


### PR DESCRIPTION
in `M(~a:x,b)` (or any other constructor expression with only argument as a labeled tuple, the conversion from Camlp5 AST to OCaml AST was wrong, erasing the labels.