### PR TITLE
[new release] odoc (5 packages) (3.2.1)

### DIFF
--- a/packages/odoc-driver/odoc-driver.3.2.1/opam
+++ b/packages/odoc-driver/odoc-driver.3.2.1/opam
@@ -1,0 +1,75 @@
+opam-version: "2.0"
+homepage: "https://github.com/ocaml/odoc"
+doc: "https://ocaml.github.io/odoc/"
+bug-reports: "https://github.com/ocaml/odoc/issues"
+license: "ISC"
+
+maintainer: [
+  "Daniel Bünzli <daniel.buenzli@erratique.ch>"
+  "Jon Ludlam <jon@recoil.org>"
+  "Jules Aguillon <juloo.dsi@gmail.com>"
+  "Paul-Elliot Anglès d'Auriac <paul-elliot@tarides.com>"
+]
+authors: [
+  "Anton Bachin <antonbachin@yahoo.com>"
+  "Daniel Bünzli <daniel.buenzli@erratique.ch>"
+  "David Sheets <sheets@alum.mit.edu>"
+  "Jon Ludlam <jon@recoil.org>"
+  "Jules Aguillon <juloo.dsi@gmail.com>"
+  "Leo White <leo@lpw25.net>"
+  "Lubega Simon <lubegasimon73@gmail.com>"
+  "Paul-Elliot Anglès d'Auriac <paul-elliot@tarides.com>"
+  "Thomas Refis <trefis@janestreet.com>"
+]
+dev-repo: "git+https://github.com/ocaml/odoc.git"
+
+synopsis: "OCaml Documentation Generator - Driver"
+description: """
+The driver is a sample implementation of a tool to drive odoc to generate
+documentation for installed packages.
+"""
+
+
+depends: [
+  "ocaml" {>= "5.1.0"}
+  "odoc" {= version}
+  "dune" {>= "3.21.0"}
+  "odoc-md"
+  "bos"
+  "fpath" {>= "0.7.3"}
+  "yojson" {>= "2.0.0"}
+  "ocamlfind"
+  "opam-format" {>= "2.1.0"}
+  "logs"
+  "eio_main"
+  "eio" {>= "1.0"}
+  "progress"
+  "cmdliner" {>= "1.3.0"}
+  "sexplib"
+  "ppx_sexp_conv"
+  "sherlodoc"
+]
+
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+
+x-maintenance-intent: ["(latest)"]
+url {
+  src: "https://github.com/ocaml/odoc/releases/download/3.2.1/odoc-3.2.1.tbz"
+  checksum: [
+    "sha256=d45eb125514839fd9ac27702bb4938d1b4f3b6978e9b16ab9673ea067245affc"
+    "sha512=3555386b4770a7caa8ec903683bde5ecdc41d5e57ffaee617d5da225c747bbd1e9c1d2677f4df97e96bbdfc69f580ea83b1b92b933ea40a436a658788b677bbc"
+  ]
+}
+x-commit-hash: "6427579346781df958b3bdfe8ac6d4550194012a"

--- a/packages/odoc-md/odoc-md.3.2.1/opam
+++ b/packages/odoc-md/odoc-md.3.2.1/opam
@@ -1,0 +1,57 @@
+opam-version: "2.0"
+homepage: "https://github.com/ocaml/odoc"
+doc: "https://ocaml.github.io/odoc/"
+bug-reports: "https://github.com/ocaml/odoc/issues"
+license: "ISC"
+
+maintainer: [
+  "Jon Ludlam <jon@recoil.org>"
+  "Jules Aguillon <juloo.dsi@gmail.com>"
+  "Paul-Elliot Anglès d'Auriac <paul-elliot@tarides.com>"
+]
+authors: [
+  "Daniel Bünzli <daniel.buenzli@erratique.ch>"
+  "Paul-Elliot Anglès d'Auriac <paul-elliot@tarides.com>"
+  "Jon Ludlam <jon@recoil.org>"
+]
+dev-repo: "git+https://github.com/ocaml/odoc.git"
+
+synopsis: "OCaml Documentation Generator - Markdown support"
+description: """
+Odoc-md is part of the odoc suite of tools for generating documentation for OCaml packages.
+
+This package provides support for generating documentation from Markdown files.
+"""
+
+depends: [
+  "ocaml" {>= "4.14.0"}
+  "odoc" {= version}
+  "dune" {>= "3.21.0"}
+  "cmdliner" {>= "1.3.0"}
+  "cmarkit"
+]
+
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+
+x-maintenance-intent: ["(latest)"]
+url {
+  src: "https://github.com/ocaml/odoc/releases/download/3.2.1/odoc-3.2.1.tbz"
+  checksum: [
+    "sha256=d45eb125514839fd9ac27702bb4938d1b4f3b6978e9b16ab9673ea067245affc"
+    "sha512=3555386b4770a7caa8ec903683bde5ecdc41d5e57ffaee617d5da225c747bbd1e9c1d2677f4df97e96bbdfc69f580ea83b1b92b933ea40a436a658788b677bbc"
+  ]
+}
+x-commit-hash: "6427579346781df958b3bdfe8ac6d4550194012a"
+

