### PR TITLE
[new release] lintcstubs-arity (0.5.2)

### DIFF
--- a/packages/lintcstubs-arity/lintcstubs-arity.0.5.2/opam
+++ b/packages/lintcstubs-arity/lintcstubs-arity.0.5.2/opam
@@ -1,0 +1,42 @@
+opam-version: "2.0"
+synopsis: "Generate headers for C bindings"
+description:
+  "Generates .h files from 'external' declarations in .ml or .cmt files. Can be used to spot mismatches in number of arguments between C primitive declared in OCaml and its implementation in the .c file."
+maintainer: ["Edwin Török <edwin@etorok.net>"]
+authors: ["Edwin Török <edwin.torok@citrix.com>"]
+license: "LGPL-2.1-or-later"
+homepage: "https://codeberg.org/edwintorok/lintcstubs-arity"
+bug-reports: "https://codeberg.org/edwintorok/lintcstubs-arity/issues"
+depends: [
+  "dune" {>= "3.18"}
+  "ocaml" {>= "4.10"}
+  "odoc" {with-doc}
+]
+depopts: [
+  "ocaml-src" {with-test}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://codeberg.org/edwintorok/lintcstubs-arity.git"
+x-maintenance-intent: ["(latest)"]
+url {
+  src:
+    "https://codeberg.org/edwintorok/lintcstubs-arity/releases/download/0.5.2/lintcstubs-arity-0.5.2.tbz"
+  checksum: [
+    "sha256=9fe1fbefa215ad0e6d974500f8259f06cb55f59227d59134fc2fcfa5fe8a840f"
+    "sha512=737a11f5dbfab51458e78014f24d4ad045f29bb50f81490a596273c4c84f7a47402b0583707818197bbd9da4da79fbc9ac238d929f9290c414c15e45684bb8df"
+  ]
+}
+x-commit-hash: "e1b2670f202a8f37fd6fc56395eb3e6ed67bf4ef"


### PR DESCRIPTION
Generate headers for C bindings

- Project page: <a href="https://codeberg.org/edwintorok/lintcstubs-arity">https://codeberg.org/edwintorok/lintcstubs-arity</a>

##### CHANGES:

* OCaml 5.5 support
