### PR TITLE
Camlp5 8.05.00: need to retract this release; nasty parsing bug in let-str-item

### DIFF
--- a/packages/camlp5/camlp5.8.05.00/opam
+++ b/packages/camlp5/camlp5.8.05.00/opam
@@ -1,5 +1,6 @@
 
 opam-version: "2.0"
+available: false
 synopsis: "Preprocessor-pretty-printer of OCaml"
 description: """
 Camlp5 is a preprocessor and pretty-printer for OCaml programs. It also provides parsing and printing tools.


### PR DESCRIPTION
Will undoubtedly cause breakage.  Have a fix, but checking that there aren't other bugs, so maybe a couple days more.