--- a/packages/odoc-parser/odoc-parser.3.2.1/opam
+++ b/packages/odoc-parser/odoc-parser.3.2.1/opam
@@ -1,0 +1,46 @@
+opam-version: "2.0"
+synopsis: "Parser for ocaml documentation comments"
+description: """
+Odoc_parser is a library for parsing the contents of OCaml documentation
+comments, formatted using 'odoc' syntax, an extension of the language
+understood by ocamldoc."""
+maintainer: ["Jon Ludlam <jon@recoil.org>"]
+authors: ["Anton Bachin <antonbachin@yahoo.com>"]
+license: "ISC"
+homepage: "https://github.com/ocaml/odoc"
+bug-reports: "https://github.com/ocaml/odoc/issues"
+dev-repo: "git+https://github.com/ocaml/odoc.git"
+doc: "https://ocaml.github.io/odoc/odoc_parser"
+depends: [
+  "dune" {>= "3.21"}
+  "ocaml" {>= "4.08.0"}
+  "astring"
+  "camlp-streams"
+  "ppx_expect" {with-test}
+  "sexplib0" {with-test}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    # Tests are not all associated with a package and would be run if using the
+    # default '@runtest'.
+    "@src/parser/runtest" {with-test}
+  ]
+]
+x-maintenance-intent: ["(latest)"]
+url {
+  src: "https://github.com/ocaml/odoc/releases/download/3.2.1/odoc-3.2.1.tbz"
+  checksum: [
+    "sha256=d45eb125514839fd9ac27702bb4938d1b4f3b6978e9b16ab9673ea067245affc"
+    "sha512=3555386b4770a7caa8ec903683bde5ecdc41d5e57ffaee617d5da225c747bbd1e9c1d2677f4df97e96bbdfc69f580ea83b1b92b933ea40a436a658788b677bbc"
+  ]
+}
+x-commit-hash: "6427579346781df958b3bdfe8ac6d4550194012a"
+

--- a/packages/odoc/odoc.3.2.1/opam
+++ b/packages/odoc/odoc.3.2.1/opam
@@ -1,0 +1,91 @@
+opam-version: "2.0"
+homepage: "https://github.com/ocaml/odoc"
+doc: "https://ocaml.github.io/odoc/"
+bug-reports: "https://github.com/ocaml/odoc/issues"
+license: "ISC"
+
+maintainer: [
+  "Daniel Bünzli <daniel.buenzli@erratique.ch>"
+  "Jon Ludlam <jon@recoil.org>"
+  "Jules Aguillon <juloo.dsi@gmail.com>"
+  "Paul-Elliot Anglès d'Auriac <paul-elliot@tarides.com>"
+]
+authors: [
+  "Anton Bachin <antonbachin@yahoo.com>"
+  "Daniel Bünzli <daniel.buenzli@erratique.ch>"
+  "David Sheets <sheets@alum.mit.edu>"
+  "Jon Ludlam <jon@recoil.org>"
+  "Jules Aguillon <juloo.dsi@gmail.com>"
+  "Leo White <leo@lpw25.net>"
+  "Lubega Simon <lubegasimon73@gmail.com>"
+  "Paul-Elliot Anglès d'Auriac <paul-elliot@tarides.com>"
+  "Thomas Refis <trefis@janestreet.com>"
+]
+dev-repo: "git+https://github.com/ocaml/odoc.git"
+
+synopsis: "OCaml Documentation Generator"
+description: """
+**odoc** is a powerful and flexible documentation generator for OCaml. It reads *doc comments*, demarcated by `(** ... *)`, and transforms them into a variety of output formats, including HTML, LaTeX, and man pages.
+
+- **Output Formats:** Odoc generates HTML for web browsing, LaTeX for PDF generation, and man pages for use on Unix-like systems.
+- **Cross-References:** odoc uses the `ocamldoc` markup, which allows to create links for functions, types, modules, and documentation pages.
+- **Link to Source Code:** Documentation generated includes links to the source code of functions, providing an easy way to navigate from the docs to the actual implementation.
+- **Code Highlighting:** odoc automatically highlights syntax in code snippets for different languages.
+
+odoc is part of the [OCaml Platform](https://ocaml.org/docs/platform), the recommended set of tools for OCaml.
+"""
+
+
+depends: [
+  "odoc-parser" {= version}
+  "astring"
+  "cmdliner" {>= "1.3.0"}
+  "cppo" {build & >= "1.1.0"}
+  "dune" {>= "3.21.0"}
+  "fpath" {>= "0.7.3"}
+  "ocaml" {>= "4.08.0" & < "5.6"}
+  "tyxml" {>= "4.4.0"}
+  "fmt"
+  "crunch" {>= "1.4.1"}
+  "ocamlfind" {with-test}
+  "yojson" {>= "2.1.0" & with-test}
+  "sexplib0" {with-test}
+  "conf-jq" {with-test}
+  "ppx_expect" {with-test}
+  "bos" {with-test}
+]
+
+conflicts: [
+  "ocaml-option-bytecode-only"
+  "oxcaml-compiler" {< "5.2.0minus31"}
+]
+
+x-extra-doc-deps: [
+  "odoc-driver" {= version}
+  "sherlodoc" {= version}
+  "odig"
+]
+
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+x-maintenance-intent: ["(latest)"]
+url {
+  src: "https://github.com/ocaml/odoc/releases/download/3.2.1/odoc-3.2.1.tbz"
+  checksum: [
+    "sha256=d45eb125514839fd9ac27702bb4938d1b4f3b6978e9b16ab9673ea067245affc"
+    "sha512=3555386b4770a7caa8ec903683bde5ecdc41d5e57ffaee617d5da225c747bbd1e9c1d2677f4df97e96bbdfc69f580ea83b1b92b933ea40a436a658788b677bbc"
+  ]
+}
+x-commit-hash: "6427579346781df958b3bdfe8ac6d4550194012a"

