### PR TITLE
[new release] dune (18 packages) (3.23.1)

### DIFF
--- a/packages/chrome-trace/chrome-trace.3.23.1/opam
+++ b/packages/chrome-trace/chrome-trace.3.23.1/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+synopsis: "Chrome trace event generation library"
+description:
+  "This library offers no backwards compatibility guarantees. Use at your own risk."
+maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+license: "MIT"
+homepage: "https://github.com/ocaml/dune"
+doc: "https://dune.readthedocs.io/"
+bug-reports: "https://github.com/ocaml/dune/issues"
+depends: [
+  "dune" {>= "3.23"}
+  "ocaml" {>= "4.14"}
+  "odoc" {with-doc}
+]
+dev-repo: "git+https://github.com/ocaml/dune.git"
+x-maintenance-intent: ["(latest)"]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src:
+    "https://github.com/ocaml/dune/releases/download/3.23.1/dune-3.23.1.tbz"
+  checksum: [
+    "sha256=93b4e7157f6ba8feb61cfc5f86008efd2c59037ba78a017d92b4abf30632348f"
+    "sha512=e5566bedc651292ae54d47ba1cdbcfff48962012c1436d0f9ece49a71aa10a674affc092058b0edee56ab2a2405c545b78fde1c472c0b4704c8f58570a2f46cd"
+  ]
+}
+x-commit-hash: "6f6eee69eda59e355bae2ca4e3ad1af678271883"

--- a/packages/dune-action-plugin/dune-action-plugin.3.23.1/opam
+++ b/packages/dune-action-plugin/dune-action-plugin.3.23.1/opam
@@ -1,0 +1,52 @@
+opam-version: "2.0"
+synopsis: "[experimental] API for writing dynamic Dune actions"
+description: """
+
+This library is experimental. No backwards compatibility is implied.
+
+dune-action-plugin provides an API for writing dynamic Dune actions.
+Dynamic dune actions do not need to declare their dependencies
+upfront; they are instead discovered automatically during the
+execution of the action.
+"""
+maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+license: "MIT"
+homepage: "https://github.com/ocaml/dune"
+doc: "https://dune.readthedocs.io/"
+bug-reports: "https://github.com/ocaml/dune/issues"
+depends: [
+  "dune" {>= "3.23"}
+  "dune-glob" {= version}
+  "csexp" {>= "1.5.0"}
+  "ppx_expect" {with-test}
+  "stdune" {= version}
+  "dune-private-libs" {= version}
+  "dune-rpc" {= version}
+  "base-unix"
+  "odoc" {with-doc}
+]
+dev-repo: "git+https://github.com/ocaml/dune.git"
+x-maintenance-intent: ["(latest)"]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src:
+    "https://github.com/ocaml/dune/releases/download/3.23.1/dune-3.23.1.tbz"
+  checksum: [
+    "sha256=93b4e7157f6ba8feb61cfc5f86008efd2c59037ba78a017d92b4abf30632348f"
+    "sha512=e5566bedc651292ae54d47ba1cdbcfff48962012c1436d0f9ece49a71aa10a674affc092058b0edee56ab2a2405c545b78fde1c472c0b4704c8f58570a2f46cd"
+  ]
+}
+x-commit-hash: "6f6eee69eda59e355bae2ca4e3ad1af678271883"

--- a/packages/dune-action-trace/dune-action-trace.3.23.1/opam
+++ b/packages/dune-action-trace/dune-action-trace.3.23.1/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+synopsis: "Dune Action Traces"
+description: "Produce trace events from dune actions"
+maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+license: "MIT"
+homepage: "https://github.com/ocaml/dune"
+doc: "https://dune.readthedocs.io/"
+bug-reports: "https://github.com/ocaml/dune/issues"
+depends: [
+  "dune" {>= "3.23"}
+  "csexp" {>= "1.5.0"}
+  "ocaml" {>= "4.14"}
+  "odoc" {with-doc}
+]
+dev-repo: "git+https://github.com/ocaml/dune.git"
+x-maintenance-intent: ["none"]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src:
+    "https://github.com/ocaml/dune/releases/download/3.23.1/dune-3.23.1.tbz"
+  checksum: [
+    "sha256=93b4e7157f6ba8feb61cfc5f86008efd2c59037ba78a017d92b4abf30632348f"
+    "sha512=e5566bedc651292ae54d47ba1cdbcfff48962012c1436d0f9ece49a71aa10a674affc092058b0edee56ab2a2405c545b78fde1c472c0b4704c8f58570a2f46cd"
+  ]
+}
+x-commit-hash: "6f6eee69eda59e355bae2ca4e3ad1af678271883"

