### PR TITLE
Package bizowie-api.0.5.0

### DIFF
--- a/packages/bizowie-api/bizowie-api.0.5.0/opam
+++ b/packages/bizowie-api/bizowie-api.0.5.0/opam
@@ -1,0 +1,42 @@
+opam-version: "2.0"
+synopsis: "OCaml client for the Bizowie ERP API"
+description:
+  "OCaml port of WWW::Bizowie::API for the Bizowie ERP platform (https://bizowie.com). Supports both v1 (multipart) and v2 (JSON) API endpoints."
+maintainer: "Michael J. Flickinger <michael.flickinger@bizowie.com>"
+authors: "Bizowie"
+license: ["Artistic-1.0-Perl" "GPL-1.0-or-later"]
+homepage: "https://bizowie.com"
+bug-reports: "https://github.com/mjflick/bizowie-api-ocaml/issues"
+depends: [
+  "ocaml" {>= "4.14"}
+  "dune" {>= "3.2"}
+  "cohttp-lwt-unix" {>= "5.0.0"}
+  "lwt" {>= "5.0.0"}
+  "yojson" {>= "2.0.0"}
+  "uri" {>= "4.0.0"}
+  "alcotest" {with-test & >= "1.5.0"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/mjflick/bizowie-api-ocaml.git"
+url {
+  src:
+    "https://github.com/mjflick/bizowie-api-ocaml/archive/refs/tags/v0.5.0.tar.gz"
+  checksum: [
+    "md5=07c0dc70d15c416aad030ace0ca00f02"
+    "sha512=32a887878afc94f99ef34b588145b9e95fc4ea071482015a341692bce843c8fd43dff0991945aabddfc973c1e8348b702f366c13cf71f82f86250ff2fa79b797"
+  ]
+}


### PR DESCRIPTION
### `bizowie-api.0.5.0`
OCaml client for the Bizowie ERP API
OCaml port of WWW::Bizowie::API for the Bizowie ERP platform (https://bizowie.com). Supports both v1 (multipart) and v2 (JSON) API endpoints.



---
* Homepage: https://bizowie.com
* Source repo: git+https://github.com/mjflick/bizowie-api-ocaml.git
* Bug tracker: https://github.com/mjflick/bizowie-api-ocaml/issues

---
:camel: Pull-request generated by opam-publish v3.0.0