--- a/packages/sherlodoc/sherlodoc.3.2.1/opam
+++ b/packages/sherlodoc/sherlodoc.3.2.1/opam
@@ -1,0 +1,54 @@
+opam-version: "2.0"
+synopsis: "Search engine for OCaml documentation"
+maintainer: ["art.wendling@gmail.com"]
+authors: ["Arthur Wendling" "Emile Trotignon"]
+license: "MIT"
+homepage: "https://github.com/ocaml/odoc"
+doc: "https://ocaml.github.io/odoc/"
+bug-reports: "https://github.com/ocaml/odoc/issues"
+depends: [
+  "dune" {>= "3.21"}
+  "ocaml" {>= "4.0.8"}
+  "odoc" {= version}
+  "base64" {>= "3.5.1"}
+  "bigstringaf" {>= "0.9.1"}
+  "js_of_ocaml" {>= "5.6.0"}
+  "brr" {>= "0.0.6"}
+  "cmdliner" {>= "1.3.0"}
+  "decompress" {>= "1.5.3"}
+  "fpath" {>= "0.7.3"}
+  "lwt" {>= "5.7.0"}
+  "menhir" {>= "20230608"}
+  "ppx_blob" {>= "0.9.0"}
+  "tyxml" {>= "4.6.0"}
+  "result" {>= "1.5"}
+  "odig" {with-test}
+  "alcotest" {with-test}
+]
+depopts: [
+  "ancient" {>= "0.9.1"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@sherlodoc/runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/ocaml/odoc.git"
+x-maintenance-intent: ["(latest)"]
+url {
+  src: "https://github.com/ocaml/odoc/releases/download/3.2.1/odoc-3.2.1.tbz"
+  checksum: [
+    "sha256=d45eb125514839fd9ac27702bb4938d1b4f3b6978e9b16ab9673ea067245affc"
+    "sha512=3555386b4770a7caa8ec903683bde5ecdc41d5e57ffaee617d5da225c747bbd1e9c1d2677f4df97e96bbdfc69f580ea83b1b92b933ea40a436a658788b677bbc"
+  ]
+}
+x-commit-hash: "6427579346781df958b3bdfe8ac6d4550194012a"


### PR DESCRIPTION
CHANGES:

- Fix ocaml/odoc#1426, which broke docs in packages including `base` in OCaml 5.5.0 (@jonludlam, ocaml/odoc#1427)
- Fix ocaml/odoc#1429, which broke docs in packages including `merlin-lib` (@jonludlam, ocaml/odoc#1430)
- Fix ocaml/odoc#1431, a regression introduced in v3.2.0 (ocaml/odoc#1433, @jonludlam)