### PR TITLE
4 packages from ocurrent/ocluster at 0.4.0

### DIFF
--- a/packages/current_ocluster/current_ocluster.0.4.0/opam
+++ b/packages/current_ocluster/current_ocluster.0.4.0/opam
@@ -27,7 +27,7 @@ depends: [
   "duration"
   "fmt"
   "logs"
-  "lwt" {>= "5.6.1"}
+  "lwt" {>= "5.7.0"}
   "ppx_deriving"
   "ppx_deriving_yojson"
   "prometheus" {>= "1.2"}

--- a/packages/current_ocluster/current_ocluster.0.4.0/opam
+++ b/packages/current_ocluster/current_ocluster.0.4.0/opam
@@ -1,0 +1,62 @@
+opam-version: "2.0"
+synopsis: "OCurrent plugin for OCluster builds"
+description:
+  "Creates a stage in an OCurrent pipeline for submitting jobs to OCluster."
+maintainer: "Mark Elvers <mark.elvers@tunbury.org>"
+authors: [
+  "Antonin Décimo <antonin@tarides.com>"
+  "David Allsopp <david.allsopp@metastack.com>"
+  "Kate <kit.ty.kate@disroot.org>"
+  "Lucas Pluvinage <lucas@tarides.com>"
+  "Mark Elvers <mark.elvers@tunbury.org>"
+  "Patrick Ferris <patrick@sirref.org>"
+  "Thomas Leonard <talex5@gmail.com>"
+  "Tim McGilchrist <timmcgil@gmail.com>"
+]
+license: "Apache-2.0"
+homepage: "https://github.com/ocurrent/ocluster"
+doc: "https://ocurrent.github.io/ocluster/"
+bug-reports: "https://github.com/ocurrent/ocluster/issues"
+depends: [
+  "dune" {>= "3.7"}
+  "ocluster-api" {= version}
+  "ocaml" {>= "4.14.1"}
+  "capnp-rpc-unix" {>= "1.2.3" & < "2.0"}
+  "current" {>= "0.6.4"}
+  "current_git" {>= "0.6.4"}
+  "duration"
+  "fmt"
+  "logs"
+  "lwt" {>= "5.6.1"}
+  "ppx_deriving"
+  "ppx_deriving_yojson"
+  "prometheus" {>= "1.2"}
+  "current_github" {>= "0.6.4" & with-test}
+  "current_web" {>= "0.6.4" & with-test}
+  "odoc" {with-doc}
+]
+available: arch != "x86_32"
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/ocurrent/ocluster.git"
+url {
+  src:
+    "https://github.com/ocurrent/ocluster/releases/download/v0.4.0/ocluster-0.4.0.tbz"
+  checksum: [
+    "md5=b024d87f08bed7a6fb40fd3a1e1d94f5"
+    "sha512=ab58b4279a5763b03c2d158d6261ca6edf800baf89c996f5a849e01ad8f332d6fdf7bb4947b36d8671b5b80a8ccc7faae252763d985464fdfb23287e057e793f"
+  ]
+}
+x-maintenance-intent: ["(latest)"]

--- a/packages/ocluster-api/ocluster-api.0.4.0/opam
+++ b/packages/ocluster-api/ocluster-api.0.4.0/opam
@@ -1,0 +1,53 @@
+opam-version: "2.0"
+synopsis: "Cap'n Proto API for OCluster"
+description: "OCaml bindings for the OCluster Cap'n Proto API."
+maintainer: "Mark Elvers <mark.elvers@tunbury.org>"
+authors: [
+  "Antonin Décimo <antonin@tarides.com>"
+  "David Allsopp <david.allsopp@metastack.com>"
+  "Kate <kit.ty.kate@disroot.org>"
+  "Lucas Pluvinage <lucas@tarides.com>"
+  "Mark Elvers <mark.elvers@tunbury.org>"
+  "Patrick Ferris <patrick@sirref.org>"
+  "Thomas Leonard <talex5@gmail.com>"
+  "Tim McGilchrist <timmcgil@gmail.com>"
+]
+license: "Apache-2.0"
+homepage: "https://github.com/ocurrent/ocluster"
+doc: "https://ocurrent.github.io/ocluster/"
+bug-reports: "https://github.com/ocurrent/ocluster/issues"
+depends: [
+  "dune" {>= "3.7"}
+  "ocaml" {>= "4.14.1"}
+  "capnp-rpc-lwt" {>= "1.2.3" & < "2.0"}
+  "fmt"
+  "lwt" {>= "5.6.1"}
+  "ppx_deriving"
+  "ppx_deriving_yojson"
+  "odoc" {with-doc}
+]
+available: arch != "x86_32"
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/ocurrent/ocluster.git"
+url {
+  src:
+    "https://github.com/ocurrent/ocluster/releases/download/v0.4.0/ocluster-0.4.0.tbz"
+  checksum: [
+    "md5=b024d87f08bed7a6fb40fd3a1e1d94f5"
+    "sha512=ab58b4279a5763b03c2d158d6261ca6edf800baf89c996f5a849e01ad8f332d6fdf7bb4947b36d8671b5b80a8ccc7faae252763d985464fdfb23287e057e793f"
+  ]
+}
+x-maintenance-intent: ["(latest)"]

--- a/packages/ocluster-worker/ocluster-worker.0.4.0/opam
+++ b/packages/ocluster-worker/ocluster-worker.0.4.0/opam
@@ -1,0 +1,58 @@
+opam-version: "2.0"
+synopsis: "OCluster library for defining workers"
+description: "OCluster library for defining workers"
+maintainer: "Mark Elvers <mark.elvers@tunbury.org>"
+authors: [
+  "Antonin Décimo <antonin@tarides.com>"
+  "David Allsopp <david.allsopp@metastack.com>"
+  "Kate <kit.ty.kate@disroot.org>"
+  "Lucas Pluvinage <lucas@tarides.com>"
+  "Mark Elvers <mark.elvers@tunbury.org>"
+  "Patrick Ferris <patrick@sirref.org>"
+  "Thomas Leonard <talex5@gmail.com>"
+  "Tim McGilchrist <timmcgil@gmail.com>"
+]
+license: "Apache-2.0"
+homepage: "https://github.com/ocurrent/ocluster"
+doc: "https://ocurrent.github.io/ocluster/"
+bug-reports: "https://github.com/ocurrent/ocluster/issues"
+depends: [
+  "dune" {>= "3.7"}
+  "ocluster-api" {= version}
+  "ocaml" {>= "4.14.1"}
+  "capnp-rpc-lwt" {>= "1.2.3" & < "2.0"}
+  "cohttp-lwt-unix" {>= "4.0"}
+  "digestif" {>= "0.8"}
+  "extunix" {>= "0.4.1"}
+  "fpath"
+  "logs"
+  "lwt" {>= "5.6.1"}
+  "obuilder" {>= "0.5.1"}
+  "prometheus-app" {>= "1.2"}
+  "odoc" {with-doc}
+]
+available: arch != "x86_32"
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/ocurrent/ocluster.git"
+url {
+  src:
+    "https://github.com/ocurrent/ocluster/releases/download/v0.4.0/ocluster-0.4.0.tbz"
+  checksum: [
+    "md5=b024d87f08bed7a6fb40fd3a1e1d94f5"
+    "sha512=ab58b4279a5763b03c2d158d6261ca6edf800baf89c996f5a849e01ad8f332d6fdf7bb4947b36d8671b5b80a8ccc7faae252763d985464fdfb23287e057e793f"
+  ]
+}
+x-maintenance-intent: ["(latest)"]

--- a/packages/ocluster-worker/ocluster-worker.0.4.0/opam
+++ b/packages/ocluster-worker/ocluster-worker.0.4.0/opam
@@ -27,7 +27,7 @@ depends: [
   "fpath"
   "logs"
   "lwt" {>= "5.7.0"}
-  "obuilder" {>= "0.6.0"}
+  "obuilder" {>= "0.7.0"}
   "prometheus-app" {>= "1.2"}
   "odoc" {with-doc}
 ]

--- a/packages/ocluster-worker/ocluster-worker.0.4.0/opam
+++ b/packages/ocluster-worker/ocluster-worker.0.4.0/opam
@@ -26,8 +26,8 @@ depends: [
   "extunix" {>= "0.4.1"}
   "fpath"
   "logs"
-  "lwt" {>= "5.6.1"}
-  "obuilder" {>= "0.5.1"}
+  "lwt" {>= "5.7.0"}
+  "obuilder" {>= "0.6.0"}
   "prometheus-app" {>= "1.2"}
   "odoc" {with-doc}
 ]

--- a/packages/ocluster/ocluster.0.4.0/opam
+++ b/packages/ocluster/ocluster.0.4.0/opam
@@ -40,10 +40,10 @@ depends: [
   "fmt"
   "fpath"
   "logs"
-  "lwt" {>= "5.6.1"}
+  "lwt" {>= "5.7.0"}
   "lwt-dllist"
   "mirage-crypto" {>= "0.8.5"}
-  "obuilder" {>= "0.5.1"}
+  "obuilder" {>= "0.6.0"}
   "ppx_expect" {>= "v0.14.1"}
   "ppx_sexp_conv"
   "prometheus"

--- a/packages/ocluster/ocluster.0.4.0/opam
+++ b/packages/ocluster/ocluster.0.4.0/opam
@@ -43,7 +43,7 @@ depends: [
   "lwt" {>= "5.7.0"}
   "lwt-dllist"
   "mirage-crypto" {>= "0.8.5"}
-  "obuilder" {>= "0.6.0"}
+  "obuilder" {>= "0.7.0"}
   "ppx_expect" {>= "v0.14.1"}
   "ppx_sexp_conv"
   "prometheus"

--- a/packages/ocluster/ocluster.0.4.0/opam
+++ b/packages/ocluster/ocluster.0.4.0/opam
@@ -1,0 +1,85 @@
+opam-version: "2.0"
+synopsis: "Distribute build jobs to workers"
+description: """\
+OCluster manages a pool of build workers.
+A build scheduler service accepts build jobs from clients and distributes them to worker machines using Cap'n Proto.
+Workers register themselves by connecting to the scheduler (and workers do not need to be able to accept incoming network connections).
+
+The scheduler can manage multiple pools (e.g. `linux-x86_64` and `linux-arm32`).
+Clients say which pool should handle their requests.
+At the moment, two build types are provided: building a Dockerfile, or building an OBuilder spec.
+In either case, the build may done in the context of some Git commit.
+The scheduler tries to schedule similar builds on the same machine, to benefit from caching."""
+maintainer: "Mark Elvers <mark.elvers@tunbury.org>"
+authors: [
+  "Antonin Décimo <antonin@tarides.com>"
+  "David Allsopp <david.allsopp@metastack.com>"
+  "Kate <kit.ty.kate@disroot.org>"
+  "Lucas Pluvinage <lucas@tarides.com>"
+  "Mark Elvers <mark.elvers@tunbury.org>"
+  "Patrick Ferris <patrick@sirref.org>"
+  "Thomas Leonard <talex5@gmail.com>"
+  "Tim McGilchrist <timmcgil@gmail.com>"
+]
+license: "Apache-2.0"
+homepage: "https://github.com/ocurrent/ocluster"
+doc: "https://ocurrent.github.io/ocluster/"
+bug-reports: "https://github.com/ocurrent/ocluster/issues"
+depends: [
+  "dune" {>= "3.7"}
+  "ocluster-api" {= version}
+  "ocluster-worker" {= version}
+  "ocaml" {>= "4.14.1"}
+  "capnp-rpc-lwt" {>= "1.2.3" & < "2.0"}
+  "capnp-rpc-net" {>= "1.2.3" & < "2.0"}
+  "capnp-rpc-unix" {>= "1.2.3" & < "2.0"}
+  "cmdliner" {>= "1.2.0"}
+  "conf-libev" {os != "win32"}
+  "digestif" {>= "0.8"}
+  "dune-build-info"
+  "fmt"
+  "fpath"
+  "logs"
+  "lwt" {>= "5.6.1"}
+  "lwt-dllist"
+  "mirage-crypto" {>= "0.8.5"}
+  "obuilder" {>= "0.5.1"}
+  "ppx_expect" {>= "v0.14.1"}
+  "ppx_sexp_conv"
+  "prometheus"
+  "prometheus-app" {>= "1.2"}
+  "psq" {>= "0.2.1"}
+  "sqlite3"
+  "winsvc" {>= "1.0.1" & os = "win32"}
+  "current_ocluster" {= version & with-test}
+  "alcotest" {>= "1.7.0" & with-test}
+  "alcotest-lwt" {>= "1.7.0" & with-test}
+  "mirage-crypto-rng" {>= "0.11.0" & with-test}
+  "mirage-crypto-rng-lwt" {>= "0.11.0" & with-test}
+  "odoc" {with-doc}
+]
+available: arch != "x86_32"
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/ocurrent/ocluster.git"
+url {
+  src:
+    "https://github.com/ocurrent/ocluster/releases/download/v0.4.0/ocluster-0.4.0.tbz"
+  checksum: [
+    "md5=b024d87f08bed7a6fb40fd3a1e1d94f5"
+    "sha512=ab58b4279a5763b03c2d158d6261ca6edf800baf89c996f5a849e01ad8f332d6fdf7bb4947b36d8671b5b80a8ccc7faae252763d985464fdfb23287e057e793f"
+  ]
+}
+x-maintenance-intent: ["(latest)"]


### PR DESCRIPTION
This pull-request concerns:
- `current_ocluster.0.4.0`: OCurrent plugin for OCluster builds
- `ocluster.0.4.0`: Distribute build jobs to workers
- `ocluster-api.0.4.0`: Cap'n Proto API for OCluster
- `ocluster-worker.0.4.0`: OCluster library for defining workers



---
* Homepage: https://github.com/ocurrent/ocluster
* Source repo: git+https://github.com/ocurrent/ocluster.git
* Bug tracker: https://github.com/ocurrent/ocluster/issues

---
### v0.4.0 (2026-05-13)

- Fix test compilation in release mode (@avsm ocurrent/ocluster#262, reviewed by @mtelvers)
- Update Dockerfile.worker and Dockerfile.worker.alpine base images (@mtelvers ocurrent/ocluster#261 ocurrent/ocluster#260)
- Constrain capnp-rpc-* < 2.0 (@mtelvers ocurrent/ocluster#259)
- Add HCS backend support for Windows containers (@mtelvers ocurrent/ocluster#258)
- Add x-maintenance-intent to opam metadata (@mtelvers ocurrent/ocluster#257)
- Add QEMU backend (@mtelvers ocurrent/ocluster#253, reviewed by @shonfeder)
- Improve Lwt exception handling (@MisterDA ocurrent/ocluster#250, reviewed by @shonfeder)
- Update bundled obuilder; mark it as vendored (@shonfeder ocurrent/ocluster#247, reviewed by @mtelvers)
- Retry on failed docker push, with new Lwt_retry utility (@shonfeder ocurrent/ocluster#246, reviewed by @mtelvers)
- Update base image and opam SHA (@mtelvers ocurrent/ocluster#245)
- Async delete in worker prune path (@mtelvers ocurrent/ocluster#243)



---
:camel: Pull-request generated by opam-publish v2.5.1