--- a/packages/dune-build-info/dune-build-info.3.23.1/opam
+++ b/packages/dune-build-info/dune-build-info.3.23.1/opam
@@ -1,0 +1,45 @@
+opam-version: "2.0"
+synopsis: "Embed build information inside executable"
+description: """
+The build-info library allows to access information about how the
+executable was built, such as the version of the project at which it
+was built or the list of statically linked libraries with their
+versions.  It supports reporting the version from the version control
+system during development to get an precise reference of when the
+executable was built.
+"""
+maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+license: "MIT"
+homepage: "https://github.com/ocaml/dune"
+doc: "https://dune.readthedocs.io/"
+bug-reports: "https://github.com/ocaml/dune/issues"
+depends: [
+  "dune" {>= "3.23"}
+  "ocaml" {>= "4.08"}
+  "odoc" {with-doc}
+]
+dev-repo: "git+https://github.com/ocaml/dune.git"
+x-maintenance-intent: ["(latest)"]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src:
+    "https://github.com/ocaml/dune/releases/download/3.23.1/dune-3.23.1.tbz"
+  checksum: [
+    "sha256=93b4e7157f6ba8feb61cfc5f86008efd2c59037ba78a017d92b4abf30632348f"
+    "sha512=e5566bedc651292ae54d47ba1cdbcfff48962012c1436d0f9ece49a71aa10a674affc092058b0edee56ab2a2405c545b78fde1c472c0b4704c8f58570a2f46cd"
+  ]
+}
+x-commit-hash: "6f6eee69eda59e355bae2ca4e3ad1af678271883"

--- a/packages/dune-configurator/dune-configurator.3.23.1/opam
+++ b/packages/dune-configurator/dune-configurator.3.23.1/opam
@@ -1,0 +1,49 @@
+opam-version: "2.0"
+synopsis: "Helper library for gathering system configuration"
+description: """
+dune-configurator is a small library that helps writing OCaml scripts that
+test features available on the system, in order to generate config.h
+files for instance.
+Among other things, dune-configurator allows one to:
+- test if a C program compiles
+- query pkg-config
+- import #define from OCaml header files
+- generate config.h file
+"""
+maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+license: "MIT"
+homepage: "https://github.com/ocaml/dune"
+doc: "https://dune.readthedocs.io/"
+bug-reports: "https://github.com/ocaml/dune/issues"
+depends: [
+  "dune" {>= "3.23"}
+  "ocaml" {>= "4.08.0"}
+  "base-unix"
+  "csexp" {>= "1.5.0"}
+  "odoc" {with-doc}
+]
+dev-repo: "git+https://github.com/ocaml/dune.git"
+x-maintenance-intent: ["(latest)"]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src:
+    "https://github.com/ocaml/dune/releases/download/3.23.1/dune-3.23.1.tbz"
+  checksum: [
+    "sha256=93b4e7157f6ba8feb61cfc5f86008efd2c59037ba78a017d92b4abf30632348f"
+    "sha512=e5566bedc651292ae54d47ba1cdbcfff48962012c1436d0f9ece49a71aa10a674affc092058b0edee56ab2a2405c545b78fde1c472c0b4704c8f58570a2f46cd"
+  ]
+}
+x-commit-hash: "6f6eee69eda59e355bae2ca4e3ad1af678271883"

