### PR TITLE
2 packages from ocurrent/obuilder at 0.7.0

### DIFF
--- a/packages/obuilder-spec/obuilder-spec.0.7.0/opam
+++ b/packages/obuilder-spec/obuilder-spec.0.7.0/opam
@@ -42,7 +42,6 @@ build: [
     "-j"
     jobs
     "@install"
-    "@runtest" {with-test}
     "@doc" {with-doc}
   ]
 ]

--- a/packages/obuilder-spec/obuilder-spec.0.7.0/opam
+++ b/packages/obuilder-spec/obuilder-spec.0.7.0/opam
@@ -1,0 +1,57 @@
+opam-version: "2.0"
+synopsis: "Build specification format"
+description:
+  "A library for constructing, reading and writing OBuilder build specification files."
+maintainer: [
+  "Tim McGilchrist <timmcgil@gmail.com>"
+  "Antonin Décimo <antonin@tarides.com>"
+]
+authors: [
+  "Antonin Décimo <antonin@tarides.com>"
+  "Arthur Wendling <art.wendling@gmail.com>"
+  "David Allsopp <david.allsopp@metastack.com>"
+  "Kate <kit.ty.kate@disroot.org>"
+  "Lucas Pluvinage <lucas@tarides.com>"
+  "Mark Elvers <mark.elvers@tunbury.org>"
+  "Patrick Ferris <pf341@patricoferris.com>"
+  "Thomas Gazagnaire <thomas@gazagnaire.org>"
+  "Thomas Leonard <talex5@gmail.com>"
+  "Tim McGilchrist <timmcgil@gmail.com>"
+]
+license: "Apache-2.0"
+homepage: "https://github.com/ocurrent/obuilder"
+doc: "https://ocurrent.github.io/obuilder/"
+bug-reports: "https://github.com/ocurrent/obuilder/issues"
+depends: [
+  "dune" {>= "3.16"}
+  "fmt" {>= "0.8.9"}
+  "sexplib"
+  "astring"
+  "ppx_deriving"
+  "ppx_sexp_conv"
+  "ocaml" {>= "4.14.2"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/ocurrent/obuilder.git"
+url {
+  src:
+    "https://github.com/ocurrent/obuilder/releases/download/v0.7.0/obuilder-0.7.0.tbz"
+  checksum: [
+    "md5=e5bb1a762df5c83a8dd060d5d0cd77cb"
+    "sha512=aad25b3ea97f09e9a256de251f86af295788eef2bb2a4a910566fd313236692c0bdd6449727667f2708bb445d7dc348b2af5627b84b7011969a8c4aec9f4d532"
+  ]
+}

--- a/packages/obuilder/obuilder.0.7.0/opam
+++ b/packages/obuilder/obuilder.0.7.0/opam
@@ -54,7 +54,6 @@ build: [
     "-j"
     jobs
     "@install"
-    "@runtest" {with-test}
     "@doc" {with-doc}
   ]
 ]

--- a/packages/obuilder/obuilder.0.7.0/opam
+++ b/packages/obuilder/obuilder.0.7.0/opam
@@ -1,0 +1,69 @@
+opam-version: "2.0"
+synopsis: "Run build scripts for CI"
+description:
+  "OBuilder takes a build script (similar to a Dockerfile) and performs the steps in it in a sandboxed environment."
+maintainer: [
+  "Tim McGilchrist <timmcgil@gmail.com>"
+  "Antonin Décimo <antonin@tarides.com>"
+]
+authors: [
+  "Antonin Décimo <antonin@tarides.com>"
+  "Arthur Wendling <art.wendling@gmail.com>"
+  "David Allsopp <david.allsopp@metastack.com>"
+  "Kate <kit.ty.kate@disroot.org>"
+  "Lucas Pluvinage <lucas@tarides.com>"
+  "Mark Elvers <mark.elvers@tunbury.org>"
+  "Patrick Ferris <pf341@patricoferris.com>"
+  "Thomas Gazagnaire <thomas@gazagnaire.org>"
+  "Thomas Leonard <talex5@gmail.com>"
+  "Tim McGilchrist <timmcgil@gmail.com>"
+]
+license: "Apache-2.0"
+homepage: "https://github.com/ocurrent/obuilder"
+doc: "https://ocurrent.github.io/obuilder/"
+bug-reports: "https://github.com/ocurrent/obuilder/issues"
+depends: [
+  "dune" {>= "3.16"}
+  "lwt" {>= "5.7.0"}
+  "astring"
+  "fmt" {>= "0.8.9"}
+  "logs"
+  "cmdliner" {>= "1.3.0"}
+  "tar-unix" {>= "2.6.0" & < "3.0.0"}
+  "yojson" {>= "1.6.0"}
+  "sexplib"
+  "ppx_deriving"
+  "ppx_sexp_conv"
+  "sha" {>= "1.15.4"}
+  "sqlite3" {>= "5.2.0"}
+  "crunch" {>= "3.3.1" & build}
+  "obuilder-spec" {= version}
+  "fpath"
+  "extunix" {>= "0.4.2"}
+  "ocaml" {>= "4.14.2"}
+  "alcotest-lwt" {>= "1.7.0" & with-test}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/ocurrent/obuilder.git"
+url {
+  src:
+    "https://github.com/ocurrent/obuilder/releases/download/v0.7.0/obuilder-0.7.0.tbz"
+  checksum: [
+    "md5=e5bb1a762df5c83a8dd060d5d0cd77cb"
+    "sha512=aad25b3ea97f09e9a256de251f86af295788eef2bb2a4a910566fd313236692c0bdd6449727667f2708bb445d7dc348b2af5627b84b7011969a8c4aec9f4d532"
+  ]
+}


### PR DESCRIPTION
This pull-request concerns:
- `obuilder.0.7.0`: Run build scripts for CI
- `obuilder-spec.0.7.0`: Build specification format



---
* Homepage: https://github.com/ocurrent/obuilder
* Source repo: git+https://github.com/ocurrent/obuilder.git
* Bug tracker: https://github.com/ocurrent/obuilder/issues

---
### v0.7.0 2026-05-12

New backends:

- Add an Overlayfs store backend (@mtelvers https://github.com/ocurrent/obuilder/pull/180)
- Add a QEMU sandbox backend, enabling Windows, OpenBSD and RISC-V builds
  (@mtelvers https://github.com/ocurrent/obuilder/pull/195, reviewed by @MisterDA, @samoht, and @shonfeder)
- Add an HCS (Host Compute Service) backend for native Windows containers
  via containerd (@mtelvers https://github.com/ocurrent/obuilder/pull/204)

Build, store and runtime fixes:

- Failed builds now correctly return a failure exit status (@mtelvers)
- Fix stale base image cache causing worker crash after pruning (@mtelvers)
- Re-raise exceptions to preserve backtraces and prefer `failwith` over
  `Lwt.fail_with` (@MisterDA)
- Remove unused `Os.copy`, `delete_recursively` and `win32_unlink`
  (@MisterDA, @shonfeder)

Copy step fixes:

- Fix copy step failure with tar 1.34 and the CVE-2025-45582 patch
  (@mtelvers https://github.com/ocurrent/obuilder/pull/205)
- Also strip `./` segments from destination tar paths (@mtelvers https://github.com/ocurrent/obuilder/pull/206)
- Remove synchronous Windows workaround in `copy_file` (@mtelvers)

Windows fixes:

- Display Windows `NTSTATUS` exit codes in hex
  (@MisterDA https://github.com/ocurrent/obuilder/pull/197, reviewed by @mtelvers)
- Fix opam pin on Windows (@mtelvers https://github.com/ocurrent/obuilder/pull/196, reviewed by @shonfeder)

Base images, CI and toolchain:

- Update base images and workers to opam 2.5, opam 2.4.1, opam 2.3,
  OCaml 5.4 and OCaml 5.3; add OpenBSD 7.7 support
  (@mtelvers https://github.com/ocurrent/obuilder/pull/198 https://github.com/ocurrent/obuilder/pull/201 https://github.com/ocurrent/obuilder/pull/202)
- Update GHA scripts: use the latest OCaml 5, switch to `setup-ocaml@v3`,
  update runc to 1.1.14 (@MisterDA)
- Update opam image hashes and dependency lower bounds for bug fixes;
  add an upper bound on `tar-unix` 3 (@MisterDA, @shonfeder)



---
:camel: Pull-request generated by opam-publish v2.5.1