### PR TITLE
Package jext.0.1.1

### DIFF
--- a/packages/jext/jext.0.1.1/opam
+++ b/packages/jext/jext.0.1.1/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+synopsis: "Js_of_ocaml tools to help handling web extension"
+maintainer: "contact@functori.com"
+authors: "Maxime Levillain <maxime.levillain@functori.com>"
+license: "MIT"
+homepage: "https://gitlab.com/functori/dev/jext"
+bug-reports: "https://gitlab.com/functori/dev/jext/-/issues"
+depends: [
+  "dune" {>= "3.6"}
+  "ocaml" {>= "4.08"}
+  "ez_api" {>= "1.2.0"}
+  "ezjs_fetch" {>= "0.3"}
+  "ppx_deriving_jsoo" {>= "0.3"}
+  "ezjs_extension"
+  "odoc" {with-doc}
+]
+depopts: ["lwt"]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git://gitlab.com/functori/dev/jext"
+url {
+  src:
+    "https://gitlab.com/functori/dev/jext/-/archive/0.1.1/jext-0.1.1.tar.gz"
+  checksum: [
+    "md5=586f3215c066e3ac542de36669d8d20b"
+    "sha512=c8cbee00bec3d580368145bcbfeb6dc7d45930993936dd7c30609d25fe72eeb1edf94897bf5bbb5aa5ee1701c599de29340be43f476f1377f8156d94aec2a000"
+  ]
+}


### PR DESCRIPTION
### `jext.0.1.1`
Js_of_ocaml tools to help handling web extension



---
* Homepage: https://gitlab.com/functori/dev/jext
* Source repo: git://gitlab.com/functori/dev/jext
* Bug tracker: https://gitlab.com/functori/dev/jext/-/issues

---
:camel: Pull-request generated by opam-publish v3.0.0