--- a/packages/dune-configurator/dune-configurator.3.23.1/opam
+++ b/packages/dune-configurator/dune-configurator.3.23.1/opam
@@ -18,7 +18,7 @@ doc: "https://dune.readthedocs.io/"
 bug-reports: "https://github.com/ocaml/dune/issues"
 depends: [
   "dune" {>= "3.23"}
-  "ocaml" {>= "4.08.0"}
+  "ocaml" {>= "4.14.0"}
   "base-unix"
   "csexp" {>= "1.5.0"}
   "odoc" {with-doc}

--- a/packages/dune-glob/dune-glob.3.23.1/opam
+++ b/packages/dune-glob/dune-glob.3.23.1/opam
@@ -1,0 +1,42 @@
+opam-version: "2.0"
+synopsis: "Glob string matching language supported by dune"
+description:
+  "dune-glob provides a parser and interpreter for globs as understood by dune language."
+maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+license: "MIT"
+homepage: "https://github.com/ocaml/dune"
+doc: "https://dune.readthedocs.io/"
+bug-reports: "https://github.com/ocaml/dune/issues"
+depends: [
+  "dune" {>= "3.23"}
+  "stdune" {= version}
+  "dyn"
+  "re"
+  "ordering"
+  "odoc" {with-doc}
+]
+dev-repo: "git+https://github.com/ocaml/dune.git"
+x-maintenance-intent: ["(latest)"]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src:
+    "https://github.com/ocaml/dune/releases/download/3.23.1/dune-3.23.1.tbz"
+  checksum: [
+    "sha256=93b4e7157f6ba8feb61cfc5f86008efd2c59037ba78a017d92b4abf30632348f"
+    "sha512=e5566bedc651292ae54d47ba1cdbcfff48962012c1436d0f9ece49a71aa10a674affc092058b0edee56ab2a2405c545b78fde1c472c0b4704c8f58570a2f46cd"
+  ]
+}
+x-commit-hash: "6f6eee69eda59e355bae2ca4e3ad1af678271883"

--- a/packages/dune-private-libs/dune-private-libs.3.23.1/opam
+++ b/packages/dune-private-libs/dune-private-libs.3.23.1/opam
@@ -1,0 +1,50 @@
+opam-version: "2.0"
+synopsis: "Private libraries of Dune"
+description: """
+!!!!!!!!!!!!!!!!!!!!!!
+!!!!! DO NOT USE !!!!!
+!!!!!!!!!!!!!!!!!!!!!!
+
+This package contains code that is shared between various dune-xxx
+packages. However, it is not meant for public consumption and provides
+no stability guarantee.
+"""
+maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+license: "MIT"
+homepage: "https://github.com/ocaml/dune"
+doc: "https://dune.readthedocs.io/"
+bug-reports: "https://github.com/ocaml/dune/issues"
+depends: [
+  "dune" {>= "3.23"}
+  "csexp" {>= "1.5.0"}
+  "pp" {>= "1.1.0"}
+  "dyn" {= version}
+  "stdune" {= version}
+  "ocaml" {>= "4.14"}
+  "odoc" {with-doc}
+]
+dev-repo: "git+https://github.com/ocaml/dune.git"
+x-maintenance-intent: ["none"]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src:
+    "https://github.com/ocaml/dune/releases/download/3.23.1/dune-3.23.1.tbz"
+  checksum: [
+    "sha256=93b4e7157f6ba8feb61cfc5f86008efd2c59037ba78a017d92b4abf30632348f"
+    "sha512=e5566bedc651292ae54d47ba1cdbcfff48962012c1436d0f9ece49a71aa10a674affc092058b0edee56ab2a2405c545b78fde1c472c0b4704c8f58570a2f46cd"
+  ]
+}
+x-commit-hash: "6f6eee69eda59e355bae2ca4e3ad1af678271883"

