### PR TITLE
Package sha256-cng.0.1.0

### DIFF
--- a/packages/sha256-cng/sha256-cng.0.1.0/opam
+++ b/packages/sha256-cng/sha256-cng.0.1.0/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+synopsis: "SHA-256 hashing for OCaml on Windows via native CNG"
+description:
+  "Thin FFI bindings over the Windows CNG (BCrypt) API for computing SHA-256 hashes of files and strings. No dependencies beyond the Windows SDK."
+maintainer: ["elfyboo" "<elfyboo.mail@gmail.com>"]
+authors: ["elfyboo" "<elfyboo.mail@gmail.com>"]
+license: "Unlicense"
+tags: ["sha256" "windows" "cng" "bcrypt"]
+homepage: "https://github.com/elfyboo/sha256-cng"
+doc: "https://github.com/elfyboo/sha256-cng"
+bug-reports: "https://github.com/elfyboo/sha256-cng/issues"
+depends: [
+  "ocaml" {>= "4.08"}
+  "dune" {>= "3.22" & >= "3.22"}
+  "alcotest" {with-test}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/elfyboo/sha256-cng.git"
+url {
+  src:
+    "https://github.com/elfyboo/sha256-cng/archive/refs/tags/v0.1.0.tar.gz"
+  checksum: [
+    "md5=37fa5e24b0a4446287103682da225ef3"
+    "sha512=6dc0b5921bd7f1133cead1399e7feeb03de520351cf827234a47c5c2337fb239c6e712c4dc9fb64a307de0d100258e5fe026e91d207a5ee911c1f02e68c07157"
+  ]
+}
+x-maintenance-intent: ["(latest)"]

--- a/packages/sha256-cng/sha256-cng.0.1.0/opam
+++ b/packages/sha256-cng/sha256-cng.0.1.0/opam
@@ -1,4 +1,5 @@
 opam-version: "2.0"
+version: "0.1.0"
 synopsis: "SHA-256 hashing for OCaml on Windows via native CNG"
 description:
   "Thin FFI bindings over the Windows CNG (BCrypt) API for computing SHA-256 hashes of files and strings. No dependencies beyond the Windows SDK."
@@ -10,8 +11,8 @@ homepage: "https://github.com/elfyboo/sha256-cng"
 doc: "https://github.com/elfyboo/sha256-cng"
 bug-reports: "https://github.com/elfyboo/sha256-cng/issues"
 depends: [
-  "ocaml" {>= "4.08"}
-  "dune" {>= "3.22" & >= "3.22"}
+  "ocaml" {>= "4.13"}
+  "dune" {>= "3.22" }
   "alcotest" {with-test}
   "odoc" {with-doc}
 ]
@@ -39,3 +40,4 @@ url {
   ]
 }
 x-maintenance-intent: ["(latest)"]
+available: [os = "win32"]

--- a/packages/sha256-cng/sha256-cng.0.1.0/opam
+++ b/packages/sha256-cng/sha256-cng.0.1.0/opam
@@ -1,5 +1,4 @@
 opam-version: "2.0"
-version: "0.1.0"
 synopsis: "SHA-256 hashing for OCaml on Windows via native CNG"
 description:
   "Thin FFI bindings over the Windows CNG (BCrypt) API for computing SHA-256 hashes of files and strings. No dependencies beyond the Windows SDK."


### PR DESCRIPTION
### `sha256-cng.0.1.0`
SHA-256 hashing for OCaml on Windows via native CNG
Thin FFI bindings over the Windows CNG (BCrypt) API for computing SHA-256 hashes of files and strings. No dependencies beyond the Windows SDK.



---
* Homepage: https://github.com/elfyboo/sha256-cng
* Source repo: git+https://github.com/elfyboo/sha256-cng.git
* Bug tracker: https://github.com/elfyboo/sha256-cng/issues

---
:camel: Pull-request generated by opam-publish v3.0.0