--- a/packages/dune-rpc-lwt/dune-rpc-lwt.3.23.1/opam
+++ b/packages/dune-rpc-lwt/dune-rpc-lwt.3.23.1/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+synopsis: "Communicate with dune using rpc and Lwt"
+description: "Specialization of dune-rpc to Lwt"
+maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+license: "MIT"
+homepage: "https://github.com/ocaml/dune"
+doc: "https://dune.readthedocs.io/"
+bug-reports: "https://github.com/ocaml/dune/issues"
+depends: [
+  "dune" {>= "3.23"}
+  "dune-rpc" {= version}
+  "csexp" {>= "1.5.0"}
+  "lwt" {>= "5.6.0"}
+  "base-unix"
+  "odoc" {with-doc}
+]
+dev-repo: "git+https://github.com/ocaml/dune.git"
+x-maintenance-intent: ["(latest)"]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src:
+    "https://github.com/ocaml/dune/releases/download/3.23.1/dune-3.23.1.tbz"
+  checksum: [
+    "sha256=93b4e7157f6ba8feb61cfc5f86008efd2c59037ba78a017d92b4abf30632348f"
+    "sha512=e5566bedc651292ae54d47ba1cdbcfff48962012c1436d0f9ece49a71aa10a674affc092058b0edee56ab2a2405c545b78fde1c472c0b4704c8f58570a2f46cd"
+  ]
+}
+x-commit-hash: "6f6eee69eda59e355bae2ca4e3ad1af678271883"

--- a/packages/dune-rpc/dune-rpc.3.23.1/opam
+++ b/packages/dune-rpc/dune-rpc.3.23.1/opam
@@ -1,0 +1,44 @@
+opam-version: "2.0"
+synopsis: "Communicate with dune using rpc"
+description: "Library to connect and control a running dune instance"
+maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+license: "MIT"
+homepage: "https://github.com/ocaml/dune"
+doc: "https://dune.readthedocs.io/"
+bug-reports: "https://github.com/ocaml/dune/issues"
+depends: [
+  "dune" {>= "3.23"}
+  "ocamlc-loc"
+  "csexp"
+  "ordering"
+  "dyn"
+  "xdg"
+  "stdune" {= version}
+  "pp" {>= "1.1.0"}
+  "odoc" {with-doc}
+]
+dev-repo: "git+https://github.com/ocaml/dune.git"
+x-maintenance-intent: ["(latest)"]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src:
+    "https://github.com/ocaml/dune/releases/download/3.23.1/dune-3.23.1.tbz"
+  checksum: [
+    "sha256=93b4e7157f6ba8feb61cfc5f86008efd2c59037ba78a017d92b4abf30632348f"
+    "sha512=e5566bedc651292ae54d47ba1cdbcfff48962012c1436d0f9ece49a71aa10a674affc092058b0edee56ab2a2405c545b78fde1c472c0b4704c8f58570a2f46cd"
+  ]
+}
+x-commit-hash: "6f6eee69eda59e355bae2ca4e3ad1af678271883"

--- a/packages/dune-site/dune-site.3.23.1/opam
+++ b/packages/dune-site/dune-site.3.23.1/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+synopsis: "Embed locations information inside executable and libraries"
+maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+license: "MIT"
+homepage: "https://github.com/ocaml/dune"
+doc: "https://dune.readthedocs.io/"
+bug-reports: "https://github.com/ocaml/dune/issues"
+depends: [
+  "dune" {>= "3.23"}
+  "dune-private-libs" {= version}
+  "odoc" {with-doc}
+]
+dev-repo: "git+https://github.com/ocaml/dune.git"
+x-maintenance-intent: ["(latest)"]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src:
+    "https://github.com/ocaml/dune/releases/download/3.23.1/dune-3.23.1.tbz"
+  checksum: [
+    "sha256=93b4e7157f6ba8feb61cfc5f86008efd2c59037ba78a017d92b4abf30632348f"
+    "sha512=e5566bedc651292ae54d47ba1cdbcfff48962012c1436d0f9ece49a71aa10a674affc092058b0edee56ab2a2405c545b78fde1c472c0b4704c8f58570a2f46cd"
+  ]
+}
+x-commit-hash: "6f6eee69eda59e355bae2ca4e3ad1af678271883"

--- a/packages/dune/dune.3.23.1/opam
+++ b/packages/dune/dune.3.23.1/opam
@@ -1,0 +1,80 @@
+opam-version: "2.0"
+synopsis: "Fast, portable, and opinionated build system"
+description: """
+
+Dune is a build system that was designed to simplify the release of
+Jane Street packages. It reads metadata from "dune" files following a
+very simple s-expression syntax.
+
+Dune is fast, has very low-overhead, and supports parallel builds on
+all platforms. It has no system dependencies; all you need to build
+dune or packages using dune is OCaml. You don't need make or bash
+as long as the packages themselves don't use bash explicitly.
+
+Dune is composable; supporting multi-package development by simply
+dropping multiple repositories into the same directory.
+
+Dune also supports multi-context builds, such as building against
+several opam roots/switches simultaneously. This helps maintaining
+packages across several versions of OCaml and gives cross-compilation
+for free.
+"""
+maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+license: "MIT"
+homepage: "https://github.com/ocaml/dune"
+doc: "https://dune.readthedocs.io/"
+bug-reports: "https://github.com/ocaml/dune/issues"
+conflicts: [
+  "merlin" {< "3.4.0"}
+  "ocaml-lsp-server" {< "1.3.0"}
+  "dune-configurator" {< "2.3.0"}
+  "odoc" {< "2.0.1"}
+  "dune-release" {< "2.0.0"}
+  "js_of_ocaml-compiler" {< "3.6.0"}
+  "jbuilder" {= "transition"}
+]
+dev-repo: "git+https://github.com/ocaml/dune.git"
+x-maintenance-intent: ["(latest)"]
+build: [
+  ["ocaml" "boot/bootstrap.ml" "-j" jobs]
+  ["./_boot/dune.exe" "build" "dune.install" "--release" "--profile" "dune-bootstrap" "-j" jobs]
+]
+depends: [
+  # Please keep the lower bound in sync with .github/workflows/workflow.yml,
+  # dune-project and min_ocaml_version in bootstrap.ml
+  ("ocaml" {>= "4.14"} | ("ocaml" {>= "4.02" & < "4.14~~"} & "ocamlfind-secondary" & "ocaml-secondary-compiler" {>= "4.14"}))
+  "base-unix"
+  "base-threads"
+  "lwt" { with-dev-setup & os != "win32" }
+  "cinaps" { with-dev-setup }
+  "csexp" { with-dev-setup & >= "1.3.0" }
+  "js_of_ocaml" { with-dev-setup & >= "6.1.0" & os != "win32" }
+  "js_of_ocaml-compiler" { with-dev-setup & >= "6.1.0" & os != "win32" }
+  "mdx" { with-dev-setup & >= "2.3.0" & os != "win32" }
+  "menhir" { with-dev-setup & os != "win32" }
+  "ocamlfind" { with-dev-setup & os != "win32" }
+  "odoc" { with-dev-setup & >= "2.4.0" & os != "win32" }
+  "ppx_expect" { with-dev-setup & >= "v0.17" & os != "win32" }
+  "spawn" { with-dev-setup }
+  "ppx_inline_test" { with-dev-setup & os != "win32" }
+  "ppxlib" { with-dev-setup & >= "0.37.0" & os != "win32" }
+  "ctypes" { with-dev-setup & os != "win32" }
+  "utop" { with-dev-setup & >= "2.6.0" & os != "win32" }
+  "melange" { with-dev-setup & >= "5.1.0-51" & os != "win32" }
+  "uutf" { with-dev-setup }
+]
+depexts: [
+  # the rev store negotiation test launches a git daemon, needs it to be
+  # installed, which is not the case on Fedora by default
+  ["git-daemon"] { with-test & os-family = "fedora" }
+]
+url {
+  src:
+    "https://github.com/ocaml/dune/releases/download/3.23.1/dune-3.23.1.tbz"
+  checksum: [
+    "sha256=93b4e7157f6ba8feb61cfc5f86008efd2c59037ba78a017d92b4abf30632348f"
+    "sha512=e5566bedc651292ae54d47ba1cdbcfff48962012c1436d0f9ece49a71aa10a674affc092058b0edee56ab2a2405c545b78fde1c472c0b4704c8f58570a2f46cd"
+  ]
+}
+x-commit-hash: "6f6eee69eda59e355bae2ca4e3ad1af678271883"

--- a/packages/dune/dune.3.23.1/opam
+++ b/packages/dune/dune.3.23.1/opam
@@ -63,11 +63,9 @@ depends: [
   "utop" { with-dev-setup & >= "2.6.0" & os != "win32" }
   "melange" { with-dev-setup & >= "5.1.0-51" & os != "win32" }
   "uutf" { with-dev-setup }
-]
-depexts: [
   # the rev store negotiation test launches a git daemon, needs it to be
-  # installed, which is not the case on Fedora by default
-  ["git-daemon"] { with-test & os-family = "fedora" }
+  # installed on some distributions
+  "conf-git-daemon" { with-test }
 ]
 url {
   src:

--- a/packages/dyn/dyn.3.23.1/opam
+++ b/packages/dyn/dyn.3.23.1/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+synopsis: "Dynamic type"
+description: "Dynamic type"
+maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+license: "MIT"
+homepage: "https://github.com/ocaml/dune"
+doc: "https://dune.readthedocs.io/"
+bug-reports: "https://github.com/ocaml/dune/issues"
+depends: [
+  "dune" {>= "3.23"}
+  "ocaml" {>= "4.14"}
+  "ordering" {= version}
+  "pp" {>= "1.1.0"}
+  "odoc" {with-doc}
+]
+dev-repo: "git+https://github.com/ocaml/dune.git"
+x-maintenance-intent: ["none"]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src:
+    "https://github.com/ocaml/dune/releases/download/3.23.1/dune-3.23.1.tbz"
+  checksum: [
+    "sha256=93b4e7157f6ba8feb61cfc5f86008efd2c59037ba78a017d92b4abf30632348f"
+    "sha512=e5566bedc651292ae54d47ba1cdbcfff48962012c1436d0f9ece49a71aa10a674affc092058b0edee56ab2a2405c545b78fde1c472c0b4704c8f58570a2f46cd"
+  ]
+}
+x-commit-hash: "6f6eee69eda59e355bae2ca4e3ad1af678271883"

--- a/packages/fs-io/fs-io.3.23.1/opam
+++ b/packages/fs-io/fs-io.3.23.1/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+synopsis: "File System Operations"
+description: "Misc. Collection of File System Operations"
+maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+license: "MIT"
+homepage: "https://github.com/ocaml/dune"
+doc: "https://dune.readthedocs.io/"
+bug-reports: "https://github.com/ocaml/dune/issues"
+depends: [
+  "dune" {>= "3.23"}
+  "base-unix"
+  "ocaml" {>= "4.14"}
+  "odoc" {with-doc}
+]
+dev-repo: "git+https://github.com/ocaml/dune.git"
+x-maintenance-intent: ["none"]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src:
+    "https://github.com/ocaml/dune/releases/download/3.23.1/dune-3.23.1.tbz"
+  checksum: [
+    "sha256=93b4e7157f6ba8feb61cfc5f86008efd2c59037ba78a017d92b4abf30632348f"
+    "sha512=e5566bedc651292ae54d47ba1cdbcfff48962012c1436d0f9ece49a71aa10a674affc092058b0edee56ab2a2405c545b78fde1c472c0b4704c8f58570a2f46cd"
+  ]
+}
+x-commit-hash: "6f6eee69eda59e355bae2ca4e3ad1af678271883"

--- a/packages/ocamlc-loc/ocamlc-loc.3.23.1/opam
+++ b/packages/ocamlc-loc/ocamlc-loc.3.23.1/opam
@@ -1,0 +1,43 @@
+opam-version: "2.0"
+synopsis: "Parse ocaml compiler output into structured form"
+description:
+  "This library offers no backwards compatibility guarantees. Use at your own risk."
+maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+license: "MIT"
+homepage: "https://github.com/ocaml/dune"
+doc: "https://dune.readthedocs.io/"
+bug-reports: "https://github.com/ocaml/dune/issues"
+depends: [
+  "dune" {>= "3.23"}
+  "ocaml" {>= "4.14"}
+  "dyn" {= version}
+  "odoc" {with-doc}
+]
+conflicts: [
+  "ocaml-lsp-server" {< "1.17.0"}
+]
+dev-repo: "git+https://github.com/ocaml/dune.git"
+x-maintenance-intent: ["none"]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src:
+    "https://github.com/ocaml/dune/releases/download/3.23.1/dune-3.23.1.tbz"
+  checksum: [
+    "sha256=93b4e7157f6ba8feb61cfc5f86008efd2c59037ba78a017d92b4abf30632348f"
+    "sha512=e5566bedc651292ae54d47ba1cdbcfff48962012c1436d0f9ece49a71aa10a674affc092058b0edee56ab2a2405c545b78fde1c472c0b4704c8f58570a2f46cd"
+  ]
+}
+x-commit-hash: "6f6eee69eda59e355bae2ca4e3ad1af678271883"

--- a/packages/ordering/ordering.3.23.1/opam
+++ b/packages/ordering/ordering.3.23.1/opam
@@ -1,0 +1,38 @@
+opam-version: "2.0"
+synopsis: "Element ordering"
+description: "Element ordering"
+maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+license: "MIT"
+homepage: "https://github.com/ocaml/dune"
+doc: "https://dune.readthedocs.io/"
+bug-reports: "https://github.com/ocaml/dune/issues"
+depends: [
+  "dune" {>= "3.23"}
+  "ocaml" {>= "4.14"}
+  "odoc" {with-doc}
+]
+dev-repo: "git+https://github.com/ocaml/dune.git"
+x-maintenance-intent: ["none"]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src:
+    "https://github.com/ocaml/dune/releases/download/3.23.1/dune-3.23.1.tbz"
+  checksum: [
+    "sha256=93b4e7157f6ba8feb61cfc5f86008efd2c59037ba78a017d92b4abf30632348f"
+    "sha512=e5566bedc651292ae54d47ba1cdbcfff48962012c1436d0f9ece49a71aa10a674affc092058b0edee56ab2a2405c545b78fde1c472c0b4704c8f58570a2f46cd"
+  ]
+}
+x-commit-hash: "6f6eee69eda59e355bae2ca4e3ad1af678271883"

--- a/packages/stdune/stdune.3.23.1/opam
+++ b/packages/stdune/stdune.3.23.1/opam
@@ -1,0 +1,46 @@
+opam-version: "2.0"
+synopsis: "Dune's unstable standard library"
+description:
+  "This library offers no backwards compatibility guarantees. Use at your own risk."
+maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+license: "MIT"
+homepage: "https://github.com/ocaml/dune"
+doc: "https://dune.readthedocs.io/"
+bug-reports: "https://github.com/ocaml/dune/issues"
+depends: [
+  "dune" {>= "3.23"}
+  "ocaml" {>= "4.14"}
+  "base-unix"
+  "csexp" {>= "1.5.0"}
+  "dyn" {= version}
+  "fs-io" {= version}
+  "ordering" {= version}
+  "pp" {>= "2.0.0"}
+  "top-closure" {= version}
+  "odoc" {with-doc}
+]
+dev-repo: "git+https://github.com/ocaml/dune.git"
+x-maintenance-intent: ["none"]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src:
+    "https://github.com/ocaml/dune/releases/download/3.23.1/dune-3.23.1.tbz"
+  checksum: [
+    "sha256=93b4e7157f6ba8feb61cfc5f86008efd2c59037ba78a017d92b4abf30632348f"
+    "sha512=e5566bedc651292ae54d47ba1cdbcfff48962012c1436d0f9ece49a71aa10a674affc092058b0edee56ab2a2405c545b78fde1c472c0b4704c8f58570a2f46cd"
+  ]
+}
+x-commit-hash: "6f6eee69eda59e355bae2ca4e3ad1af678271883"

--- a/packages/top-closure/top-closure.3.23.1/opam
+++ b/packages/top-closure/top-closure.3.23.1/opam
@@ -1,0 +1,38 @@
+opam-version: "2.0"
+synopsis: "Topological Closure"
+description: "Generic Topological Closure"
+maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+license: "MIT"
+homepage: "https://github.com/ocaml/dune"
+doc: "https://dune.readthedocs.io/"
+bug-reports: "https://github.com/ocaml/dune/issues"
+depends: [
+  "dune" {>= "3.23"}
+  "ocaml" {>= "4.14"}
+  "odoc" {with-doc}
+]
+dev-repo: "git+https://github.com/ocaml/dune.git"
+x-maintenance-intent: ["none"]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src:
+    "https://github.com/ocaml/dune/releases/download/3.23.1/dune-3.23.1.tbz"
+  checksum: [
+    "sha256=93b4e7157f6ba8feb61cfc5f86008efd2c59037ba78a017d92b4abf30632348f"
+    "sha512=e5566bedc651292ae54d47ba1cdbcfff48962012c1436d0f9ece49a71aa10a674affc092058b0edee56ab2a2405c545b78fde1c472c0b4704c8f58570a2f46cd"
+  ]
+}
+x-commit-hash: "6f6eee69eda59e355bae2ca4e3ad1af678271883"

--- a/packages/xdg/xdg.3.23.1/opam
+++ b/packages/xdg/xdg.3.23.1/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+synopsis: "XDG Base Directory Specification"
+description:
+  "https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html"
+maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+license: "MIT"
+homepage: "https://github.com/ocaml/dune"
+doc: "https://dune.readthedocs.io/"
+bug-reports: "https://github.com/ocaml/dune/issues"
+depends: [
+  "dune" {>= "3.23"}
+  "ocaml" {>= "4.14"}
+  "odoc" {with-doc}
+]
+dev-repo: "git+https://github.com/ocaml/dune.git"
+x-maintenance-intent: ["(latest)"]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src:
+    "https://github.com/ocaml/dune/releases/download/3.23.1/dune-3.23.1.tbz"
+  checksum: [
+    "sha256=93b4e7157f6ba8feb61cfc5f86008efd2c59037ba78a017d92b4abf30632348f"
+    "sha512=e5566bedc651292ae54d47ba1cdbcfff48962012c1436d0f9ece49a71aa10a674affc092058b0edee56ab2a2405c545b78fde1c472c0b4704c8f58570a2f46cd"
+  ]
+}
+x-commit-hash: "6f6eee69eda59e355bae2ca4e3ad1af678271883"


### PR DESCRIPTION
Fast, portable, and opinionated build system

- Project page: <a href="https://github.com/ocaml/dune">https://github.com/ocaml/dune</a>
- Documentation: <a href="https://dune.readthedocs.io/">https://dune.readthedocs.io/</a>

##### CHANGES:

### Fixed

- Fix the `menhir` opam dependency injection introduced in 3.23. Dune
  now only fills in the lower bound `{>= "20180523"}` on an existing
  user-declared `menhir` dependency; it no longer adds `menhir` as a
  new dependency to packages that did not declare it themselves.
  (ocaml/dune#14434, fixes ocaml/dune#14428, @robinbb)

- Gate the `dune` version-bound deduplication in generated opam files
  (introduced in 3.23) on `(lang dune 3.23)`. Projects at earlier lang
  versions get the prior `And [...]` shape — e.g.
  `{>= "3.17" & >= "3.20"}` — restoring 3.22 behaviour and avoiding a
  silent change to opam output on dune-binary upgrade. (ocaml/dune#14436,
  @robinbb)

- Preserve library order when building a shared jsoo standalone runtime.
  (ocaml/dune#14438, @vouillon)

- Fix the fallback to the secondary compiler, allowing recovering of support for
  packages with upper bounds on OCaml less than 4.14. Packages depending on dune
  3.23.1 or later and with an upper bound on the OCaml compiler that is less
  than 4.14, will now be able to use the latest dune, but dune will be built
  with the secondary compiler at version 4.14. (ocaml/dune#14443, @Alizter)

- Fix the bootstrap on NetBSD by including `<sys/wait.h>` in `lev_stubs.c`,
  matching the existing FreeBSD/OpenBSD guard.
  (ocaml/dune#14512, fixes ocaml/dune#14484, @0-wiz-0)
