### PR TITLE
Windows dependency graph fixes

### DIFF
--- a/packages/ocaml-base-compiler/ocaml-base-compiler.4.13.0/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.4.13.0/opam
@@ -1,7 +1,15 @@
 opam-version: "2.0"
+# These packages are part of the infrastructure for maintaining the OCaml
+# compiler dependencies in opam. It's not possible to version the metadata
+# itself, because opam's versioning provides no mechanism to ignore the
+# revision (i.e. we don't have a way to have two revisions of ocaml.5.4.1 but
+# where "ocaml" {= "5.4.1"} would always mean to use the latest revision).
+# It is however useful to know which version of the metadata is installed.
+# This number should be bumped whenever a pertinent change is made.
+x-revision: "7"
 synopsis: "Official release 4.13.0"
 maintainer: [
-  "David Allsopp <david@tarides.com>"
+  "David Allsopp <dra27@dra27.uk>"
   "Florian Angeletti <florian.angeletti@inria.fr>"
 ]
 license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.4.13.0/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.4.13.0/opam
@@ -6,7 +6,7 @@ opam-version: "2.0"
 # where "ocaml" {= "5.4.1"} would always mean to use the latest revision).
 # It is however useful to know which version of the metadata is installed.
 # This number should be bumped whenever a pertinent change is made.
-x-revision: "7"
+x-revision: "8"
 synopsis: "Official release 4.13.0"
 maintainer: [
   "David Allsopp <dra27@dra27.uk>"
@@ -29,12 +29,10 @@ depends: [
   # Port selection (Windows)
   # amd64 mingw-w64 / MSVC
   (("arch-x86_64" {os = "win32" & arch = "x86_64"} &
-     (("system-mingw" & "mingw-w64-shims" {os-distribution = "cygwin" & post}) |
-      "system-msvc")) |
+     ("system-mingw" | "system-msvc")) |
   # i686 mingw-w64 / MSVC
    ("arch-x86_32" {os = "win32"} &
-     (("system-mingw" & "mingw-w64-shims" {os-distribution = "cygwin" & post}) |
-      "system-msvc")) |
+     ("system-mingw" | "system-msvc")) |
   # Non-Windows systems need to install something to satisfy this formula, so
   # repeat the base-unix dependency
    "base-unix" {os != "win32" & post})

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.4.13.1/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.4.13.1/opam
@@ -1,7 +1,15 @@
 opam-version: "2.0"
+# These packages are part of the infrastructure for maintaining the OCaml
+# compiler dependencies in opam. It's not possible to version the metadata
+# itself, because opam's versioning provides no mechanism to ignore the
+# revision (i.e. we don't have a way to have two revisions of ocaml.5.4.1 but
+# where "ocaml" {= "5.4.1"} would always mean to use the latest revision).
+# It is however useful to know which version of the metadata is installed.
+# This number should be bumped whenever a pertinent change is made.
+x-revision: "7"
 synopsis: "Official release 4.13.1"
 maintainer: [
-  "David Allsopp <david@tarides.com>"
+  "David Allsopp <dra27@dra27.uk>"
   "Florian Angeletti <florian.angeletti@inria.fr>"
 ]
 license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.4.13.1/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.4.13.1/opam
@@ -6,7 +6,7 @@ opam-version: "2.0"
 # where "ocaml" {= "5.4.1"} would always mean to use the latest revision).
 # It is however useful to know which version of the metadata is installed.
 # This number should be bumped whenever a pertinent change is made.
-x-revision: "7"
+x-revision: "8"
 synopsis: "Official release 4.13.1"
 maintainer: [
   "David Allsopp <dra27@dra27.uk>"
@@ -29,12 +29,10 @@ depends: [
   # Port selection (Windows)
   # amd64 mingw-w64 / MSVC
   (("arch-x86_64" {os = "win32" & arch = "x86_64"} &
-     (("system-mingw" & "mingw-w64-shims" {os-distribution = "cygwin" & post}) |
-      "system-msvc")) |
+     ("system-mingw" | "system-msvc")) |
   # i686 mingw-w64 / MSVC
    ("arch-x86_32" {os = "win32"} &
-     (("system-mingw" & "mingw-w64-shims" {os-distribution = "cygwin" & post}) |
-      "system-msvc")) |
+     ("system-mingw" | "system-msvc")) |
   # Non-Windows systems need to install something to satisfy this formula, so
   # repeat the base-unix dependency
    "base-unix" {os != "win32" & post})

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.4.14.0/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.4.14.0/opam
@@ -1,7 +1,15 @@
 opam-version: "2.0"
+# These packages are part of the infrastructure for maintaining the OCaml
+# compiler dependencies in opam. It's not possible to version the metadata
+# itself, because opam's versioning provides no mechanism to ignore the
+# revision (i.e. we don't have a way to have two revisions of ocaml.5.4.1 but
+# where "ocaml" {= "5.4.1"} would always mean to use the latest revision).
+# It is however useful to know which version of the metadata is installed.
+# This number should be bumped whenever a pertinent change is made.
+x-revision: "8"
 synopsis: "Official release 4.14.0"
 maintainer: [
-  "David Allsopp <david@tarides.com>"
+  "David Allsopp <dra27@dra27.uk>"
   "Florian Angeletti <florian.angeletti@inria.fr>"
 ]
 license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.4.14.0/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.4.14.0/opam
@@ -6,7 +6,7 @@ opam-version: "2.0"
 # where "ocaml" {= "5.4.1"} would always mean to use the latest revision).
 # It is however useful to know which version of the metadata is installed.
 # This number should be bumped whenever a pertinent change is made.
-x-revision: "8"
+x-revision: "9"
 synopsis: "Official release 4.14.0"
 maintainer: [
   "David Allsopp <dra27@dra27.uk>"
@@ -29,12 +29,10 @@ depends: [
   # Port selection (Windows)
   # amd64 mingw-w64 / MSVC
   (("arch-x86_64" {os = "win32" & arch = "x86_64"} &
-     (("system-mingw" & "mingw-w64-shims" {os-distribution = "cygwin" & post}) |
-      "system-msvc")) |
+     ("system-mingw" | "system-msvc")) |
   # i686 mingw-w64 / MSVC
    ("arch-x86_32" {os = "win32"} &
-     (("system-mingw" & "mingw-w64-shims" {os-distribution = "cygwin" & post}) |
-      "system-msvc")) |
+     ("system-mingw" | "system-msvc")) |
   # Non-Windows systems need to install something to satisfy this formula, so
   # repeat the base-unix dependency
    "base-unix" {os != "win32" & post})

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.4.14.1/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.4.14.1/opam
@@ -1,7 +1,15 @@
 opam-version: "2.0"
+# These packages are part of the infrastructure for maintaining the OCaml
+# compiler dependencies in opam. It's not possible to version the metadata
+# itself, because opam's versioning provides no mechanism to ignore the
+# revision (i.e. we don't have a way to have two revisions of ocaml.5.4.1 but
+# where "ocaml" {= "5.4.1"} would always mean to use the latest revision).
+# It is however useful to know which version of the metadata is installed.
+# This number should be bumped whenever a pertinent change is made.
+x-revision: "7"
 synopsis: "Official release 4.14.1"
 maintainer: [
-  "David Allsopp <david@tarides.com>"
+  "David Allsopp <dra27@dra27.uk>"
   "Florian Angeletti <florian.angeletti@inria.fr>"
 ]
 license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.4.14.1/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.4.14.1/opam
@@ -6,7 +6,7 @@ opam-version: "2.0"
 # where "ocaml" {= "5.4.1"} would always mean to use the latest revision).
 # It is however useful to know which version of the metadata is installed.
 # This number should be bumped whenever a pertinent change is made.
-x-revision: "7"
+x-revision: "8"
 synopsis: "Official release 4.14.1"
 maintainer: [
   "David Allsopp <dra27@dra27.uk>"
@@ -29,12 +29,10 @@ depends: [
   # Port selection (Windows)
   # amd64 mingw-w64 / MSVC
   (("arch-x86_64" {os = "win32" & arch = "x86_64"} &
-     (("system-mingw" & "mingw-w64-shims" {os-distribution = "cygwin" & post}) |
-      "system-msvc")) |
+     ("system-mingw" | "system-msvc")) |
   # i686 mingw-w64 / MSVC
    ("arch-x86_32" {os = "win32"} &
-     (("system-mingw" & "mingw-w64-shims" {os-distribution = "cygwin" & post}) |
-      "system-msvc")) |
+     ("system-mingw" | "system-msvc")) |
   # Non-Windows systems need to install something to satisfy this formula, so
   # repeat the base-unix dependency
    "base-unix" {os != "win32" & post})

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.4.14.2/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.4.14.2/opam
@@ -6,7 +6,7 @@ opam-version: "2.0"
 # where "ocaml" {= "5.4.1"} would always mean to use the latest revision).
 # It is however useful to know which version of the metadata is installed.
 # This number should be bumped whenever a pertinent change is made.
-x-revision: "7"
+x-revision: "8"
 synopsis: "Official release 4.14.2"
 maintainer: [
   "David Allsopp <dra27@dra27.uk>"
@@ -29,12 +29,10 @@ depends: [
   # Port selection (Windows)
   # amd64 mingw-w64 / MSVC
   (("arch-x86_64" {os = "win32" & arch = "x86_64"} &
-     (("system-mingw" & "mingw-w64-shims" {os-distribution = "cygwin" & post}) |
-      "system-msvc")) |
+     ("system-mingw" | "system-msvc")) |
   # i686 mingw-w64 / MSVC
    ("arch-x86_32" {os = "win32"} &
-     (("system-mingw" & "mingw-w64-shims" {os-distribution = "cygwin" & post}) |
-      "system-msvc")) |
+     ("system-mingw" | "system-msvc")) |
   # Non-Windows systems need to install something to satisfy this formula, so
   # repeat the base-unix dependency
    "base-unix" {os != "win32" & post})

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.4.14.2/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.4.14.2/opam
@@ -1,7 +1,15 @@
 opam-version: "2.0"
+# These packages are part of the infrastructure for maintaining the OCaml
+# compiler dependencies in opam. It's not possible to version the metadata
+# itself, because opam's versioning provides no mechanism to ignore the
+# revision (i.e. we don't have a way to have two revisions of ocaml.5.4.1 but
+# where "ocaml" {= "5.4.1"} would always mean to use the latest revision).
+# It is however useful to know which version of the metadata is installed.
+# This number should be bumped whenever a pertinent change is made.
+x-revision: "7"
 synopsis: "Official release 4.14.2"
 maintainer: [
-  "David Allsopp <david@tarides.com>"
+  "David Allsopp <dra27@dra27.uk>"
   "Florian Angeletti <florian.angeletti@inria.fr>"
 ]
 license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.4.14.3/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.4.14.3/opam
@@ -6,7 +6,7 @@ opam-version: "2.0"
 # where "ocaml" {= "5.4.1"} would always mean to use the latest revision).
 # It is however useful to know which version of the metadata is installed.
 # This number should be bumped whenever a pertinent change is made.
-x-revision: "2"
+x-revision: "3"
 synopsis: "Official release 4.14.3"
 maintainer: [
   "David Allsopp <dra27@dra27.uk>"
@@ -29,12 +29,10 @@ depends: [
   # Port selection (Windows)
   # amd64 mingw-w64 / MSVC
   (("arch-x86_64" {os = "win32" & arch = "x86_64"} &
-     (("system-mingw" & "mingw-w64-shims" {os-distribution = "cygwin" & post}) |
-      "system-msvc")) |
+     ("system-mingw" | "system-msvc")) |
   # i686 mingw-w64 / MSVC
    ("arch-x86_32" {os = "win32"} &
-     (("system-mingw" & "mingw-w64-shims" {os-distribution = "cygwin" & post}) |
-      "system-msvc")) |
+     ("system-mingw" | "system-msvc")) |
   # Non-Windows systems need to install something to satisfy this formula, so
   # repeat the base-unix dependency
    "base-unix" {os != "win32" & post})

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.4.14.3/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.4.14.3/opam
@@ -1,7 +1,15 @@
 opam-version: "2.0"
+# These packages are part of the infrastructure for maintaining the OCaml
+# compiler dependencies in opam. It's not possible to version the metadata
+# itself, because opam's versioning provides no mechanism to ignore the
+# revision (i.e. we don't have a way to have two revisions of ocaml.5.4.1 but
+# where "ocaml" {= "5.4.1"} would always mean to use the latest revision).
+# It is however useful to know which version of the metadata is installed.
+# This number should be bumped whenever a pertinent change is made.
+x-revision: "2"
 synopsis: "Official release 4.14.3"
 maintainer: [
-  "David Allsopp <david@tarides.com>"
+  "David Allsopp <dra27@dra27.uk>"
   "Florian Angeletti <florian.angeletti@inria.fr>"
 ]
 license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.5.0.0/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.5.0.0/opam
@@ -6,7 +6,7 @@ opam-version: "2.0"
 # where "ocaml" {= "5.4.1"} would always mean to use the latest revision).
 # It is however useful to know which version of the metadata is installed.
 # This number should be bumped whenever a pertinent change is made.
-x-revision: "7"
+x-revision: "8"
 synopsis: "Official release 5.0.0"
 maintainer: [
   "David Allsopp <dra27@dra27.uk>"
@@ -31,10 +31,10 @@ depends: [
   # Port selection (Windows)
   # amd64 mingw-w64 only
   (("arch-x86_64" {os = "win32" & arch = "x86_64"} &
-     "system-mingw" & "mingw-w64-shims" {os-distribution = "cygwin" & post}) |
+     "system-mingw") |
   # i686 mingw-w64 only
    ("arch-x86_32" {os = "win32"} & "ocaml-option-bytecode-only" &
-     "system-mingw" & "mingw-w64-shims" {os-distribution = "cygwin" & post}) |
+     "system-mingw") |
   # Non-Windows systems need to install something to satisfy this formula, so
   # repeat the base-unix dependency
    "base-unix" {os != "win32" & post})

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.5.0.0/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.5.0.0/opam
@@ -1,7 +1,15 @@
 opam-version: "2.0"
+# These packages are part of the infrastructure for maintaining the OCaml
+# compiler dependencies in opam. It's not possible to version the metadata
+# itself, because opam's versioning provides no mechanism to ignore the
+# revision (i.e. we don't have a way to have two revisions of ocaml.5.4.1 but
+# where "ocaml" {= "5.4.1"} would always mean to use the latest revision).
+# It is however useful to know which version of the metadata is installed.
+# This number should be bumped whenever a pertinent change is made.
+x-revision: "7"
 synopsis: "Official release 5.0.0"
 maintainer: [
-  "David Allsopp <david@tarides.com>"
+  "David Allsopp <dra27@dra27.uk>"
   "Florian Angeletti <florian.angeletti@inria.fr>"
 ]
 license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.5.1.0/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.5.1.0/opam
@@ -6,7 +6,7 @@ opam-version: "2.0"
 # where "ocaml" {= "5.4.1"} would always mean to use the latest revision).
 # It is however useful to know which version of the metadata is installed.
 # This number should be bumped whenever a pertinent change is made.
-x-revision: "8"
+x-revision: "9"
 synopsis: "Official release 5.1.0"
 maintainer: [
   "David Allsopp <dra27@dra27.uk>"
@@ -31,10 +31,10 @@ depends: [
   # Port selection (Windows)
   # amd64 mingw-w64 only
   (("arch-x86_64" {os = "win32" & arch = "x86_64"} &
-     "system-mingw" & "mingw-w64-shims" {os-distribution = "cygwin" & build}) |
+     "system-mingw") |
   # i686 mingw-w64 only
    ("arch-x86_32" {os = "win32"} & "ocaml-option-bytecode-only" &
-     "system-mingw" & "mingw-w64-shims" {os-distribution = "cygwin" & build}) |
+     "system-mingw") |
   # Non-Windows systems need to install something to satisfy this formula, so
   # repeat the base-unix dependency
    "base-unix" {os != "win32" & post})

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.5.1.0/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.5.1.0/opam
@@ -1,7 +1,15 @@
 opam-version: "2.0"
+# These packages are part of the infrastructure for maintaining the OCaml
+# compiler dependencies in opam. It's not possible to version the metadata
+# itself, because opam's versioning provides no mechanism to ignore the
+# revision (i.e. we don't have a way to have two revisions of ocaml.5.4.1 but
+# where "ocaml" {= "5.4.1"} would always mean to use the latest revision).
+# It is however useful to know which version of the metadata is installed.
+# This number should be bumped whenever a pertinent change is made.
+x-revision: "8"
 synopsis: "Official release 5.1.0"
 maintainer: [
-  "David Allsopp <david@tarides.com>"
+  "David Allsopp <dra27@dra27.uk>"
   "Florian Angeletti <florian.angeletti@inria.fr>"
 ]
 license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.5.1.1/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.5.1.1/opam
@@ -6,7 +6,7 @@ opam-version: "2.0"
 # where "ocaml" {= "5.4.1"} would always mean to use the latest revision).
 # It is however useful to know which version of the metadata is installed.
 # This number should be bumped whenever a pertinent change is made.
-x-revision: "7"
+x-revision: "8"
 synopsis: "Official release 5.1.1"
 maintainer: [
   "David Allsopp <dra27@dra27.uk>"
@@ -31,10 +31,10 @@ depends: [
   # Port selection (Windows)
   # amd64 mingw-w64 only
   (("arch-x86_64" {os = "win32" & arch = "x86_64"} &
-     "system-mingw" & "mingw-w64-shims" {os-distribution = "cygwin" & build}) |
+     "system-mingw") |
   # i686 mingw-w64 only
    ("arch-x86_32" {os = "win32"} & "ocaml-option-bytecode-only" &
-     "system-mingw" & "mingw-w64-shims" {os-distribution = "cygwin" & build}) |
+     "system-mingw") |
   # Non-Windows systems need to install something to satisfy this formula, so
   # repeat the base-unix dependency
    "base-unix" {os != "win32" & post})

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.5.1.1/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.5.1.1/opam
@@ -1,7 +1,15 @@
 opam-version: "2.0"
+# These packages are part of the infrastructure for maintaining the OCaml
+# compiler dependencies in opam. It's not possible to version the metadata
+# itself, because opam's versioning provides no mechanism to ignore the
+# revision (i.e. we don't have a way to have two revisions of ocaml.5.4.1 but
+# where "ocaml" {= "5.4.1"} would always mean to use the latest revision).
+# It is however useful to know which version of the metadata is installed.
+# This number should be bumped whenever a pertinent change is made.
+x-revision: "7"
 synopsis: "Official release 5.1.1"
 maintainer: [
-  "David Allsopp <david@tarides.com>"
+  "David Allsopp <dra27@dra27.uk>"
   "Florian Angeletti <florian.angeletti@inria.fr>"
 ]
 license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.5.2.0/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.5.2.0/opam
@@ -6,7 +6,7 @@ opam-version: "2.0"
 # where "ocaml" {= "5.4.1"} would always mean to use the latest revision).
 # It is however useful to know which version of the metadata is installed.
 # This number should be bumped whenever a pertinent change is made.
-x-revision: "8"
+x-revision: "9"
 synopsis: "Official release 5.2.0"
 maintainer: [
   "David Allsopp <dra27@dra27.uk>"
@@ -31,10 +31,10 @@ depends: [
   # Port selection (Windows)
   # amd64 mingw-w64 only
   (("arch-x86_64" {os = "win32" & arch = "x86_64"} &
-     "system-mingw" & "mingw-w64-shims" {os-distribution = "cygwin" & build}) |
+     "system-mingw") |
   # i686 mingw-w64 only
    ("arch-x86_32" {os = "win32"} & "ocaml-option-bytecode-only" &
-     "system-mingw" & "mingw-w64-shims" {os-distribution = "cygwin" & build}) |
+     "system-mingw") |
   # Non-Windows systems need to install something to satisfy this formula, so
   # repeat the base-unix dependency
    "base-unix" {os != "win32" & post})

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.5.2.0/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.5.2.0/opam
@@ -1,7 +1,15 @@
 opam-version: "2.0"
+# These packages are part of the infrastructure for maintaining the OCaml
+# compiler dependencies in opam. It's not possible to version the metadata
+# itself, because opam's versioning provides no mechanism to ignore the
+# revision (i.e. we don't have a way to have two revisions of ocaml.5.4.1 but
+# where "ocaml" {= "5.4.1"} would always mean to use the latest revision).
+# It is however useful to know which version of the metadata is installed.
+# This number should be bumped whenever a pertinent change is made.
+x-revision: "8"
 synopsis: "Official release 5.2.0"
 maintainer: [
-  "David Allsopp <david@tarides.com>"
+  "David Allsopp <dra27@dra27.uk>"
   "Florian Angeletti <florian.angeletti@inria.fr>"
 ]
 license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.5.2.1/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.5.2.1/opam
@@ -6,7 +6,7 @@ opam-version: "2.0"
 # where "ocaml" {= "5.4.1"} would always mean to use the latest revision).
 # It is however useful to know which version of the metadata is installed.
 # This number should be bumped whenever a pertinent change is made.
-x-revision: "4"
+x-revision: "5"
 synopsis: "Official release 5.2.1"
 maintainer: [
   "David Allsopp <dra27@dra27.uk>"
@@ -31,10 +31,10 @@ depends: [
   # Port selection (Windows)
   # amd64 mingw-w64 only
   (("arch-x86_64" {os = "win32" & arch = "x86_64"} &
-     "system-mingw" & "mingw-w64-shims" {os-distribution = "cygwin" & build}) |
+     "system-mingw") |
   # i686 mingw-w64 only
    ("arch-x86_32" {os = "win32"} & "ocaml-option-bytecode-only" &
-     "system-mingw" & "mingw-w64-shims" {os-distribution = "cygwin" & build}) |
+     "system-mingw") |
   # Non-Windows systems need to install something to satisfy this formula, so
   # repeat the base-unix dependency
    "base-unix" {os != "win32" & post})

--- a/packages/ocaml-base-compiler/ocaml-base-compiler.5.2.1/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.5.2.1/opam
@@ -1,7 +1,15 @@
 opam-version: "2.0"
+# These packages are part of the infrastructure for maintaining the OCaml
+# compiler dependencies in opam. It's not possible to version the metadata
+# itself, because opam's versioning provides no mechanism to ignore the
+# revision (i.e. we don't have a way to have two revisions of ocaml.5.4.1 but
+# where "ocaml" {= "5.4.1"} would always mean to use the latest revision).
+# It is however useful to know which version of the metadata is installed.
+# This number should be bumped whenever a pertinent change is made.
+x-revision: "4"
 synopsis: "Official release 5.2.1"
 maintainer: [
-  "David Allsopp <david@tarides.com>"
+  "David Allsopp <dra27@dra27.uk>"
   "Florian Angeletti <florian.angeletti@inria.fr>"
 ]
 license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"

--- a/packages/ocaml-compiler/ocaml-compiler.5.3.0/opam
+++ b/packages/ocaml-compiler/ocaml-compiler.5.3.0/opam
@@ -1,8 +1,16 @@
 opam-version: "2.0"
+# These packages are part of the infrastructure for maintaining the OCaml
+# compiler dependencies in opam. It's not possible to version the metadata
+# itself, because opam's versioning provides no mechanism to ignore the
+# revision (i.e. we don't have a way to have two revisions of ocaml.5.4.1 but
+# where "ocaml" {= "5.4.1"} would always mean to use the latest revision).
+# It is however useful to know which version of the metadata is installed.
+# This number should be bumped whenever a pertinent change is made.
+x-revision: "2"
 license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 synopsis: "Official release of OCaml 5.3.0"
 maintainer: [
-  "David Allsopp <david@tarides.com>"
+  "David Allsopp <dra27@dra27.uk>"
   "Florian Angeletti <florian.angeletti@inria.fr>"
 ]
 authors: [

--- a/packages/ocaml-compiler/ocaml-compiler.5.3.0/opam
+++ b/packages/ocaml-compiler/ocaml-compiler.5.3.0/opam
@@ -6,7 +6,7 @@ opam-version: "2.0"
 # where "ocaml" {= "5.4.1"} would always mean to use the latest revision).
 # It is however useful to know which version of the metadata is installed.
 # This number should be bumped whenever a pertinent change is made.
-x-revision: "2"
+x-revision: "3"
 license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 synopsis: "Official release of OCaml 5.3.0"
 maintainer: [
@@ -40,11 +40,11 @@ depends: [
   # Port selection (Windows)
   # amd64 mingw-w64 / MSVC
   (("arch-x86_64" {os = "win32" & arch = "x86_64"} &
-     (("system-mingw" & "mingw-w64-shims" {os-distribution = "cygwin" & build}) |
+     ("system-mingw" |
       ("system-msvc" & "winpthreads" & "ocaml-option-no-compression" {os = "win32"}))) |
   # i686 mingw-w64 / MSVC
    ("arch-x86_32" {os = "win32"} & "ocaml-option-bytecode-only" {os = "win32"} &
-     (("system-mingw" & "mingw-w64-shims" {os-distribution = "cygwin" & build}) |
+     ("system-mingw" |
       ("system-msvc" & "winpthreads" & "ocaml-option-no-compression" {os = "win32"}))) |
   # Non-Windows systems need to install something to satisfy this formula, so
   # repeat the base-unix dependency

--- a/packages/ocaml-compiler/ocaml-compiler.5.3/opam
+++ b/packages/ocaml-compiler/ocaml-compiler.5.3/opam
@@ -6,7 +6,7 @@ opam-version: "2.0"
 # where "ocaml" {= "5.4.1"} would always mean to use the latest revision).
 # It is however useful to know which version of the metadata is installed.
 # This number should be bumped whenever a pertinent change is made.
-x-revision: "4"
+x-revision: "5"
 license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 synopsis: "Latest 5.3 development"
 maintainer: [
@@ -58,11 +58,11 @@ depends: [
   # Port selection (Windows)
   # amd64 mingw-w64 / MSVC
   (("arch-x86_64" {os = "win32" & arch = "x86_64"} &
-     (("system-mingw" & "mingw-w64-shims" {os-distribution = "cygwin" & build}) |
+     ("system-mingw" |
       ("system-msvc" & "winpthreads" & "ocaml-option-no-compression" {os = "win32"}))) |
   # i686 mingw-w64 / MSVC
    ("arch-x86_32" {os = "win32"} & "ocaml-option-bytecode-only" {os = "win32"} &
-     (("system-mingw" & "mingw-w64-shims" {os-distribution = "cygwin" & build}) |
+     ("system-mingw" |
       ("system-msvc" & "winpthreads" & "ocaml-option-no-compression" {os = "win32"}))) |
   # Non-Windows systems
    "host-system-other" {os != "win32" & post})

--- a/packages/ocaml-compiler/ocaml-compiler.5.3/opam
+++ b/packages/ocaml-compiler/ocaml-compiler.5.3/opam
@@ -1,8 +1,16 @@
 opam-version: "2.0"
+# These packages are part of the infrastructure for maintaining the OCaml
+# compiler dependencies in opam. It's not possible to version the metadata
+# itself, because opam's versioning provides no mechanism to ignore the
+# revision (i.e. we don't have a way to have two revisions of ocaml.5.4.1 but
+# where "ocaml" {= "5.4.1"} would always mean to use the latest revision).
+# It is however useful to know which version of the metadata is installed.
+# This number should be bumped whenever a pertinent change is made.
+x-revision: "4"
 license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 synopsis: "Latest 5.3 development"
 maintainer: [
-  "David Allsopp <david@tarides.com>"
+  "David Allsopp <dra27@dra27.uk>"
   "Florian Angeletti <florian.angeletti@inria.fr>"
 ]
 authors: [

--- a/packages/ocaml-compiler/ocaml-compiler.5.4.0/opam
+++ b/packages/ocaml-compiler/ocaml-compiler.5.4.0/opam
@@ -6,7 +6,7 @@ opam-version: "2.0"
 # where "ocaml" {= "5.4.1"} would always mean to use the latest revision).
 # It is however useful to know which version of the metadata is installed.
 # This number should be bumped whenever a pertinent change is made.
-x-revision: "2"
+x-revision: "3"
 license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 synopsis: "Official release of OCaml 5.4.0"
 maintainer: [
@@ -40,11 +40,11 @@ depends: [
   # Port selection (Windows)
   # amd64 mingw-w64 / MSVC
   (("arch-x86_64" {os = "win32" & arch = "x86_64"} &
-     (("system-mingw" & "mingw-w64-shims" {os-distribution = "cygwin" & build}) |
+     ("system-mingw" |
       ("system-msvc" & "winpthreads" & "ocaml-option-no-compression" {os = "win32"}))) |
   # i686 mingw-w64 / MSVC
    ("arch-x86_32" {os = "win32"} & "ocaml-option-bytecode-only" {os = "win32"} &
-     (("system-mingw" & "mingw-w64-shims" {os-distribution = "cygwin" & build}) |
+     ("system-mingw" |
       ("system-msvc" & "winpthreads" & "ocaml-option-no-compression" {os = "win32"}))) |
   # Non-Windows systems need to install something to satisfy this formula, so
   # repeat the base-unix dependency

--- a/packages/ocaml-compiler/ocaml-compiler.5.4.0/opam
+++ b/packages/ocaml-compiler/ocaml-compiler.5.4.0/opam
@@ -1,8 +1,16 @@
 opam-version: "2.0"
+# These packages are part of the infrastructure for maintaining the OCaml
+# compiler dependencies in opam. It's not possible to version the metadata
+# itself, because opam's versioning provides no mechanism to ignore the
+# revision (i.e. we don't have a way to have two revisions of ocaml.5.4.1 but
+# where "ocaml" {= "5.4.1"} would always mean to use the latest revision).
+# It is however useful to know which version of the metadata is installed.
+# This number should be bumped whenever a pertinent change is made.
+x-revision: "2"
 license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 synopsis: "Official release of OCaml 5.4.0"
 maintainer: [
-  "David Allsopp <david@tarides.com>"
+  "David Allsopp <dra27@dra27.uk>"
   "Florian Angeletti <florian.angeletti@inria.fr>"
 ]
 authors: [

--- a/packages/ocaml-compiler/ocaml-compiler.5.4.0~alpha1/opam
+++ b/packages/ocaml-compiler/ocaml-compiler.5.4.0~alpha1/opam
@@ -6,7 +6,7 @@ opam-version: "2.0"
 # where "ocaml" {= "5.4.1"} would always mean to use the latest revision).
 # It is however useful to know which version of the metadata is installed.
 # This number should be bumped whenever a pertinent change is made.
-x-revision: "2"
+x-revision: "3"
 license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 synopsis: "First alpha release of OCaml 5.4.0"
 maintainer: [
@@ -42,11 +42,11 @@ depends: [
   # Port selection (Windows)
   # amd64 mingw-w64 / MSVC
   (("arch-x86_64" {os = "win32" & arch = "x86_64"} &
-     (("system-mingw" & "mingw-w64-shims" {os-distribution = "cygwin" & build}) |
+     ("system-mingw" |
       ("system-msvc" & "winpthreads" & "ocaml-option-no-compression" {os = "win32"}))) |
   # i686 mingw-w64 / MSVC
    ("arch-x86_32" {os = "win32"} & "ocaml-option-bytecode-only" {os = "win32"} &
-     (("system-mingw" & "mingw-w64-shims" {os-distribution = "cygwin" & build}) |
+     ("system-mingw" |
       ("system-msvc" & "winpthreads" & "ocaml-option-no-compression" {os = "win32"}))) |
   # Non-Windows systems need to install something to satisfy this formula, so
   # repeat the base-unix dependency

--- a/packages/ocaml-compiler/ocaml-compiler.5.4.0~alpha1/opam
+++ b/packages/ocaml-compiler/ocaml-compiler.5.4.0~alpha1/opam
@@ -1,8 +1,16 @@
 opam-version: "2.0"
+# These packages are part of the infrastructure for maintaining the OCaml
+# compiler dependencies in opam. It's not possible to version the metadata
+# itself, because opam's versioning provides no mechanism to ignore the
+# revision (i.e. we don't have a way to have two revisions of ocaml.5.4.1 but
+# where "ocaml" {= "5.4.1"} would always mean to use the latest revision).
+# It is however useful to know which version of the metadata is installed.
+# This number should be bumped whenever a pertinent change is made.
+x-revision: "2"
 license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 synopsis: "First alpha release of OCaml 5.4.0"
 maintainer: [
-  "David Allsopp <david@tarides.com>"
+  "David Allsopp <dra27@dra27.uk>"
   "Florian Angeletti <florian.angeletti@inria.fr>"
 ]
 authors: [

--- a/packages/ocaml-compiler/ocaml-compiler.5.4.0~beta1/opam
+++ b/packages/ocaml-compiler/ocaml-compiler.5.4.0~beta1/opam
@@ -1,8 +1,16 @@
 opam-version: "2.0"
+# These packages are part of the infrastructure for maintaining the OCaml
+# compiler dependencies in opam. It's not possible to version the metadata
+# itself, because opam's versioning provides no mechanism to ignore the
+# revision (i.e. we don't have a way to have two revisions of ocaml.5.4.1 but
+# where "ocaml" {= "5.4.1"} would always mean to use the latest revision).
+# It is however useful to know which version of the metadata is installed.
+# This number should be bumped whenever a pertinent change is made.
+x-revision: "2"
 license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 synopsis: "First beta release of OCaml 5.4.0"
 maintainer: [
-  "David Allsopp <david@tarides.com>"
+  "David Allsopp <dra27@dra27.uk>"
   "Florian Angeletti <florian.angeletti@inria.fr>"
 ]
 authors: [

--- a/packages/ocaml-compiler/ocaml-compiler.5.4.0~beta1/opam
+++ b/packages/ocaml-compiler/ocaml-compiler.5.4.0~beta1/opam
@@ -6,7 +6,7 @@ opam-version: "2.0"
 # where "ocaml" {= "5.4.1"} would always mean to use the latest revision).
 # It is however useful to know which version of the metadata is installed.
 # This number should be bumped whenever a pertinent change is made.
-x-revision: "2"
+x-revision: "3"
 license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 synopsis: "First beta release of OCaml 5.4.0"
 maintainer: [
@@ -42,11 +42,11 @@ depends: [
   # Port selection (Windows)
   # amd64 mingw-w64 / MSVC
   (("arch-x86_64" {os = "win32" & arch = "x86_64"} &
-     (("system-mingw" & "mingw-w64-shims" {os-distribution = "cygwin" & build}) |
+     ("system-mingw" |
       ("system-msvc" & "winpthreads" & "ocaml-option-no-compression" {os = "win32"}))) |
   # i686 mingw-w64 / MSVC
    ("arch-x86_32" {os = "win32"} & "ocaml-option-bytecode-only" {os = "win32"} &
-     (("system-mingw" & "mingw-w64-shims" {os-distribution = "cygwin" & build}) |
+     ("system-mingw" |
       ("system-msvc" & "winpthreads" & "ocaml-option-no-compression" {os = "win32"}))) |
   # Non-Windows systems need to install something to satisfy this formula, so
   # repeat the base-unix dependency

--- a/packages/ocaml-compiler/ocaml-compiler.5.4.0~beta2/opam
+++ b/packages/ocaml-compiler/ocaml-compiler.5.4.0~beta2/opam
@@ -6,7 +6,7 @@ opam-version: "2.0"
 # where "ocaml" {= "5.4.1"} would always mean to use the latest revision).
 # It is however useful to know which version of the metadata is installed.
 # This number should be bumped whenever a pertinent change is made.
-x-revision: "2"
+x-revision: "3"
 license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 synopsis: "Second beta release of OCaml 5.4.0"
 maintainer: [
@@ -42,11 +42,11 @@ depends: [
   # Port selection (Windows)
   # amd64 mingw-w64 / MSVC
   (("arch-x86_64" {os = "win32" & arch = "x86_64"} &
-     (("system-mingw" & "mingw-w64-shims" {os-distribution = "cygwin" & build}) |
+     ("system-mingw" |
       ("system-msvc" & "winpthreads" & "ocaml-option-no-compression" {os = "win32"}))) |
   # i686 mingw-w64 / MSVC
    ("arch-x86_32" {os = "win32"} & "ocaml-option-bytecode-only" {os = "win32"} &
-     (("system-mingw" & "mingw-w64-shims" {os-distribution = "cygwin" & build}) |
+     ("system-mingw" |
       ("system-msvc" & "winpthreads" & "ocaml-option-no-compression" {os = "win32"}))) |
   # Non-Windows systems need to install something to satisfy this formula, so
   # repeat the base-unix dependency

--- a/packages/ocaml-compiler/ocaml-compiler.5.4.0~beta2/opam
+++ b/packages/ocaml-compiler/ocaml-compiler.5.4.0~beta2/opam
@@ -1,8 +1,16 @@
 opam-version: "2.0"
+# These packages are part of the infrastructure for maintaining the OCaml
+# compiler dependencies in opam. It's not possible to version the metadata
+# itself, because opam's versioning provides no mechanism to ignore the
+# revision (i.e. we don't have a way to have two revisions of ocaml.5.4.1 but
+# where "ocaml" {= "5.4.1"} would always mean to use the latest revision).
+# It is however useful to know which version of the metadata is installed.
+# This number should be bumped whenever a pertinent change is made.
+x-revision: "2"
 license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 synopsis: "Second beta release of OCaml 5.4.0"
 maintainer: [
-  "David Allsopp <david@tarides.com>"
+  "David Allsopp <dra27@dra27.uk>"
   "Florian Angeletti <florian.angeletti@inria.fr>"
 ]
 authors: [

--- a/packages/ocaml-compiler/ocaml-compiler.5.4.0~rc1/opam
+++ b/packages/ocaml-compiler/ocaml-compiler.5.4.0~rc1/opam
@@ -6,7 +6,7 @@ opam-version: "2.0"
 # where "ocaml" {= "5.4.1"} would always mean to use the latest revision).
 # It is however useful to know which version of the metadata is installed.
 # This number should be bumped whenever a pertinent change is made.
-x-revision: "2"
+x-revision: "3"
 license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 synopsis: "First release candidate of OCaml 5.4.0"
 maintainer: [
@@ -42,11 +42,11 @@ depends: [
   # Port selection (Windows)
   # amd64 mingw-w64 / MSVC
   (("arch-x86_64" {os = "win32" & arch = "x86_64"} &
-     (("system-mingw" & "mingw-w64-shims" {os-distribution = "cygwin" & build}) |
+     ("system-mingw" |
       ("system-msvc" & "winpthreads" & "ocaml-option-no-compression" {os = "win32"}))) |
   # i686 mingw-w64 / MSVC
    ("arch-x86_32" {os = "win32"} & "ocaml-option-bytecode-only" {os = "win32"} &
-     (("system-mingw" & "mingw-w64-shims" {os-distribution = "cygwin" & build}) |
+     ("system-mingw" |
       ("system-msvc" & "winpthreads" & "ocaml-option-no-compression" {os = "win32"}))) |
   # Non-Windows systems need to install something to satisfy this formula, so
   # repeat the base-unix dependency

--- a/packages/ocaml-compiler/ocaml-compiler.5.4.0~rc1/opam
+++ b/packages/ocaml-compiler/ocaml-compiler.5.4.0~rc1/opam
@@ -1,8 +1,16 @@
 opam-version: "2.0"
+# These packages are part of the infrastructure for maintaining the OCaml
+# compiler dependencies in opam. It's not possible to version the metadata
+# itself, because opam's versioning provides no mechanism to ignore the
+# revision (i.e. we don't have a way to have two revisions of ocaml.5.4.1 but
+# where "ocaml" {= "5.4.1"} would always mean to use the latest revision).
+# It is however useful to know which version of the metadata is installed.
+# This number should be bumped whenever a pertinent change is made.
+x-revision: "2"
 license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 synopsis: "First release candidate of OCaml 5.4.0"
 maintainer: [
-  "David Allsopp <david@tarides.com>"
+  "David Allsopp <dra27@dra27.uk>"
   "Florian Angeletti <florian.angeletti@inria.fr>"
 ]
 authors: [

--- a/packages/ocaml-compiler/ocaml-compiler.5.4.1/opam
+++ b/packages/ocaml-compiler/ocaml-compiler.5.4.1/opam
@@ -1,8 +1,16 @@
 opam-version: "2.0"
+# These packages are part of the infrastructure for maintaining the OCaml
+# compiler dependencies in opam. It's not possible to version the metadata
+# itself, because opam's versioning provides no mechanism to ignore the
+# revision (i.e. we don't have a way to have two revisions of ocaml.5.4.1 but
+# where "ocaml" {= "5.4.1"} would always mean to use the latest revision).
+# It is however useful to know which version of the metadata is installed.
+# This number should be bumped whenever a pertinent change is made.
+x-revision: "2"
 license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 synopsis: "Official release of OCaml 5.4.1"
 maintainer: [
-  "David Allsopp <david@tarides.com>"
+  "David Allsopp <dra27@dra27.uk>"
   "Florian Angeletti <florian.angeletti@inria.fr>"
 ]
 authors: [

--- a/packages/ocaml-compiler/ocaml-compiler.5.4.1/opam
+++ b/packages/ocaml-compiler/ocaml-compiler.5.4.1/opam
@@ -6,7 +6,7 @@ opam-version: "2.0"
 # where "ocaml" {= "5.4.1"} would always mean to use the latest revision).
 # It is however useful to know which version of the metadata is installed.
 # This number should be bumped whenever a pertinent change is made.
-x-revision: "2"
+x-revision: "3"
 license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 synopsis: "Official release of OCaml 5.4.1"
 maintainer: [
@@ -40,11 +40,11 @@ depends: [
   # Port selection (Windows)
   # amd64 mingw-w64 / MSVC
   (("arch-x86_64" {os = "win32" & arch = "x86_64"} &
-     (("system-mingw" & "mingw-w64-shims" {os-distribution = "cygwin" & build}) |
+     ("system-mingw" |
       ("system-msvc" & "winpthreads" & "ocaml-option-no-compression" {os = "win32"}))) |
   # i686 mingw-w64 / MSVC
    ("arch-x86_32" {os = "win32"} & "ocaml-option-bytecode-only" {os = "win32"} &
-     (("system-mingw" & "mingw-w64-shims" {os-distribution = "cygwin" & build}) |
+     ("system-mingw" |
       ("system-msvc" & "winpthreads" & "ocaml-option-no-compression" {os = "win32"}))) |
   # Non-Windows systems need to install something to satisfy this formula, so
   # repeat the base-unix dependency

--- a/packages/ocaml-compiler/ocaml-compiler.5.4/opam
+++ b/packages/ocaml-compiler/ocaml-compiler.5.4/opam
@@ -1,8 +1,16 @@
 opam-version: "2.0"
+# These packages are part of the infrastructure for maintaining the OCaml
+# compiler dependencies in opam. It's not possible to version the metadata
+# itself, because opam's versioning provides no mechanism to ignore the
+# revision (i.e. we don't have a way to have two revisions of ocaml.5.4.1 but
+# where "ocaml" {= "5.4.1"} would always mean to use the latest revision).
+# It is however useful to know which version of the metadata is installed.
+# This number should be bumped whenever a pertinent change is made.
+x-revision: "3"
 license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 synopsis: "Latest 5.4 development"
 maintainer: [
-  "David Allsopp <david@tarides.com>"
+  "David Allsopp <dra27@dra27.uk>"
   "Florian Angeletti <florian.angeletti@inria.fr>"
 ]
 authors: [

--- a/packages/ocaml-compiler/ocaml-compiler.5.4/opam
+++ b/packages/ocaml-compiler/ocaml-compiler.5.4/opam
@@ -6,7 +6,7 @@ opam-version: "2.0"
 # where "ocaml" {= "5.4.1"} would always mean to use the latest revision).
 # It is however useful to know which version of the metadata is installed.
 # This number should be bumped whenever a pertinent change is made.
-x-revision: "3"
+x-revision: "4"
 license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 synopsis: "Latest 5.4 development"
 maintainer: [
@@ -58,11 +58,11 @@ depends: [
   # Port selection (Windows)
   # amd64 mingw-w64 / MSVC
   (("arch-x86_64" {os = "win32" & arch = "x86_64"} &
-     (("system-mingw" & "mingw-w64-shims" {os-distribution = "cygwin" & build}) |
+     ("system-mingw" |
       ("system-msvc" & "winpthreads" & "ocaml-option-no-compression" {os = "win32"}))) |
   # i686 mingw-w64 / MSVC
    ("arch-x86_32" {os = "win32"} & "ocaml-option-bytecode-only" {os = "win32"} &
-     (("system-mingw" & "mingw-w64-shims" {os-distribution = "cygwin" & build}) |
+     ("system-mingw" |
       ("system-msvc" & "winpthreads" & "ocaml-option-no-compression" {os = "win32"}))) |
   # Non-Windows systems
    "host-system-other" {os != "win32" & post})

--- a/packages/ocaml-compiler/ocaml-compiler.5.5.0~alpha1/opam
+++ b/packages/ocaml-compiler/ocaml-compiler.5.5.0~alpha1/opam
@@ -6,7 +6,7 @@ opam-version: "2.0"
 # where "ocaml" {= "5.4.1"} would always mean to use the latest revision).
 # It is however useful to know which version of the metadata is installed.
 # This number should be bumped whenever a pertinent change is made.
-x-revision: "1"
+x-revision: "2"
 license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 synopsis: "First alpha release of OCaml 5.5.0"
 maintainer: [
@@ -43,11 +43,11 @@ depends: [
   # Port selection (Windows)
   # amd64 mingw-w64 / MSVC
   (("arch-x86_64" {os = "win32" & arch = "x86_64"} &
-     (("system-mingw" & "mingw-w64-shims" {os-distribution = "cygwin" & build}) |
+     ("system-mingw" |
       ("system-msvc" & "ocaml-option-no-compression" {os = "win32"}))) |
   # i686 mingw-w64 / MSVC
    ("arch-x86_32" {os = "win32"} & "ocaml-option-bytecode-only" {os = "win32"} &
-     (("system-mingw" & "mingw-w64-shims" {os-distribution = "cygwin" & build}) |
+     ("system-mingw" |
       ("system-msvc" & "ocaml-option-no-compression" {os = "win32"}))) |
   # Non-Windows systems need to install something to satisfy this formula, so
   # repeat the base-unix dependency

--- a/packages/ocaml-compiler/ocaml-compiler.5.5.0~alpha1/opam
+++ b/packages/ocaml-compiler/ocaml-compiler.5.5.0~alpha1/opam
@@ -1,4 +1,12 @@
 opam-version: "2.0"
+# These packages are part of the infrastructure for maintaining the OCaml
+# compiler dependencies in opam. It's not possible to version the metadata
+# itself, because opam's versioning provides no mechanism to ignore the
+# revision (i.e. we don't have a way to have two revisions of ocaml.5.4.1 but
+# where "ocaml" {= "5.4.1"} would always mean to use the latest revision).
+# It is however useful to know which version of the metadata is installed.
+# This number should be bumped whenever a pertinent change is made.
+x-revision: "1"
 license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 synopsis: "First alpha release of OCaml 5.5.0"
 maintainer: [

--- a/packages/ocaml-compiler/ocaml-compiler.5.5.0~alpha3/opam
+++ b/packages/ocaml-compiler/ocaml-compiler.5.5.0~alpha3/opam
@@ -6,7 +6,7 @@ opam-version: "2.0"
 # where "ocaml" {= "5.4.1"} would always mean to use the latest revision).
 # It is however useful to know which version of the metadata is installed.
 # This number should be bumped whenever a pertinent change is made.
-x-revision: "1"
+x-revision: "2"
 license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 synopsis: "Third alpha release of OCaml 5.5.0"
 maintainer: [
@@ -43,11 +43,11 @@ depends: [
   # Port selection (Windows)
   # amd64 mingw-w64 / MSVC
   (("arch-x86_64" {os = "win32" & arch = "x86_64"} &
-     (("system-mingw" & "mingw-w64-shims" {os-distribution = "cygwin" & build}) |
+     ("system-mingw" |
       ("system-msvc" & "ocaml-option-no-compression" {os = "win32"}))) |
   # i686 mingw-w64 / MSVC
    ("arch-x86_32" {os = "win32"} & "ocaml-option-bytecode-only" {os = "win32"} &
-     (("system-mingw" & "mingw-w64-shims" {os-distribution = "cygwin" & build}) |
+     ("system-mingw" |
       ("system-msvc" & "ocaml-option-no-compression" {os = "win32"}))) |
   # Non-Windows systems need to install something to satisfy this formula, so
   # repeat the base-unix dependency

--- a/packages/ocaml-compiler/ocaml-compiler.5.5.0~alpha3/opam
+++ b/packages/ocaml-compiler/ocaml-compiler.5.5.0~alpha3/opam
@@ -1,4 +1,12 @@
 opam-version: "2.0"
+# These packages are part of the infrastructure for maintaining the OCaml
+# compiler dependencies in opam. It's not possible to version the metadata
+# itself, because opam's versioning provides no mechanism to ignore the
+# revision (i.e. we don't have a way to have two revisions of ocaml.5.4.1 but
+# where "ocaml" {= "5.4.1"} would always mean to use the latest revision).
+# It is however useful to know which version of the metadata is installed.
+# This number should be bumped whenever a pertinent change is made.
+x-revision: "1"
 license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 synopsis: "Third alpha release of OCaml 5.5.0"
 maintainer: [

--- a/packages/ocaml-compiler/ocaml-compiler.5.5.0~beta1/opam
+++ b/packages/ocaml-compiler/ocaml-compiler.5.5.0~beta1/opam
@@ -6,7 +6,7 @@ opam-version: "2.0"
 # where "ocaml" {= "5.4.1"} would always mean to use the latest revision).
 # It is however useful to know which version of the metadata is installed.
 # This number should be bumped whenever a pertinent change is made.
-x-revision: "1"
+x-revision: "2"
 license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 synopsis: "First beta release of OCaml 5.5.0"
 maintainer: [
@@ -43,11 +43,11 @@ depends: [
   # Port selection (Windows)
   # amd64 mingw-w64 / MSVC
   (("arch-x86_64" {os = "win32" & arch = "x86_64"} &
-     (("system-mingw" & "mingw-w64-shims" {os-distribution = "cygwin" & build}) |
+     ("system-mingw" |
       ("system-msvc" & "ocaml-option-no-compression" {os = "win32"}))) |
   # i686 mingw-w64 / MSVC
    ("arch-x86_32" {os = "win32"} & "ocaml-option-bytecode-only" {os = "win32"} &
-     (("system-mingw" & "mingw-w64-shims" {os-distribution = "cygwin" & build}) |
+     ("system-mingw" |
       ("system-msvc" & "ocaml-option-no-compression" {os = "win32"}))) |
   # Non-Windows systems need to install something to satisfy this formula, so
   # repeat the base-unix dependency

--- a/packages/ocaml-compiler/ocaml-compiler.5.5.0~beta1/opam
+++ b/packages/ocaml-compiler/ocaml-compiler.5.5.0~beta1/opam
@@ -1,4 +1,12 @@
 opam-version: "2.0"
+# These packages are part of the infrastructure for maintaining the OCaml
+# compiler dependencies in opam. It's not possible to version the metadata
+# itself, because opam's versioning provides no mechanism to ignore the
+# revision (i.e. we don't have a way to have two revisions of ocaml.5.4.1 but
+# where "ocaml" {= "5.4.1"} would always mean to use the latest revision).
+# It is however useful to know which version of the metadata is installed.
+# This number should be bumped whenever a pertinent change is made.
+x-revision: "1"
 license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 synopsis: "First beta release of OCaml 5.5.0"
 maintainer: [

--- a/packages/ocaml-compiler/ocaml-compiler.5.5/opam
+++ b/packages/ocaml-compiler/ocaml-compiler.5.5/opam
@@ -1,8 +1,16 @@
 opam-version: "2.0"
+# These packages are part of the infrastructure for maintaining the OCaml
+# compiler dependencies in opam. It's not possible to version the metadata
+# itself, because opam's versioning provides no mechanism to ignore the
+# revision (i.e. we don't have a way to have two revisions of ocaml.5.4.1 but
+# where "ocaml" {= "5.4.1"} would always mean to use the latest revision).
+# It is however useful to know which version of the metadata is installed.
+# This number should be bumped whenever a pertinent change is made.
+x-revision: "5"
 license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 synopsis: "Latest 5.5 development"
 maintainer: [
-  "David Allsopp <david@tarides.com>"
+  "David Allsopp <dra27@dra27.uk>"
   "Florian Angeletti <florian.angeletti@inria.fr>"
 ]
 authors: [

--- a/packages/ocaml-compiler/ocaml-compiler.5.5/opam
+++ b/packages/ocaml-compiler/ocaml-compiler.5.5/opam
@@ -6,7 +6,7 @@ opam-version: "2.0"
 # where "ocaml" {= "5.4.1"} would always mean to use the latest revision).
 # It is however useful to know which version of the metadata is installed.
 # This number should be bumped whenever a pertinent change is made.
-x-revision: "5"
+x-revision: "6"
 license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 synopsis: "Latest 5.5 development"
 maintainer: [
@@ -59,11 +59,11 @@ depends: [
   # Port selection (Windows)
   # amd64 mingw-w64 / MSVC
   (("arch-x86_64" {os = "win32" & arch = "x86_64"} &
-     (("system-mingw" & "mingw-w64-shims" {os-distribution = "cygwin" & build}) |
+     ("system-mingw" |
       ("system-msvc" & "winpthreads" & "ocaml-option-no-compression" {os = "win32"}))) |
   # i686 mingw-w64 / MSVC
    ("arch-x86_32" {os = "win32"} & "ocaml-option-bytecode-only" {os = "win32"} &
-     (("system-mingw" & "mingw-w64-shims" {os-distribution = "cygwin" & build}) |
+     ("system-mingw" |
       ("system-msvc" & "winpthreads" & "ocaml-option-no-compression" {os = "win32"}))) |
   # Non-Windows systems
    "host-system-other" {os != "win32" & post})

--- a/packages/ocaml-compiler/ocaml-compiler.5.6/opam
+++ b/packages/ocaml-compiler/ocaml-compiler.5.6/opam
@@ -1,8 +1,16 @@
 opam-version: "2.0"
+# These packages are part of the infrastructure for maintaining the OCaml
+# compiler dependencies in opam. It's not possible to version the metadata
+# itself, because opam's versioning provides no mechanism to ignore the
+# revision (i.e. we don't have a way to have two revisions of ocaml.5.4.1 but
+# where "ocaml" {= "5.4.1"} would always mean to use the latest revision).
+# It is however useful to know which version of the metadata is installed.
+# This number should be bumped whenever a pertinent change is made.
+x-revision: "1"
 license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 synopsis: "Current trunk"
 maintainer: [
-  "David Allsopp <david@tarides.com>"
+  "David Allsopp <dra27@dra27.uk>"
   "Florian Angeletti <florian.angeletti@inria.fr>"
 ]
 authors: [

--- a/packages/ocaml-compiler/ocaml-compiler.5.6/opam
+++ b/packages/ocaml-compiler/ocaml-compiler.5.6/opam
@@ -6,7 +6,7 @@ opam-version: "2.0"
 # where "ocaml" {= "5.4.1"} would always mean to use the latest revision).
 # It is however useful to know which version of the metadata is installed.
 # This number should be bumped whenever a pertinent change is made.
-x-revision: "1"
+x-revision: "2"
 license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 synopsis: "Current trunk"
 maintainer: [
@@ -58,11 +58,11 @@ depends: [
   # Port selection (Windows)
   # amd64 mingw-w64 / MSVC
   (("arch-x86_64" {os = "win32" & arch = "x86_64"} &
-     (("system-mingw" & "mingw-w64-shims" {os-distribution = "cygwin" & build}) |
+     ("system-mingw" |
       ("system-msvc" & "winpthreads" & "ocaml-option-no-compression" {os = "win32"}))) |
   # i686 mingw-w64 / MSVC
    ("arch-x86_32" {os = "win32"} & "ocaml-option-bytecode-only" {os = "win32"} &
-     (("system-mingw" & "mingw-w64-shims" {os-distribution = "cygwin" & build}) |
+     ("system-mingw" |
       ("system-msvc" & "winpthreads" & "ocaml-option-no-compression" {os = "win32"}))) |
   # Non-Windows systems
    "host-system-other" {os != "win32" & post})

--- a/packages/ocaml-env-mingw32/ocaml-env-mingw32.1/opam
+++ b/packages/ocaml-env-mingw32/ocaml-env-mingw32.1/opam
@@ -1,4 +1,11 @@
 opam-version: "2.0"
+# This package is part of the infrastructure for maintaining the OCaml compiler
+# dependencies in opam. It's not meaningful or helpful to version the package
+# itself, as its more part of the logical infrastructure providing the
+# repository, rather than a particular version of some code.
+# It is however useful to know which version of the metadata is installed.
+# This number should be bumped whenever a pertinent change is made.
+x-revision: "2"
 synopsis: "GCC mingw-w64 OCaml Runtime Dependency (32-bit)"
 description: """
 This package is an internal part of the implementation of the OCaml compiler in
@@ -14,14 +21,14 @@ By having the compiler packages instead depend on either ocaml-env-mingw64 or
 ocaml-env-mingw32, the installation of conf-mingw-w64-gcc-x86_64 into a switch
 already containing ocaml-env-mingw32 does not trigger a rebuild of the OCaml
 compiler, because ocaml-env-mingw64 is not installed."""
-maintainer: "David Allsopp <david@tarides.com>"
+maintainer: "David Allsopp <dra27@dra27.uk>"
 authors: "David Allsopp"
 license: "CC0-1.0+"
 homepage: "https://opam.ocaml.org"
 bug-reports: "https://github.com/ocaml/opam-repository/issues"
 depends: [
-  "host-system-mingw" {post}
-  "host-arch-x86_32" {post}
+  "host-system-mingw"
+  "host-arch-x86_32"
   "conf-mingw-w64-gcc-i686"
 ]
 conflict-class: "ocaml-env-mingw"

--- a/packages/ocaml-env-mingw32/ocaml-env-mingw32.1/opam
+++ b/packages/ocaml-env-mingw32/ocaml-env-mingw32.1/opam
@@ -30,6 +30,7 @@ depends: [
   "host-system-mingw"
   "host-arch-x86_32"
   "conf-mingw-w64-gcc-i686"
+  "mingw-w64-shims" {os-distribution = "cygwin"}
 ]
 conflict-class: "ocaml-env-mingw"
 flags: conf

--- a/packages/ocaml-env-mingw64/ocaml-env-mingw64.1/opam
+++ b/packages/ocaml-env-mingw64/ocaml-env-mingw64.1/opam
@@ -1,4 +1,11 @@
 opam-version: "2.0"
+# This package is part of the infrastructure for maintaining the OCaml compiler
+# dependencies in opam. It's not meaningful or helpful to version the package
+# itself, as its more part of the logical infrastructure providing the
+# repository, rather than a particular version of some code.
+# It is however useful to know which version of the metadata is installed.
+# This number should be bumped whenever a pertinent change is made.
+x-revision: "2"
 synopsis: "GCC mingw-w64 OCaml Runtime Dependency (64-bit)"
 description: """
 This package is an internal part of the implementation of the OCaml compiler in
@@ -14,14 +21,14 @@ By having the compiler packages instead depend on either ocaml-env-mingw64 or
 ocaml-env-mingw32, the installation of conf-mingw-w64-gcc-i686 into a switch
 already containing ocaml-env-mingw64 does not trigger a rebuild of the OCaml
 compiler, because ocaml-env-mingw32 is not installed."""
-maintainer: "David Allsopp <david@tarides.com>"
+maintainer: "David Allsopp <dra27@dra27.uk>"
 authors: "David Allsopp"
 license: "CC0-1.0+"
 homepage: "https://opam.ocaml.org"
 bug-reports: "https://github.com/ocaml/opam-repository/issues"
 depends: [
-  "host-system-mingw" {post}
-  "host-arch-x86_64" {post}
+  "host-system-mingw"
+  "host-arch-x86_64"
   "conf-mingw-w64-gcc-x86_64"
 ]
 conflict-class: "ocaml-env-mingw"

--- a/packages/ocaml-env-mingw64/ocaml-env-mingw64.1/opam
+++ b/packages/ocaml-env-mingw64/ocaml-env-mingw64.1/opam
@@ -30,6 +30,7 @@ depends: [
   "host-system-mingw"
   "host-arch-x86_64"
   "conf-mingw-w64-gcc-x86_64"
+  "mingw-w64-shims" {os-distribution = "cygwin"}
 ]
 conflict-class: "ocaml-env-mingw"
 flags: conf

--- a/packages/ocaml-env-msvc32/ocaml-env-msvc32.1/opam
+++ b/packages/ocaml-env-msvc32/ocaml-env-msvc32.1/opam
@@ -1,11 +1,18 @@
 opam-version: "2.0"
+# This package is part of the infrastructure for maintaining the OCaml compiler
+# dependencies in opam. It's not meaningful or helpful to version the package
+# itself, as its more part of the logical infrastructure providing the
+# repository, rather than a particular version of some code.
+# It is however useful to know which version of the metadata is installed.
+# This number should be bumped whenever a pertinent change is made.
+x-revision: "2"
 synopsis: "Microsoft C Compiler OCaml Runtime Dependency (32-bit)"
 description: """
 This package is an internal part of the implementation of the OCaml compiler in
 opam-repository. It is used to store the active environment variable settings
 for Microsoft Visual Studio and adds them to the environment.
 """
-maintainer: "David Allsopp <david@tarides.com>"
+maintainer: "David Allsopp <dra27@dra27.uk>"
 authors: "David Allsopp"
 license: "CC0-1.0+"
 homepage: "https://opam.ocaml.org"
@@ -14,8 +21,8 @@ bug-reports: "https://github.com/ocaml/opam-repository/issues"
 # versions of 2.0.x and 2.1.x crash on these updates.
 available: opam-version >= "2.2.0~"
 depends: [
-  "host-system-msvc" {post}
-  "host-arch-x86_32" {post}
+  "host-system-msvc"
+  "host-arch-x86_32"
   "conf-msvc32"
 ]
 conflict-class: "ocaml-env-msvc"

--- a/packages/ocaml-env-msvc64/ocaml-env-msvc64.1/opam
+++ b/packages/ocaml-env-msvc64/ocaml-env-msvc64.1/opam
@@ -1,11 +1,18 @@
 opam-version: "2.0"
+# This package is part of the infrastructure for maintaining the OCaml compiler
+# dependencies in opam. It's not meaningful or helpful to version the package
+# itself, as its more part of the logical infrastructure providing the
+# repository, rather than a particular version of some code.
+# It is however useful to know which version of the metadata is installed.
+# This number should be bumped whenever a pertinent change is made.
+x-revision: "2"
 synopsis: "Microsoft C Compiler OCaml Runtime Dependency (64-bit)"
 description: """
 This package is an internal part of the implementation of the OCaml compiler in
 opam-repository. It is used to store the active environment variable settings
 for Microsoft Visual Studio and adds them to the environment.
 """
-maintainer: "David Allsopp <david@tarides.com>"
+maintainer: "David Allsopp <dra27@dra27.uk>"
 authors: "David Allsopp"
 license: "CC0-1.0+"
 homepage: "https://opam.ocaml.org"
@@ -14,8 +21,8 @@ bug-reports: "https://github.com/ocaml/opam-repository/issues"
 # versions of 2.0.x and 2.1.x crash on these updates.
 available: opam-version >= "2.2.0~"
 depends: [
-  "host-system-msvc" {post}
-  "host-arch-x86_64" {post}
+  "host-system-msvc"
+  "host-arch-x86_64"
   "conf-msvc64"
 ]
 conflict-class: "ocaml-env-msvc"

--- a/packages/ocaml-secondary-compiler/ocaml-secondary-compiler.4.14.2/opam
+++ b/packages/ocaml-secondary-compiler/ocaml-secondary-compiler.4.14.2/opam
@@ -18,12 +18,10 @@ depends: [
   # Port selection (Windows)
   # amd64 mingw-w64 / MSVC
   (("arch-x86_64" {os = "win32" & arch = "x86_64"} &
-     (("system-mingw" & "mingw-w64-shims" {os-distribution = "cygwin" & post}) |
-      "system-msvc")) |
+     ("system-mingw" | "system-msvc")) |
   # i686 mingw-w64 / MSVC
    ("arch-x86_32" {os = "win32"} &
-     (("system-mingw" & "mingw-w64-shims" {os-distribution = "cygwin" & post}) |
-      "system-msvc")) |
+     ("system-mingw" | "system-msvc")) |
   # Non-Windows systems need to install something to satisfy this formula, so
   # repeat the base-unix dependency
    "base-unix" {os != "win32" & post})

--- a/packages/ocaml-secondary-compiler/ocaml-secondary-compiler.4.14.2/opam
+++ b/packages/ocaml-secondary-compiler/ocaml-secondary-compiler.4.14.2/opam
@@ -1,6 +1,14 @@
 opam-version: "2.0"
+# These packages are part of the infrastructure for maintaining the OCaml
+# compiler dependencies in opam. It's not possible to version the metadata
+# itself, because opam's versioning provides no mechanism to ignore the
+# revision (i.e. we don't have a way to have two revisions of ocaml.5.4.1 but
+# where "ocaml" {= "5.4.1"} would always mean to use the latest revision).
+# It is however useful to know which version of the metadata is installed.
+# This number should be bumped whenever a pertinent change is made.
+x-revision: "3"
 synopsis: "OCaml 4.14.2 Secondary Switch Compiler"
-maintainer: "David Allsopp <david@tarides.com>"
+maintainer: "David Allsopp <dra27@dra27.uk>"
 authors: "Xavier Leroy and many contributors"
 license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 homepage: "https://ocaml.org"

--- a/packages/ocaml-system/ocaml-system.4.13.0/opam
+++ b/packages/ocaml-system/ocaml-system.4.13.0/opam
@@ -1,7 +1,15 @@
 opam-version: "2.0"
+# These packages are part of the infrastructure for maintaining the OCaml
+# compiler dependencies in opam. It's not possible to version the metadata
+# itself, because opam's versioning provides no mechanism to ignore the
+# revision (i.e. we don't have a way to have two revisions of ocaml.5.4.1 but
+# where "ocaml" {= "5.4.1"} would always mean to use the latest revision).
+# It is however useful to know which version of the metadata is installed.
+# This number should be bumped whenever a pertinent change is made.
+x-revision: "7"
 synopsis: "The OCaml compiler (system version, from outside of opam)"
 maintainer: [
-  "David Allsopp <david@tarides.com>"
+  "David Allsopp <dra27@dra27.uk>"
   "Florian Angeletti <florian.angeletti@inria.fr>"
 ]
 license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"

--- a/packages/ocaml-system/ocaml-system.4.13.0/opam
+++ b/packages/ocaml-system/ocaml-system.4.13.0/opam
@@ -6,7 +6,7 @@ opam-version: "2.0"
 # where "ocaml" {= "5.4.1"} would always mean to use the latest revision).
 # It is however useful to know which version of the metadata is installed.
 # This number should be bumped whenever a pertinent change is made.
-x-revision: "7"
+x-revision: "8"
 synopsis: "The OCaml compiler (system version, from outside of opam)"
 maintainer: [
   "David Allsopp <dra27@dra27.uk>"
@@ -45,7 +45,8 @@ depends: [
   # configuration.
   "conf-mingw-w64-gcc-x86_64" {?sys-ocaml-arch & sys-ocaml-arch = "x86_64" & sys-ocaml-libc = "msvc" & sys-ocaml-cc = "cc" & post}
   "conf-mingw-w64-gcc-i686" {?sys-ocaml-arch & sys-ocaml-arch = "i686" & sys-ocaml-libc = "msvc" & sys-ocaml-cc = "cc" & post}
-  "mingw-w64-shims" {?sys-ocaml-arch & sys-ocaml-libc = "msvc" & sys-ocaml-cc = "cc" & os-distribution = "cygwin" & post}
+  "ocaml-env-mingw32" {?sys-ocaml-arch & sys-ocaml-libc = "msvc" & sys-ocaml-arch = "i686" & sys-ocaml-cc = "cc" & post}
+  "ocaml-env-mingw64" {?sys-ocaml-arch & sys-ocaml-libc = "msvc" & sys-ocaml-arch = "x86_64" & sys-ocaml-cc = "cc" & post}
   "ocaml-env-msvc32" {?sys-ocaml-arch & sys-ocaml-arch = "i686" & sys-ocaml-cc = "msvc" & post}
   "ocaml-env-msvc64" {?sys-ocaml-arch & sys-ocaml-arch = "x86_64" & sys-ocaml-cc = "msvc" & post}
 ]

--- a/packages/ocaml-system/ocaml-system.4.13.1/opam
+++ b/packages/ocaml-system/ocaml-system.4.13.1/opam
@@ -1,7 +1,15 @@
 opam-version: "2.0"
+# These packages are part of the infrastructure for maintaining the OCaml
+# compiler dependencies in opam. It's not possible to version the metadata
+# itself, because opam's versioning provides no mechanism to ignore the
+# revision (i.e. we don't have a way to have two revisions of ocaml.5.4.1 but
+# where "ocaml" {= "5.4.1"} would always mean to use the latest revision).
+# It is however useful to know which version of the metadata is installed.
+# This number should be bumped whenever a pertinent change is made.
+x-revision: "8"
 synopsis: "The OCaml compiler (system version, from outside of opam)"
 maintainer: [
-  "David Allsopp <david@tarides.com>"
+  "David Allsopp <dra27@dra27.uk>"
   "Florian Angeletti <florian.angeletti@inria.fr>"
 ]
 license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"

--- a/packages/ocaml-system/ocaml-system.4.13.1/opam
+++ b/packages/ocaml-system/ocaml-system.4.13.1/opam
@@ -6,7 +6,7 @@ opam-version: "2.0"
 # where "ocaml" {= "5.4.1"} would always mean to use the latest revision).
 # It is however useful to know which version of the metadata is installed.
 # This number should be bumped whenever a pertinent change is made.
-x-revision: "8"
+x-revision: "9"
 synopsis: "The OCaml compiler (system version, from outside of opam)"
 maintainer: [
   "David Allsopp <dra27@dra27.uk>"
@@ -45,7 +45,8 @@ depends: [
   # configuration.
   "conf-mingw-w64-gcc-x86_64" {?sys-ocaml-arch & sys-ocaml-arch = "x86_64" & sys-ocaml-libc = "msvc" & sys-ocaml-cc = "cc" & post}
   "conf-mingw-w64-gcc-i686" {?sys-ocaml-arch & sys-ocaml-arch = "i686" & sys-ocaml-libc = "msvc" & sys-ocaml-cc = "cc" & post}
-  "mingw-w64-shims" {?sys-ocaml-arch & sys-ocaml-libc = "msvc" & sys-ocaml-cc = "cc" & os-distribution = "cygwin" & post}
+  "ocaml-env-mingw32" {?sys-ocaml-arch & sys-ocaml-libc = "msvc" & sys-ocaml-arch = "i686" & sys-ocaml-cc = "cc" & post}
+  "ocaml-env-mingw64" {?sys-ocaml-arch & sys-ocaml-libc = "msvc" & sys-ocaml-arch = "x86_64" & sys-ocaml-cc = "cc" & post}
   "ocaml-env-msvc32" {?sys-ocaml-arch & sys-ocaml-arch = "i686" & sys-ocaml-cc = "msvc" & post}
   "ocaml-env-msvc64" {?sys-ocaml-arch & sys-ocaml-arch = "x86_64" & sys-ocaml-cc = "msvc" & post}
 ]

--- a/packages/ocaml-system/ocaml-system.4.14.0/opam
+++ b/packages/ocaml-system/ocaml-system.4.14.0/opam
@@ -1,7 +1,15 @@
 opam-version: "2.0"
+# These packages are part of the infrastructure for maintaining the OCaml
+# compiler dependencies in opam. It's not possible to version the metadata
+# itself, because opam's versioning provides no mechanism to ignore the
+# revision (i.e. we don't have a way to have two revisions of ocaml.5.4.1 but
+# where "ocaml" {= "5.4.1"} would always mean to use the latest revision).
+# It is however useful to know which version of the metadata is installed.
+# This number should be bumped whenever a pertinent change is made.
+x-revision: "6"
 synopsis: "The OCaml compiler (system version, from outside of opam)"
 maintainer: [
-  "David Allsopp <david@tarides.com>"
+  "David Allsopp <dra27@dra27.uk>"
   "Florian Angeletti <florian.angeletti@inria.fr>"
 ]
 license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"

--- a/packages/ocaml-system/ocaml-system.4.14.0/opam
+++ b/packages/ocaml-system/ocaml-system.4.14.0/opam
@@ -6,7 +6,7 @@ opam-version: "2.0"
 # where "ocaml" {= "5.4.1"} would always mean to use the latest revision).
 # It is however useful to know which version of the metadata is installed.
 # This number should be bumped whenever a pertinent change is made.
-x-revision: "6"
+x-revision: "7"
 synopsis: "The OCaml compiler (system version, from outside of opam)"
 maintainer: [
   "David Allsopp <dra27@dra27.uk>"
@@ -45,7 +45,8 @@ depends: [
   # configuration.
   "conf-mingw-w64-gcc-x86_64" {?sys-ocaml-arch & sys-ocaml-arch = "x86_64" & sys-ocaml-libc = "msvc" & sys-ocaml-cc = "cc" & post}
   "conf-mingw-w64-gcc-i686" {?sys-ocaml-arch & sys-ocaml-arch = "i686" & sys-ocaml-libc = "msvc" & sys-ocaml-cc = "cc" & post}
-  "mingw-w64-shims" {?sys-ocaml-arch & sys-ocaml-libc = "msvc" & sys-ocaml-cc = "cc" & os-distribution = "cygwin" & post}
+  "ocaml-env-mingw32" {?sys-ocaml-arch & sys-ocaml-libc = "msvc" & sys-ocaml-arch = "i686" & sys-ocaml-cc = "cc" & post}
+  "ocaml-env-mingw64" {?sys-ocaml-arch & sys-ocaml-libc = "msvc" & sys-ocaml-arch = "x86_64" & sys-ocaml-cc = "cc" & post}
   "ocaml-env-msvc32" {?sys-ocaml-arch & sys-ocaml-arch = "i686" & sys-ocaml-cc = "msvc" & post}
   "ocaml-env-msvc64" {?sys-ocaml-arch & sys-ocaml-arch = "x86_64" & sys-ocaml-cc = "msvc" & post}
 ]

--- a/packages/ocaml-system/ocaml-system.4.14.1/opam
+++ b/packages/ocaml-system/ocaml-system.4.14.1/opam
@@ -1,7 +1,15 @@
 opam-version: "2.0"
+# These packages are part of the infrastructure for maintaining the OCaml
+# compiler dependencies in opam. It's not possible to version the metadata
+# itself, because opam's versioning provides no mechanism to ignore the
+# revision (i.e. we don't have a way to have two revisions of ocaml.5.4.1 but
+# where "ocaml" {= "5.4.1"} would always mean to use the latest revision).
+# It is however useful to know which version of the metadata is installed.
+# This number should be bumped whenever a pertinent change is made.
+x-revision: "6"
 synopsis: "The OCaml compiler (system version, from outside of opam)"
 maintainer: [
-  "David Allsopp <david@tarides.com>"
+  "David Allsopp <dra27@dra27.uk>"
   "Florian Angeletti <florian.angeletti@inria.fr>"
 ]
 license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"

--- a/packages/ocaml-system/ocaml-system.4.14.1/opam
+++ b/packages/ocaml-system/ocaml-system.4.14.1/opam
@@ -6,7 +6,7 @@ opam-version: "2.0"
 # where "ocaml" {= "5.4.1"} would always mean to use the latest revision).
 # It is however useful to know which version of the metadata is installed.
 # This number should be bumped whenever a pertinent change is made.
-x-revision: "6"
+x-revision: "7"
 synopsis: "The OCaml compiler (system version, from outside of opam)"
 maintainer: [
   "David Allsopp <dra27@dra27.uk>"
@@ -45,7 +45,8 @@ depends: [
   # configuration.
   "conf-mingw-w64-gcc-x86_64" {?sys-ocaml-arch & sys-ocaml-arch = "x86_64" & sys-ocaml-libc = "msvc" & sys-ocaml-cc = "cc" & post}
   "conf-mingw-w64-gcc-i686" {?sys-ocaml-arch & sys-ocaml-arch = "i686" & sys-ocaml-libc = "msvc" & sys-ocaml-cc = "cc" & post}
-  "mingw-w64-shims" {?sys-ocaml-arch & sys-ocaml-libc = "msvc" & sys-ocaml-cc = "cc" & os-distribution = "cygwin" & post}
+  "ocaml-env-mingw32" {?sys-ocaml-arch & sys-ocaml-libc = "msvc" & sys-ocaml-arch = "i686" & sys-ocaml-cc = "cc" & post}
+  "ocaml-env-mingw64" {?sys-ocaml-arch & sys-ocaml-libc = "msvc" & sys-ocaml-arch = "x86_64" & sys-ocaml-cc = "cc" & post}
   "ocaml-env-msvc32" {?sys-ocaml-arch & sys-ocaml-arch = "i686" & sys-ocaml-cc = "msvc" & post}
   "ocaml-env-msvc64" {?sys-ocaml-arch & sys-ocaml-arch = "x86_64" & sys-ocaml-cc = "msvc" & post}
 ]

--- a/packages/ocaml-system/ocaml-system.4.14.2/opam
+++ b/packages/ocaml-system/ocaml-system.4.14.2/opam
@@ -1,7 +1,15 @@
 opam-version: "2.0"
+# These packages are part of the infrastructure for maintaining the OCaml
+# compiler dependencies in opam. It's not possible to version the metadata
+# itself, because opam's versioning provides no mechanism to ignore the
+# revision (i.e. we don't have a way to have two revisions of ocaml.5.4.1 but
+# where "ocaml" {= "5.4.1"} would always mean to use the latest revision).
+# It is however useful to know which version of the metadata is installed.
+# This number should be bumped whenever a pertinent change is made.
+x-revision: "6"
 synopsis: "The OCaml compiler (system version, from outside of opam)"
 maintainer: [
-  "David Allsopp <david@tarides.com>"
+  "David Allsopp <dra27@dra27.uk>"
   "Florian Angeletti <florian.angeletti@inria.fr>"
 ]
 license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"

--- a/packages/ocaml-system/ocaml-system.4.14.2/opam
+++ b/packages/ocaml-system/ocaml-system.4.14.2/opam
@@ -6,7 +6,7 @@ opam-version: "2.0"
 # where "ocaml" {= "5.4.1"} would always mean to use the latest revision).
 # It is however useful to know which version of the metadata is installed.
 # This number should be bumped whenever a pertinent change is made.
-x-revision: "6"
+x-revision: "7"
 synopsis: "The OCaml compiler (system version, from outside of opam)"
 maintainer: [
   "David Allsopp <dra27@dra27.uk>"
@@ -45,7 +45,8 @@ depends: [
   # configuration.
   "conf-mingw-w64-gcc-x86_64" {?sys-ocaml-arch & sys-ocaml-arch = "x86_64" & sys-ocaml-libc = "msvc" & sys-ocaml-cc = "cc" & post}
   "conf-mingw-w64-gcc-i686" {?sys-ocaml-arch & sys-ocaml-arch = "i686" & sys-ocaml-libc = "msvc" & sys-ocaml-cc = "cc" & post}
-  "mingw-w64-shims" {?sys-ocaml-arch & sys-ocaml-libc = "msvc" & sys-ocaml-cc = "cc" & os-distribution = "cygwin" & post}
+  "ocaml-env-mingw32" {?sys-ocaml-arch & sys-ocaml-libc = "msvc" & sys-ocaml-arch = "i686" & sys-ocaml-cc = "cc" & post}
+  "ocaml-env-mingw64" {?sys-ocaml-arch & sys-ocaml-libc = "msvc" & sys-ocaml-arch = "x86_64" & sys-ocaml-cc = "cc" & post}
   "ocaml-env-msvc32" {?sys-ocaml-arch & sys-ocaml-arch = "i686" & sys-ocaml-cc = "msvc" & post}
   "ocaml-env-msvc64" {?sys-ocaml-arch & sys-ocaml-arch = "x86_64" & sys-ocaml-cc = "msvc" & post}
 ]

--- a/packages/ocaml-system/ocaml-system.4.14.3/opam
+++ b/packages/ocaml-system/ocaml-system.4.14.3/opam
@@ -1,7 +1,15 @@
 opam-version: "2.0"
+# These packages are part of the infrastructure for maintaining the OCaml
+# compiler dependencies in opam. It's not possible to version the metadata
+# itself, because opam's versioning provides no mechanism to ignore the
+# revision (i.e. we don't have a way to have two revisions of ocaml.5.4.1 but
+# where "ocaml" {= "5.4.1"} would always mean to use the latest revision).
+# It is however useful to know which version of the metadata is installed.
+# This number should be bumped whenever a pertinent change is made.
+x-revision: "1"
 synopsis: "The OCaml compiler (system version, from outside of opam)"
 maintainer: [
-  "David Allsopp <david@tarides.com>"
+  "David Allsopp <dra27@dra27.uk>"
   "Florian Angeletti <florian.angeletti@inria.fr>"
 ]
 license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"

--- a/packages/ocaml-system/ocaml-system.4.14.3/opam
+++ b/packages/ocaml-system/ocaml-system.4.14.3/opam
@@ -6,7 +6,7 @@ opam-version: "2.0"
 # where "ocaml" {= "5.4.1"} would always mean to use the latest revision).
 # It is however useful to know which version of the metadata is installed.
 # This number should be bumped whenever a pertinent change is made.
-x-revision: "1"
+x-revision: "2"
 synopsis: "The OCaml compiler (system version, from outside of opam)"
 maintainer: [
   "David Allsopp <dra27@dra27.uk>"
@@ -45,7 +45,8 @@ depends: [
   # configuration.
   "conf-mingw-w64-gcc-x86_64" {?sys-ocaml-arch & sys-ocaml-arch = "x86_64" & sys-ocaml-libc = "msvc" & sys-ocaml-cc = "cc" & post}
   "conf-mingw-w64-gcc-i686" {?sys-ocaml-arch & sys-ocaml-arch = "i686" & sys-ocaml-libc = "msvc" & sys-ocaml-cc = "cc" & post}
-  "mingw-w64-shims" {?sys-ocaml-arch & sys-ocaml-libc = "msvc" & sys-ocaml-cc = "cc" & os-distribution = "cygwin" & post}
+  "ocaml-env-mingw32" {?sys-ocaml-arch & sys-ocaml-libc = "msvc" & sys-ocaml-arch = "i686" & sys-ocaml-cc = "cc" & post}
+  "ocaml-env-mingw64" {?sys-ocaml-arch & sys-ocaml-libc = "msvc" & sys-ocaml-arch = "x86_64" & sys-ocaml-cc = "cc" & post}
   "ocaml-env-msvc32" {?sys-ocaml-arch & sys-ocaml-arch = "i686" & sys-ocaml-cc = "msvc" & post}
   "ocaml-env-msvc64" {?sys-ocaml-arch & sys-ocaml-arch = "x86_64" & sys-ocaml-cc = "msvc" & post}
 ]

--- a/packages/ocaml-system/ocaml-system.5.0.0/opam
+++ b/packages/ocaml-system/ocaml-system.5.0.0/opam
@@ -1,7 +1,15 @@
 opam-version: "2.0"
+# These packages are part of the infrastructure for maintaining the OCaml
+# compiler dependencies in opam. It's not possible to version the metadata
+# itself, because opam's versioning provides no mechanism to ignore the
+# revision (i.e. we don't have a way to have two revisions of ocaml.5.4.1 but
+# where "ocaml" {= "5.4.1"} would always mean to use the latest revision).
+# It is however useful to know which version of the metadata is installed.
+# This number should be bumped whenever a pertinent change is made.
+x-revision: "6"
 synopsis: "The OCaml compiler (system version, from outside of opam)"
 maintainer: [
-  "David Allsopp <david@tarides.com>"
+  "David Allsopp <dra27@dra27.uk>"
   "Florian Angeletti <florian.angeletti@inria.fr>"
 ]
 license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"

--- a/packages/ocaml-system/ocaml-system.5.0.0/opam
+++ b/packages/ocaml-system/ocaml-system.5.0.0/opam
@@ -6,7 +6,7 @@ opam-version: "2.0"
 # where "ocaml" {= "5.4.1"} would always mean to use the latest revision).
 # It is however useful to know which version of the metadata is installed.
 # This number should be bumped whenever a pertinent change is made.
-x-revision: "6"
+x-revision: "7"
 synopsis: "The OCaml compiler (system version, from outside of opam)"
 maintainer: [
   "David Allsopp <dra27@dra27.uk>"
@@ -48,7 +48,8 @@ depends: [
   # configuration.
   "conf-mingw-w64-gcc-x86_64" {?sys-ocaml-arch & sys-ocaml-arch = "x86_64" & sys-ocaml-libc = "msvc" & sys-ocaml-cc = "cc" & post}
   "conf-mingw-w64-gcc-i686" {?sys-ocaml-arch & sys-ocaml-arch = "i686" & sys-ocaml-libc = "msvc" & sys-ocaml-cc = "cc" & post}
-  "mingw-w64-shims" {?sys-ocaml-arch & sys-ocaml-libc = "msvc" & sys-ocaml-cc = "cc" & os-distribution = "cygwin" & post}
+  "ocaml-env-mingw32" {?sys-ocaml-arch & sys-ocaml-libc = "msvc" & sys-ocaml-arch = "i686" & sys-ocaml-cc = "cc" & post}
+  "ocaml-env-mingw64" {?sys-ocaml-arch & sys-ocaml-libc = "msvc" & sys-ocaml-arch = "x86_64" & sys-ocaml-cc = "cc" & post}
   "ocaml-env-msvc32" {?sys-ocaml-arch & sys-ocaml-arch = "i686" & sys-ocaml-cc = "msvc" & post}
   "ocaml-env-msvc64" {?sys-ocaml-arch & sys-ocaml-arch = "x86_64" & sys-ocaml-cc = "msvc" & post}
 ]

--- a/packages/ocaml-system/ocaml-system.5.1.0/opam
+++ b/packages/ocaml-system/ocaml-system.5.1.0/opam
@@ -1,7 +1,15 @@
 opam-version: "2.0"
+# These packages are part of the infrastructure for maintaining the OCaml
+# compiler dependencies in opam. It's not possible to version the metadata
+# itself, because opam's versioning provides no mechanism to ignore the
+# revision (i.e. we don't have a way to have two revisions of ocaml.5.4.1 but
+# where "ocaml" {= "5.4.1"} would always mean to use the latest revision).
+# It is however useful to know which version of the metadata is installed.
+# This number should be bumped whenever a pertinent change is made.
+x-revision: "6"
 synopsis: "The OCaml compiler (system version, from outside of opam)"
 maintainer: [
-  "David Allsopp <david@tarides.com>"
+  "David Allsopp <dra27@dra27.uk>"
   "Florian Angeletti <florian.angeletti@inria.fr>"
 ]
 license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"

--- a/packages/ocaml-system/ocaml-system.5.1.0/opam
+++ b/packages/ocaml-system/ocaml-system.5.1.0/opam
@@ -6,7 +6,7 @@ opam-version: "2.0"
 # where "ocaml" {= "5.4.1"} would always mean to use the latest revision).
 # It is however useful to know which version of the metadata is installed.
 # This number should be bumped whenever a pertinent change is made.
-x-revision: "6"
+x-revision: "7"
 synopsis: "The OCaml compiler (system version, from outside of opam)"
 maintainer: [
   "David Allsopp <dra27@dra27.uk>"
@@ -50,7 +50,8 @@ depends: [
   "conf-mingw-w64-gcc-i686" {?sys-ocaml-arch & sys-ocaml-arch = "i686" & sys-ocaml-libc = "msvc" & sys-ocaml-cc = "cc" & post}
   "conf-mingw-w64-zstd-x86_64" {?sys-ocaml-arch & sys-ocaml-arch = "x86_64" & sys-ocaml-libc = "msvc" & sys-ocaml-cc = "cc" & post}
   "conf-mingw-w64-zstd-i686" {?sys-ocaml-arch & sys-ocaml-arch = "i686" & sys-ocaml-libc = "msvc" & sys-ocaml-cc = "cc" & post}
-  "mingw-w64-shims" {?sys-ocaml-arch & sys-ocaml-libc = "msvc" & sys-ocaml-cc = "cc" & os-distribution = "cygwin" & post}
+  "ocaml-env-mingw32" {?sys-ocaml-arch & sys-ocaml-libc = "msvc" & sys-ocaml-arch = "i686" & sys-ocaml-cc = "cc" & post}
+  "ocaml-env-mingw64" {?sys-ocaml-arch & sys-ocaml-libc = "msvc" & sys-ocaml-arch = "x86_64" & sys-ocaml-cc = "cc" & post}
   "ocaml-env-msvc32" {?sys-ocaml-arch & sys-ocaml-arch = "i686" & sys-ocaml-cc = "msvc" & post}
   "ocaml-env-msvc64" {?sys-ocaml-arch & sys-ocaml-arch = "x86_64" & sys-ocaml-cc = "msvc" & post}
 ]

--- a/packages/ocaml-system/ocaml-system.5.1.1/opam
+++ b/packages/ocaml-system/ocaml-system.5.1.1/opam
@@ -1,7 +1,15 @@
 opam-version: "2.0"
+# These packages are part of the infrastructure for maintaining the OCaml
+# compiler dependencies in opam. It's not possible to version the metadata
+# itself, because opam's versioning provides no mechanism to ignore the
+# revision (i.e. we don't have a way to have two revisions of ocaml.5.4.1 but
+# where "ocaml" {= "5.4.1"} would always mean to use the latest revision).
+# It is however useful to know which version of the metadata is installed.
+# This number should be bumped whenever a pertinent change is made.
+x-revision: "6"
 synopsis: "The OCaml compiler (system version, from outside of opam)"
 maintainer: [
-  "David Allsopp <david@tarides.com>"
+  "David Allsopp <dra27@dra27.uk>"
   "Florian Angeletti <florian.angeletti@inria.fr>"
 ]
 license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"

--- a/packages/ocaml-system/ocaml-system.5.1.1/opam
+++ b/packages/ocaml-system/ocaml-system.5.1.1/opam
@@ -6,7 +6,7 @@ opam-version: "2.0"
 # where "ocaml" {= "5.4.1"} would always mean to use the latest revision).
 # It is however useful to know which version of the metadata is installed.
 # This number should be bumped whenever a pertinent change is made.
-x-revision: "6"
+x-revision: "7"
 synopsis: "The OCaml compiler (system version, from outside of opam)"
 maintainer: [
   "David Allsopp <dra27@dra27.uk>"
@@ -50,7 +50,8 @@ depends: [
   "conf-mingw-w64-gcc-i686" {?sys-ocaml-arch & sys-ocaml-arch = "i686" & sys-ocaml-libc = "msvc" & sys-ocaml-cc = "cc" & post}
   "conf-mingw-w64-zstd-x86_64" {?sys-ocaml-arch & sys-ocaml-arch = "x86_64" & sys-ocaml-libc = "msvc" & sys-ocaml-cc = "cc" & post}
   "conf-mingw-w64-zstd-i686" {?sys-ocaml-arch & sys-ocaml-arch = "i686" & sys-ocaml-libc = "msvc" & sys-ocaml-cc = "cc" & post}
-  "mingw-w64-shims" {?sys-ocaml-arch & sys-ocaml-libc = "msvc" & sys-ocaml-cc = "cc" & os-distribution = "cygwin" & post}
+  "ocaml-env-mingw32" {?sys-ocaml-arch & sys-ocaml-libc = "msvc" & sys-ocaml-arch = "i686" & sys-ocaml-cc = "cc" & post}
+  "ocaml-env-mingw64" {?sys-ocaml-arch & sys-ocaml-libc = "msvc" & sys-ocaml-arch = "x86_64" & sys-ocaml-cc = "cc" & post}
   "ocaml-env-msvc32" {?sys-ocaml-arch & sys-ocaml-arch = "i686" & sys-ocaml-cc = "msvc" & post}
   "ocaml-env-msvc64" {?sys-ocaml-arch & sys-ocaml-arch = "x86_64" & sys-ocaml-cc = "msvc" & post}
 ]

--- a/packages/ocaml-system/ocaml-system.5.2.0/opam
+++ b/packages/ocaml-system/ocaml-system.5.2.0/opam
@@ -1,7 +1,15 @@
 opam-version: "2.0"
+# These packages are part of the infrastructure for maintaining the OCaml
+# compiler dependencies in opam. It's not possible to version the metadata
+# itself, because opam's versioning provides no mechanism to ignore the
+# revision (i.e. we don't have a way to have two revisions of ocaml.5.4.1 but
+# where "ocaml" {= "5.4.1"} would always mean to use the latest revision).
+# It is however useful to know which version of the metadata is installed.
+# This number should be bumped whenever a pertinent change is made.
+x-revision: "6"
 synopsis: "The OCaml compiler (system version, from outside of opam)"
 maintainer: [
-  "David Allsopp <david@tarides.com>"
+  "David Allsopp <dra27@dra27.uk>"
   "Florian Angeletti <florian.angeletti@inria.fr>"
 ]
 license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"

--- a/packages/ocaml-system/ocaml-system.5.2.0/opam
+++ b/packages/ocaml-system/ocaml-system.5.2.0/opam
@@ -6,7 +6,7 @@ opam-version: "2.0"
 # where "ocaml" {= "5.4.1"} would always mean to use the latest revision).
 # It is however useful to know which version of the metadata is installed.
 # This number should be bumped whenever a pertinent change is made.
-x-revision: "6"
+x-revision: "7"
 synopsis: "The OCaml compiler (system version, from outside of opam)"
 maintainer: [
   "David Allsopp <dra27@dra27.uk>"
@@ -50,7 +50,8 @@ depends: [
   "conf-mingw-w64-gcc-i686" {?sys-ocaml-arch & sys-ocaml-arch = "i686" & sys-ocaml-libc = "msvc" & sys-ocaml-cc = "cc" & post}
   "conf-mingw-w64-zstd-x86_64" {?sys-ocaml-arch & sys-ocaml-arch = "x86_64" & sys-ocaml-libc = "msvc" & sys-ocaml-cc = "cc" & post}
   "conf-mingw-w64-zstd-i686" {?sys-ocaml-arch & sys-ocaml-arch = "i686" & sys-ocaml-libc = "msvc" & sys-ocaml-cc = "cc" & post}
-  "mingw-w64-shims" {?sys-ocaml-arch & sys-ocaml-libc = "msvc" & sys-ocaml-cc = "cc" & os-distribution = "cygwin" & post}
+  "ocaml-env-mingw32" {?sys-ocaml-arch & sys-ocaml-libc = "msvc" & sys-ocaml-arch = "i686" & sys-ocaml-cc = "cc" & post}
+  "ocaml-env-mingw64" {?sys-ocaml-arch & sys-ocaml-libc = "msvc" & sys-ocaml-arch = "x86_64" & sys-ocaml-cc = "cc" & post}
   "ocaml-env-msvc32" {?sys-ocaml-arch & sys-ocaml-arch = "i686" & sys-ocaml-cc = "msvc" & post}
   "ocaml-env-msvc64" {?sys-ocaml-arch & sys-ocaml-arch = "x86_64" & sys-ocaml-cc = "msvc" & post}
 ]

--- a/packages/ocaml-system/ocaml-system.5.2.1/opam
+++ b/packages/ocaml-system/ocaml-system.5.2.1/opam
@@ -6,7 +6,7 @@ opam-version: "2.0"
 # where "ocaml" {= "5.4.1"} would always mean to use the latest revision).
 # It is however useful to know which version of the metadata is installed.
 # This number should be bumped whenever a pertinent change is made.
-x-revision: "4"
+x-revision: "5"
 synopsis: "The OCaml compiler (system version, from outside of opam)"
 maintainer: [
   "David Allsopp <dra27@dra27.uk>"
@@ -50,7 +50,8 @@ depends: [
   "conf-mingw-w64-gcc-i686" {?sys-ocaml-arch & sys-ocaml-arch = "i686" & sys-ocaml-libc = "msvc" & sys-ocaml-cc = "cc" & post}
   "conf-mingw-w64-zstd-x86_64" {?sys-ocaml-arch & sys-ocaml-arch = "x86_64" & sys-ocaml-libc = "msvc" & sys-ocaml-cc = "cc" & post}
   "conf-mingw-w64-zstd-i686" {?sys-ocaml-arch & sys-ocaml-arch = "i686" & sys-ocaml-libc = "msvc" & sys-ocaml-cc = "cc" & post}
-  "mingw-w64-shims" {?sys-ocaml-arch & sys-ocaml-libc = "msvc" & sys-ocaml-cc = "cc" & os-distribution = "cygwin" & post}
+  "ocaml-env-mingw32" {?sys-ocaml-arch & sys-ocaml-libc = "msvc" & sys-ocaml-arch = "i686" & sys-ocaml-cc = "cc" & post}
+  "ocaml-env-mingw64" {?sys-ocaml-arch & sys-ocaml-libc = "msvc" & sys-ocaml-arch = "x86_64" & sys-ocaml-cc = "cc" & post}
   "ocaml-env-msvc32" {?sys-ocaml-arch & sys-ocaml-arch = "i686" & sys-ocaml-cc = "msvc" & post}
   "ocaml-env-msvc64" {?sys-ocaml-arch & sys-ocaml-arch = "x86_64" & sys-ocaml-cc = "msvc" & post}
 ]

--- a/packages/ocaml-system/ocaml-system.5.2.1/opam
+++ b/packages/ocaml-system/ocaml-system.5.2.1/opam
@@ -1,7 +1,15 @@
 opam-version: "2.0"
+# These packages are part of the infrastructure for maintaining the OCaml
+# compiler dependencies in opam. It's not possible to version the metadata
+# itself, because opam's versioning provides no mechanism to ignore the
+# revision (i.e. we don't have a way to have two revisions of ocaml.5.4.1 but
+# where "ocaml" {= "5.4.1"} would always mean to use the latest revision).
+# It is however useful to know which version of the metadata is installed.
+# This number should be bumped whenever a pertinent change is made.
+x-revision: "4"
 synopsis: "The OCaml compiler (system version, from outside of opam)"
 maintainer: [
-  "David Allsopp <david@tarides.com>"
+  "David Allsopp <dra27@dra27.uk>"
   "Florian Angeletti <florian.angeletti@inria.fr>"
 ]
 license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"

--- a/packages/ocaml-system/ocaml-system.5.3.0/opam
+++ b/packages/ocaml-system/ocaml-system.5.3.0/opam
@@ -1,7 +1,15 @@
 opam-version: "2.0"
+# These packages are part of the infrastructure for maintaining the OCaml
+# compiler dependencies in opam. It's not possible to version the metadata
+# itself, because opam's versioning provides no mechanism to ignore the
+# revision (i.e. we don't have a way to have two revisions of ocaml.5.4.1 but
+# where "ocaml" {= "5.4.1"} would always mean to use the latest revision).
+# It is however useful to know which version of the metadata is installed.
+# This number should be bumped whenever a pertinent change is made.
+x-revision: "3"
 synopsis: "The OCaml compiler (system version, from outside of opam)"
 maintainer: [
-  "David Allsopp <david@tarides.com>"
+  "David Allsopp <dra27@dra27.uk>"
   "Florian Angeletti <florian.angeletti@inria.fr>"
 ]
 license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"

--- a/packages/ocaml-system/ocaml-system.5.3.0/opam
+++ b/packages/ocaml-system/ocaml-system.5.3.0/opam
@@ -6,7 +6,7 @@ opam-version: "2.0"
 # where "ocaml" {= "5.4.1"} would always mean to use the latest revision).
 # It is however useful to know which version of the metadata is installed.
 # This number should be bumped whenever a pertinent change is made.
-x-revision: "3"
+x-revision: "4"
 synopsis: "The OCaml compiler (system version, from outside of opam)"
 maintainer: [
   "David Allsopp <dra27@dra27.uk>"
@@ -50,7 +50,8 @@ depends: [
   "conf-mingw-w64-gcc-i686" {?sys-ocaml-arch & sys-ocaml-arch = "i686" & sys-ocaml-libc = "msvc" & sys-ocaml-cc = "cc" & post}
   "conf-mingw-w64-zstd-x86_64" {?sys-ocaml-arch & sys-ocaml-arch = "x86_64" & sys-ocaml-libc = "msvc" & sys-ocaml-cc = "cc" & post}
   "conf-mingw-w64-zstd-i686" {?sys-ocaml-arch & sys-ocaml-arch = "i686" & sys-ocaml-libc = "msvc" & sys-ocaml-cc = "cc" & post}
-  "mingw-w64-shims" {?sys-ocaml-arch & sys-ocaml-libc = "msvc" & sys-ocaml-cc = "cc" & os-distribution = "cygwin" & post}
+  "ocaml-env-mingw32" {?sys-ocaml-arch & sys-ocaml-libc = "msvc" & sys-ocaml-arch = "i686" & sys-ocaml-cc = "cc" & post}
+  "ocaml-env-mingw64" {?sys-ocaml-arch & sys-ocaml-libc = "msvc" & sys-ocaml-arch = "x86_64" & sys-ocaml-cc = "cc" & post}
   "ocaml-env-msvc32" {?sys-ocaml-arch & sys-ocaml-arch = "i686" & sys-ocaml-cc = "msvc" & post}
   "ocaml-env-msvc64" {?sys-ocaml-arch & sys-ocaml-arch = "x86_64" & sys-ocaml-cc = "msvc" & post}
 ]

--- a/packages/ocaml-system/ocaml-system.5.4.0/opam
+++ b/packages/ocaml-system/ocaml-system.5.4.0/opam
@@ -6,7 +6,7 @@ opam-version: "2.0"
 # where "ocaml" {= "5.4.1"} would always mean to use the latest revision).
 # It is however useful to know which version of the metadata is installed.
 # This number should be bumped whenever a pertinent change is made.
-x-revision: "2"
+x-revision: "3"
 synopsis: "The OCaml compiler (system version, from outside of opam)"
 maintainer: [
   "David Allsopp <dra27@dra27.uk>"
@@ -50,7 +50,8 @@ depends: [
   "conf-mingw-w64-gcc-i686" {?sys-ocaml-arch & sys-ocaml-arch = "i686" & sys-ocaml-libc = "msvc" & sys-ocaml-cc = "cc" & post}
   "conf-mingw-w64-zstd-x86_64" {?sys-ocaml-arch & sys-ocaml-arch = "x86_64" & sys-ocaml-libc = "msvc" & sys-ocaml-cc = "cc" & post}
   "conf-mingw-w64-zstd-i686" {?sys-ocaml-arch & sys-ocaml-arch = "i686" & sys-ocaml-libc = "msvc" & sys-ocaml-cc = "cc" & post}
-  "mingw-w64-shims" {?sys-ocaml-arch & sys-ocaml-libc = "msvc" & sys-ocaml-cc = "cc" & os-distribution = "cygwin" & post}
+  "ocaml-env-mingw32" {?sys-ocaml-arch & sys-ocaml-libc = "msvc" & sys-ocaml-arch = "i686" & sys-ocaml-cc = "cc" & post}
+  "ocaml-env-mingw64" {?sys-ocaml-arch & sys-ocaml-libc = "msvc" & sys-ocaml-arch = "x86_64" & sys-ocaml-cc = "cc" & post}
   "ocaml-env-msvc32" {?sys-ocaml-arch & sys-ocaml-arch = "i686" & sys-ocaml-cc = "msvc" & post}
   "ocaml-env-msvc64" {?sys-ocaml-arch & sys-ocaml-arch = "x86_64" & sys-ocaml-cc = "msvc" & post}
 ]

--- a/packages/ocaml-system/ocaml-system.5.4.0/opam
+++ b/packages/ocaml-system/ocaml-system.5.4.0/opam
@@ -1,7 +1,15 @@
 opam-version: "2.0"
+# These packages are part of the infrastructure for maintaining the OCaml
+# compiler dependencies in opam. It's not possible to version the metadata
+# itself, because opam's versioning provides no mechanism to ignore the
+# revision (i.e. we don't have a way to have two revisions of ocaml.5.4.1 but
+# where "ocaml" {= "5.4.1"} would always mean to use the latest revision).
+# It is however useful to know which version of the metadata is installed.
+# This number should be bumped whenever a pertinent change is made.
+x-revision: "2"
 synopsis: "The OCaml compiler (system version, from outside of opam)"
 maintainer: [
-  "David Allsopp <david@tarides.com>"
+  "David Allsopp <dra27@dra27.uk>"
   "Florian Angeletti <florian.angeletti@inria.fr>"
 ]
 license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"

--- a/packages/ocaml-system/ocaml-system.5.4.1/opam
+++ b/packages/ocaml-system/ocaml-system.5.4.1/opam
@@ -1,7 +1,15 @@
 opam-version: "2.0"
+# These packages are part of the infrastructure for maintaining the OCaml
+# compiler dependencies in opam. It's not possible to version the metadata
+# itself, because opam's versioning provides no mechanism to ignore the
+# revision (i.e. we don't have a way to have two revisions of ocaml.5.4.1 but
+# where "ocaml" {= "5.4.1"} would always mean to use the latest revision).
+# It is however useful to know which version of the metadata is installed.
+# This number should be bumped whenever a pertinent change is made.
+x-revision: "1"
 synopsis: "The OCaml compiler (system version, from outside of opam)"
 maintainer: [
-  "David Allsopp <david@tarides.com>"
+  "David Allsopp <dra27@dra27.uk>"
   "Florian Angeletti <florian.angeletti@inria.fr>"
 ]
 license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"

--- a/packages/ocaml-system/ocaml-system.5.4.1/opam
+++ b/packages/ocaml-system/ocaml-system.5.4.1/opam
@@ -6,7 +6,7 @@ opam-version: "2.0"
 # where "ocaml" {= "5.4.1"} would always mean to use the latest revision).
 # It is however useful to know which version of the metadata is installed.
 # This number should be bumped whenever a pertinent change is made.
-x-revision: "1"
+x-revision: "2"
 synopsis: "The OCaml compiler (system version, from outside of opam)"
 maintainer: [
   "David Allsopp <dra27@dra27.uk>"
@@ -50,7 +50,8 @@ depends: [
   "conf-mingw-w64-gcc-i686" {?sys-ocaml-arch & sys-ocaml-arch = "i686" & sys-ocaml-libc = "msvc" & sys-ocaml-cc = "cc" & post}
   "conf-mingw-w64-zstd-x86_64" {?sys-ocaml-arch & sys-ocaml-arch = "x86_64" & sys-ocaml-libc = "msvc" & sys-ocaml-cc = "cc" & post}
   "conf-mingw-w64-zstd-i686" {?sys-ocaml-arch & sys-ocaml-arch = "i686" & sys-ocaml-libc = "msvc" & sys-ocaml-cc = "cc" & post}
-  "mingw-w64-shims" {?sys-ocaml-arch & sys-ocaml-libc = "msvc" & sys-ocaml-cc = "cc" & os-distribution = "cygwin" & post}
+  "ocaml-env-mingw32" {?sys-ocaml-arch & sys-ocaml-libc = "msvc" & sys-ocaml-arch = "i686" & sys-ocaml-cc = "cc" & post}
+  "ocaml-env-mingw64" {?sys-ocaml-arch & sys-ocaml-libc = "msvc" & sys-ocaml-arch = "x86_64" & sys-ocaml-cc = "cc" & post}
   "ocaml-env-msvc32" {?sys-ocaml-arch & sys-ocaml-arch = "i686" & sys-ocaml-cc = "msvc" & post}
   "ocaml-env-msvc64" {?sys-ocaml-arch & sys-ocaml-arch = "x86_64" & sys-ocaml-cc = "msvc" & post}
 ]

--- a/packages/ocaml-variants/ocaml-variants.4.13.0+options/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.13.0+options/opam
@@ -6,7 +6,7 @@ opam-version: "2.0"
 # where "ocaml" {= "5.4.1"} would always mean to use the latest revision).
 # It is however useful to know which version of the metadata is installed.
 # This number should be bumped whenever a pertinent change is made.
-x-revision: "9"
+x-revision: "10"
 license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 synopsis: "Official release of OCaml 4.13.0"
 maintainer: [
@@ -29,12 +29,10 @@ depends: [
   # Port selection (Windows)
   # amd64 mingw-w64 / MSVC
   (("arch-x86_64" {os = "win32" & arch = "x86_64"} &
-     (("system-mingw" & "mingw-w64-shims" {os-distribution = "cygwin" & post}) |
-      "system-msvc")) |
+     ("system-mingw" | "system-msvc")) |
   # i686 mingw-w64 / MSVC
    ("arch-x86_32" {os = "win32"} &
-     (("system-mingw" & "mingw-w64-shims" {os-distribution = "cygwin" & post}) |
-      "system-msvc")) |
+     ("system-mingw" | "system-msvc")) |
   # Non-Windows systems need to install something to satisfy this formula, so
   # repeat the base-unix dependency
    "base-unix" {os != "win32" & post})

--- a/packages/ocaml-variants/ocaml-variants.4.13.0+options/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.13.0+options/opam
@@ -1,8 +1,16 @@
 opam-version: "2.0"
+# These packages are part of the infrastructure for maintaining the OCaml
+# compiler dependencies in opam. It's not possible to version the metadata
+# itself, because opam's versioning provides no mechanism to ignore the
+# revision (i.e. we don't have a way to have two revisions of ocaml.5.4.1 but
+# where "ocaml" {= "5.4.1"} would always mean to use the latest revision).
+# It is however useful to know which version of the metadata is installed.
+# This number should be bumped whenever a pertinent change is made.
+x-revision: "9"
 license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 synopsis: "Official release of OCaml 4.13.0"
 maintainer: [
-  "David Allsopp <david@tarides.com>"
+  "David Allsopp <dra27@dra27.uk>"
   "Florian Angeletti <florian.angeletti@inria.fr>"
 ]
 authors: ["Xavier Leroy" "Damien Doligez" "Alain Frisch" "Jacques Garrigue" "Didier Rémy" "Jérôme Vouillon"]

--- a/packages/ocaml-variants/ocaml-variants.4.13.1+options/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.13.1+options/opam
@@ -6,7 +6,7 @@ opam-version: "2.0"
 # where "ocaml" {= "5.4.1"} would always mean to use the latest revision).
 # It is however useful to know which version of the metadata is installed.
 # This number should be bumped whenever a pertinent change is made.
-x-revision: "9"
+x-revision: "10"
 license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 synopsis: "Official release of OCaml 4.13.1"
 maintainer: [
@@ -29,12 +29,10 @@ depends: [
   # Port selection (Windows)
   # amd64 mingw-w64 / MSVC
   (("arch-x86_64" {os = "win32" & arch = "x86_64"} &
-     (("system-mingw" & "mingw-w64-shims" {os-distribution = "cygwin" & post}) |
-      "system-msvc")) |
+     ("system-mingw" | "system-msvc")) |
   # i686 mingw-w64 / MSVC
    ("arch-x86_32" {os = "win32"} &
-     (("system-mingw" & "mingw-w64-shims" {os-distribution = "cygwin" & post}) |
-      "system-msvc")) |
+     ("system-mingw" | "system-msvc")) |
   # Non-Windows systems need to install something to satisfy this formula, so
   # repeat the base-unix dependency
    "base-unix" {os != "win32" & post})

--- a/packages/ocaml-variants/ocaml-variants.4.13.1+options/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.13.1+options/opam
@@ -1,8 +1,16 @@
 opam-version: "2.0"
+# These packages are part of the infrastructure for maintaining the OCaml
+# compiler dependencies in opam. It's not possible to version the metadata
+# itself, because opam's versioning provides no mechanism to ignore the
+# revision (i.e. we don't have a way to have two revisions of ocaml.5.4.1 but
+# where "ocaml" {= "5.4.1"} would always mean to use the latest revision).
+# It is however useful to know which version of the metadata is installed.
+# This number should be bumped whenever a pertinent change is made.
+x-revision: "9"
 license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 synopsis: "Official release of OCaml 4.13.1"
 maintainer: [
-  "David Allsopp <david@tarides.com>"
+  "David Allsopp <dra27@dra27.uk>"
   "Florian Angeletti <florian.angeletti@inria.fr>"
 ]
 authors: ["Xavier Leroy" "Damien Doligez" "Alain Frisch" "Jacques Garrigue" "Didier Rémy" "Jérôme Vouillon"]

--- a/packages/ocaml-variants/ocaml-variants.4.13.2+trunk/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.13.2+trunk/opam
@@ -1,8 +1,16 @@
 opam-version: "2.0"
+# These packages are part of the infrastructure for maintaining the OCaml
+# compiler dependencies in opam. It's not possible to version the metadata
+# itself, because opam's versioning provides no mechanism to ignore the
+# revision (i.e. we don't have a way to have two revisions of ocaml.5.4.1 but
+# where "ocaml" {= "5.4.1"} would always mean to use the latest revision).
+# It is however useful to know which version of the metadata is installed.
+# This number should be bumped whenever a pertinent change is made.
+x-revision: "10"
 license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 synopsis: "Latest 4.13 development"
 maintainer: [
-  "David Allsopp <david@tarides.com>"
+  "David Allsopp <dra27@dra27.uk>"
   "Florian Angeletti <florian.angeletti@inria.fr>"
 ]
 authors: ["Xavier Leroy" "Damien Doligez" "Alain Frisch" "Jacques Garrigue" "Didier Rémy" "Jérôme Vouillon"]

--- a/packages/ocaml-variants/ocaml-variants.4.13.2+trunk/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.13.2+trunk/opam
@@ -6,7 +6,7 @@ opam-version: "2.0"
 # where "ocaml" {= "5.4.1"} would always mean to use the latest revision).
 # It is however useful to know which version of the metadata is installed.
 # This number should be bumped whenever a pertinent change is made.
-x-revision: "10"
+x-revision: "11"
 license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 synopsis: "Latest 4.13 development"
 maintainer: [
@@ -47,12 +47,10 @@ depends: [
   # Port selection (Windows)
   # amd64 mingw-w64 / MSVC
   (("arch-x86_64" {os = "win32" & arch = "x86_64"} &
-     (("system-mingw" & "mingw-w64-shims" {os-distribution = "cygwin" & post}) |
-      "system-msvc")) |
+     ("system-mingw" | "system-msvc")) |
   # i686 mingw-w64 / MSVC
    ("arch-x86_32" {os = "win32"} &
-     (("system-mingw" & "mingw-w64-shims" {os-distribution = "cygwin" & post}) |
-      "system-msvc")) |
+     ("system-mingw" | "system-msvc")) |
   # Non-Windows systems
    "host-system-other" {os != "win32" & post})
 

--- a/packages/ocaml-variants/ocaml-variants.4.14.0+options/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.14.0+options/opam
@@ -1,8 +1,16 @@
 opam-version: "2.0"
+# These packages are part of the infrastructure for maintaining the OCaml
+# compiler dependencies in opam. It's not possible to version the metadata
+# itself, because opam's versioning provides no mechanism to ignore the
+# revision (i.e. we don't have a way to have two revisions of ocaml.5.4.1 but
+# where "ocaml" {= "5.4.1"} would always mean to use the latest revision).
+# It is however useful to know which version of the metadata is installed.
+# This number should be bumped whenever a pertinent change is made.
+x-revision: "10"
 license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 synopsis: "Official release of OCaml 4.14.0"
 maintainer: [
-  "David Allsopp <david@tarides.com>"
+  "David Allsopp <dra27@dra27.uk>"
   "Florian Angeletti <florian.angeletti@inria.fr>"
 ]
 authors: ["Xavier Leroy" "Damien Doligez" "Alain Frisch" "Jacques Garrigue" "Didier Rémy" "Jérôme Vouillon"]

--- a/packages/ocaml-variants/ocaml-variants.4.14.0+options/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.14.0+options/opam
@@ -6,7 +6,7 @@ opam-version: "2.0"
 # where "ocaml" {= "5.4.1"} would always mean to use the latest revision).
 # It is however useful to know which version of the metadata is installed.
 # This number should be bumped whenever a pertinent change is made.
-x-revision: "10"
+x-revision: "11"
 license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 synopsis: "Official release of OCaml 4.14.0"
 maintainer: [
@@ -29,12 +29,10 @@ depends: [
   # Port selection (Windows)
   # amd64 mingw-w64 / MSVC
   (("arch-x86_64" {os = "win32" & arch = "x86_64"} &
-     (("system-mingw" & "mingw-w64-shims" {os-distribution = "cygwin" & post}) |
-      "system-msvc")) |
+     ("system-mingw" | "system-msvc")) |
   # i686 mingw-w64 / MSVC
    ("arch-x86_32" {os = "win32"} &
-     (("system-mingw" & "mingw-w64-shims" {os-distribution = "cygwin" & post}) |
-      "system-msvc")) |
+     ("system-mingw" | "system-msvc")) |
   # Non-Windows systems need to install something to satisfy this formula, so
   # repeat the base-unix dependency
    "base-unix" {os != "win32" & post})

--- a/packages/ocaml-variants/ocaml-variants.4.14.1+options/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.14.1+options/opam
@@ -1,8 +1,16 @@
 opam-version: "2.0"
+# These packages are part of the infrastructure for maintaining the OCaml
+# compiler dependencies in opam. It's not possible to version the metadata
+# itself, because opam's versioning provides no mechanism to ignore the
+# revision (i.e. we don't have a way to have two revisions of ocaml.5.4.1 but
+# where "ocaml" {= "5.4.1"} would always mean to use the latest revision).
+# It is however useful to know which version of the metadata is installed.
+# This number should be bumped whenever a pertinent change is made.
+x-revision: "8"
 license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 synopsis: "Official release of OCaml 4.14.1"
 maintainer: [
-  "David Allsopp <david@tarides.com>"
+  "David Allsopp <dra27@dra27.uk>"
   "Florian Angeletti <florian.angeletti@inria.fr>"
 ]
 authors: ["Xavier Leroy" "Damien Doligez" "Alain Frisch" "Jacques Garrigue" "Didier Rémy" "Jérôme Vouillon"]

--- a/packages/ocaml-variants/ocaml-variants.4.14.1+options/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.14.1+options/opam
@@ -6,7 +6,7 @@ opam-version: "2.0"
 # where "ocaml" {= "5.4.1"} would always mean to use the latest revision).
 # It is however useful to know which version of the metadata is installed.
 # This number should be bumped whenever a pertinent change is made.
-x-revision: "8"
+x-revision: "9"
 license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 synopsis: "Official release of OCaml 4.14.1"
 maintainer: [
@@ -29,12 +29,10 @@ depends: [
   # Port selection (Windows)
   # amd64 mingw-w64 / MSVC
   (("arch-x86_64" {os = "win32" & arch = "x86_64"} &
-     (("system-mingw" & "mingw-w64-shims" {os-distribution = "cygwin" & post}) |
-      "system-msvc")) |
+     ("system-mingw" | "system-msvc")) |
   # i686 mingw-w64 / MSVC
    ("arch-x86_32" {os = "win32"} &
-     (("system-mingw" & "mingw-w64-shims" {os-distribution = "cygwin" & post}) |
-      "system-msvc")) |
+     ("system-mingw" | "system-msvc")) |
   # Non-Windows systems need to install something to satisfy this formula, so
   # repeat the base-unix dependency
    "base-unix" {os != "win32" & post})

--- a/packages/ocaml-variants/ocaml-variants.4.14.2+options/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.14.2+options/opam
@@ -6,7 +6,7 @@ opam-version: "2.0"
 # where "ocaml" {= "5.4.1"} would always mean to use the latest revision).
 # It is however useful to know which version of the metadata is installed.
 # This number should be bumped whenever a pertinent change is made.
-x-revision: "8"
+x-revision: "9"
 license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 synopsis: "Official release of OCaml 4.14.2"
 maintainer: [
@@ -29,12 +29,10 @@ depends: [
   # Port selection (Windows)
   # amd64 mingw-w64 / MSVC
   (("arch-x86_64" {os = "win32" & arch = "x86_64"} &
-     (("system-mingw" & "mingw-w64-shims" {os-distribution = "cygwin" & post}) |
-      "system-msvc")) |
+     ("system-mingw" | "system-msvc")) |
   # i686 mingw-w64 / MSVC
    ("arch-x86_32" {os = "win32"} &
-     (("system-mingw" & "mingw-w64-shims" {os-distribution = "cygwin" & post}) |
-      "system-msvc")) |
+     ("system-mingw" | "system-msvc")) |
   # Non-Windows systems need to install something to satisfy this formula, so
   # repeat the base-unix dependency
    "base-unix" {os != "win32" & post})

--- a/packages/ocaml-variants/ocaml-variants.4.14.2+options/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.14.2+options/opam
@@ -1,8 +1,16 @@
 opam-version: "2.0"
+# These packages are part of the infrastructure for maintaining the OCaml
+# compiler dependencies in opam. It's not possible to version the metadata
+# itself, because opam's versioning provides no mechanism to ignore the
+# revision (i.e. we don't have a way to have two revisions of ocaml.5.4.1 but
+# where "ocaml" {= "5.4.1"} would always mean to use the latest revision).
+# It is however useful to know which version of the metadata is installed.
+# This number should be bumped whenever a pertinent change is made.
+x-revision: "8"
 license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 synopsis: "Official release of OCaml 4.14.2"
 maintainer: [
-  "David Allsopp <david@tarides.com>"
+  "David Allsopp <dra27@dra27.uk>"
   "Florian Angeletti <florian.angeletti@inria.fr>"
 ]
 authors: ["Xavier Leroy" "Damien Doligez" "Alain Frisch" "Jacques Garrigue" "Didier Rémy" "Jérôme Vouillon"]

--- a/packages/ocaml-variants/ocaml-variants.4.14.3+options/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.14.3+options/opam
@@ -6,7 +6,7 @@ opam-version: "2.0"
 # where "ocaml" {= "5.4.1"} would always mean to use the latest revision).
 # It is however useful to know which version of the metadata is installed.
 # This number should be bumped whenever a pertinent change is made.
-x-revision: "2"
+x-revision: "3"
 license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 synopsis: "Official release of OCaml 4.14.3"
 maintainer: [
@@ -29,12 +29,10 @@ depends: [
   # Port selection (Windows)
   # amd64 mingw-w64 / MSVC
   (("arch-x86_64" {os = "win32" & arch = "x86_64"} &
-     (("system-mingw" & "mingw-w64-shims" {os-distribution = "cygwin" & post}) |
-      "system-msvc")) |
+     ("system-mingw" | "system-msvc")) |
   # i686 mingw-w64 / MSVC
    ("arch-x86_32" {os = "win32"} &
-     (("system-mingw" & "mingw-w64-shims" {os-distribution = "cygwin" & post}) |
-      "system-msvc")) |
+     ("system-mingw" | "system-msvc")) |
   # Non-Windows systems need to install something to satisfy this formula, so
   # repeat the base-unix dependency
    "base-unix" {os != "win32" & post})

--- a/packages/ocaml-variants/ocaml-variants.4.14.3+options/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.14.3+options/opam
@@ -1,8 +1,16 @@
 opam-version: "2.0"
+# These packages are part of the infrastructure for maintaining the OCaml
+# compiler dependencies in opam. It's not possible to version the metadata
+# itself, because opam's versioning provides no mechanism to ignore the
+# revision (i.e. we don't have a way to have two revisions of ocaml.5.4.1 but
+# where "ocaml" {= "5.4.1"} would always mean to use the latest revision).
+# It is however useful to know which version of the metadata is installed.
+# This number should be bumped whenever a pertinent change is made.
+x-revision: "2"
 license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 synopsis: "Official release of OCaml 4.14.3"
 maintainer: [
-  "David Allsopp <david@tarides.com>"
+  "David Allsopp <dra27@dra27.uk>"
   "Florian Angeletti <florian.angeletti@inria.fr>"
 ]
 authors: ["Xavier Leroy" "Damien Doligez" "Alain Frisch" "Jacques Garrigue" "Didier Rémy" "Jérôme Vouillon"]

--- a/packages/ocaml-variants/ocaml-variants.4.14.4+trunk/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.14.4+trunk/opam
@@ -6,7 +6,7 @@ opam-version: "2.0"
 # where "ocaml" {= "5.4.1"} would always mean to use the latest revision).
 # It is however useful to know which version of the metadata is installed.
 # This number should be bumped whenever a pertinent change is made.
-x-revision: "2"
+x-revision: "3"
 license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 synopsis: "Latest 4.14 development"
 maintainer: [
@@ -54,12 +54,10 @@ depends: [
   # Port selection (Windows)
   # amd64 mingw-w64 / MSVC
   (("arch-x86_64" {os = "win32" & arch = "x86_64"} &
-     (("system-mingw" & "mingw-w64-shims" {os-distribution = "cygwin" & post}) |
-      "system-msvc")) |
+     ("system-mingw" | "system-msvc")) |
   # i686 mingw-w64 / MSVC
    ("arch-x86_32" {os = "win32"} &
-     (("system-mingw" & "mingw-w64-shims" {os-distribution = "cygwin" & post}) |
-      "system-msvc")) |
+     ("system-mingw" | "system-msvc")) |
   # Non-Windows systems
    "host-system-other" {os != "win32" & post})
 

--- a/packages/ocaml-variants/ocaml-variants.4.14.4+trunk/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.14.4+trunk/opam
@@ -1,8 +1,16 @@
 opam-version: "2.0"
+# These packages are part of the infrastructure for maintaining the OCaml
+# compiler dependencies in opam. It's not possible to version the metadata
+# itself, because opam's versioning provides no mechanism to ignore the
+# revision (i.e. we don't have a way to have two revisions of ocaml.5.4.1 but
+# where "ocaml" {= "5.4.1"} would always mean to use the latest revision).
+# It is however useful to know which version of the metadata is installed.
+# This number should be bumped whenever a pertinent change is made.
+x-revision: "2"
 license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 synopsis: "Latest 4.14 development"
 maintainer: [
-  "David Allsopp <david@tarides.com>"
+  "David Allsopp <dra27@dra27.uk>"
   "Florian Angeletti <florian.angeletti@inria.fr>"
 ]
 authors: [

--- a/packages/ocaml-variants/ocaml-variants.5.0.0+options/opam
+++ b/packages/ocaml-variants/ocaml-variants.5.0.0+options/opam
@@ -6,7 +6,7 @@ opam-version: "2.0"
 # where "ocaml" {= "5.4.1"} would always mean to use the latest revision).
 # It is however useful to know which version of the metadata is installed.
 # This number should be bumped whenever a pertinent change is made.
-x-revision: "9"
+x-revision: "10"
 license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 synopsis: "Official release of OCaml 5.0.0"
 maintainer: [
@@ -38,10 +38,10 @@ depends: [
   # Port selection (Windows)
   # amd64 mingw-w64 only
   (("arch-x86_64" {os = "win32" & arch = "x86_64"} &
-     "system-mingw" & "mingw-w64-shims" {os-distribution = "cygwin" & post}) |
+     "system-mingw") |
   # i686 mingw-w64 only
    ("arch-x86_32" {os = "win32"} & "ocaml-option-bytecode-only" {os = "win32"} &
-     "system-mingw" & "mingw-w64-shims" {os-distribution = "cygwin" & post}) |
+     "system-mingw") |
   # Non-Windows systems need to install something to satisfy this formula, so
   # repeat the base-unix dependency
    "base-unix" {os != "win32" & post})

--- a/packages/ocaml-variants/ocaml-variants.5.0.0+options/opam
+++ b/packages/ocaml-variants/ocaml-variants.5.0.0+options/opam
@@ -1,8 +1,16 @@
 opam-version: "2.0"
+# These packages are part of the infrastructure for maintaining the OCaml
+# compiler dependencies in opam. It's not possible to version the metadata
+# itself, because opam's versioning provides no mechanism to ignore the
+# revision (i.e. we don't have a way to have two revisions of ocaml.5.4.1 but
+# where "ocaml" {= "5.4.1"} would always mean to use the latest revision).
+# It is however useful to know which version of the metadata is installed.
+# This number should be bumped whenever a pertinent change is made.
+x-revision: "9"
 license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 synopsis: "Official release of OCaml 5.0.0"
 maintainer: [
-  "David Allsopp <david@tarides.com>"
+  "David Allsopp <dra27@dra27.uk>"
   "Florian Angeletti <florian.angeletti@inria.fr>"
 ]
 authors: [

--- a/packages/ocaml-variants/ocaml-variants.5.0.1+trunk/opam
+++ b/packages/ocaml-variants/ocaml-variants.5.0.1+trunk/opam
@@ -6,7 +6,7 @@ opam-version: "2.0"
 # where "ocaml" {= "5.4.1"} would always mean to use the latest revision).
 # It is however useful to know which version of the metadata is installed.
 # This number should be bumped whenever a pertinent change is made.
-x-revision: "8"
+x-revision: "9"
 license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 synopsis: "Latest 5.0 development"
 maintainer: [
@@ -56,10 +56,10 @@ depends: [
   # Port selection (Windows)
   # amd64 mingw-w64 only
   (("arch-x86_64" {os = "win32" & arch = "x86_64"} &
-     "system-mingw" & "mingw-w64-shims" {os-distribution = "cygwin" & post}) |
+     "system-mingw") |
   # i686 mingw-w64 only
    ("arch-x86_32" {os = "win32"} & "ocaml-option-bytecode-only" {os = "win32"} &
-     "system-mingw" & "mingw-w64-shims" {os-distribution = "cygwin" & post}) |
+     "system-mingw") |
   # Non-Windows systems
    "host-system-other" {os != "win32" & post})
 

--- a/packages/ocaml-variants/ocaml-variants.5.0.1+trunk/opam
+++ b/packages/ocaml-variants/ocaml-variants.5.0.1+trunk/opam
@@ -1,8 +1,16 @@
 opam-version: "2.0"
+# These packages are part of the infrastructure for maintaining the OCaml
+# compiler dependencies in opam. It's not possible to version the metadata
+# itself, because opam's versioning provides no mechanism to ignore the
+# revision (i.e. we don't have a way to have two revisions of ocaml.5.4.1 but
+# where "ocaml" {= "5.4.1"} would always mean to use the latest revision).
+# It is however useful to know which version of the metadata is installed.
+# This number should be bumped whenever a pertinent change is made.
+x-revision: "8"
 license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 synopsis: "Latest 5.0 development"
 maintainer: [
-  "David Allsopp <david@tarides.com>"
+  "David Allsopp <dra27@dra27.uk>"
   "Florian Angeletti <florian.angeletti@inria.fr>"
 ]
 authors: [

--- a/packages/ocaml-variants/ocaml-variants.5.1.0+options/opam
+++ b/packages/ocaml-variants/ocaml-variants.5.1.0+options/opam
@@ -6,7 +6,7 @@ opam-version: "2.0"
 # where "ocaml" {= "5.4.1"} would always mean to use the latest revision).
 # It is however useful to know which version of the metadata is installed.
 # This number should be bumped whenever a pertinent change is made.
-x-revision: "10"
+x-revision: "11"
 license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 synopsis: "Official release of OCaml 5.1.0"
 maintainer: [
@@ -38,10 +38,10 @@ depends: [
   # Port selection (Windows)
   # amd64 mingw-w64 only
   (("arch-x86_64" {os = "win32" & arch = "x86_64"} &
-     "system-mingw" & "mingw-w64-shims" {os-distribution = "cygwin" & build}) |
+     "system-mingw") |
   # i686 mingw-w64 only
    ("arch-x86_32" {os = "win32"} & "ocaml-option-bytecode-only" {os = "win32"} &
-     "system-mingw" & "mingw-w64-shims" {os-distribution = "cygwin" & build}) |
+     "system-mingw") |
   # Non-Windows systems need to install something to satisfy this formula, so
   # repeat the base-unix dependency
    "base-unix" {os != "win32" & post})

--- a/packages/ocaml-variants/ocaml-variants.5.1.0+options/opam
+++ b/packages/ocaml-variants/ocaml-variants.5.1.0+options/opam
@@ -1,8 +1,16 @@
 opam-version: "2.0"
+# These packages are part of the infrastructure for maintaining the OCaml
+# compiler dependencies in opam. It's not possible to version the metadata
+# itself, because opam's versioning provides no mechanism to ignore the
+# revision (i.e. we don't have a way to have two revisions of ocaml.5.4.1 but
+# where "ocaml" {= "5.4.1"} would always mean to use the latest revision).
+# It is however useful to know which version of the metadata is installed.
+# This number should be bumped whenever a pertinent change is made.
+x-revision: "10"
 license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 synopsis: "Official release of OCaml 5.1.0"
 maintainer: [
-  "David Allsopp <david@tarides.com>"
+  "David Allsopp <dra27@dra27.uk>"
   "Florian Angeletti <florian.angeletti@inria.fr>"
 ]
 authors: [

--- a/packages/ocaml-variants/ocaml-variants.5.1.1+effect-syntax/opam
+++ b/packages/ocaml-variants/ocaml-variants.5.1.1+effect-syntax/opam
@@ -6,7 +6,7 @@ opam-version: "2.0"
 # where "ocaml" {= "5.4.1"} would always mean to use the latest revision).
 # It is however useful to know which version of the metadata is installed.
 # This number should be bumped whenever a pertinent change is made.
-x-revision: "9"
+x-revision: "10"
 license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 synopsis: "OCaml 5.1.1, with effect syntax support"
 maintainer: [
@@ -41,10 +41,10 @@ depends: [
   # Port selection (Windows)
   # amd64 mingw-w64 only
   (("arch-x86_64" {os = "win32" & arch = "x86_64"} &
-     "system-mingw" & "mingw-w64-shims" {os-distribution = "cygwin" & build}) |
+     "system-mingw") |
   # i686 mingw-w64 only
    ("arch-x86_32" {os = "win32"} & "ocaml-option-bytecode-only" {os = "win32"} &
-     "system-mingw" & "mingw-w64-shims" {os-distribution = "cygwin" & build}) |
+     "system-mingw") |
   # Non-Windows systems need to install something to satisfy this formula, so
   # repeat the base-unix dependency
    "base-unix" {os != "win32" & post})

--- a/packages/ocaml-variants/ocaml-variants.5.1.1+effect-syntax/opam
+++ b/packages/ocaml-variants/ocaml-variants.5.1.1+effect-syntax/opam
@@ -1,8 +1,16 @@
 opam-version: "2.0"
+# These packages are part of the infrastructure for maintaining the OCaml
+# compiler dependencies in opam. It's not possible to version the metadata
+# itself, because opam's versioning provides no mechanism to ignore the
+# revision (i.e. we don't have a way to have two revisions of ocaml.5.4.1 but
+# where "ocaml" {= "5.4.1"} would always mean to use the latest revision).
+# It is however useful to know which version of the metadata is installed.
+# This number should be bumped whenever a pertinent change is made.
+x-revision: "9"
 license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 synopsis: "OCaml 5.1.1, with effect syntax support"
 maintainer: [
-  "David Allsopp <david@tarides.com>"
+  "David Allsopp <dra27@dra27.uk>"
   "Florian Angeletti <florian.angeletti@inria.fr>"
 ]
 authors: [

--- a/packages/ocaml-variants/ocaml-variants.5.1.1+options/opam
+++ b/packages/ocaml-variants/ocaml-variants.5.1.1+options/opam
@@ -1,8 +1,16 @@
 opam-version: "2.0"
+# These packages are part of the infrastructure for maintaining the OCaml
+# compiler dependencies in opam. It's not possible to version the metadata
+# itself, because opam's versioning provides no mechanism to ignore the
+# revision (i.e. we don't have a way to have two revisions of ocaml.5.4.1 but
+# where "ocaml" {= "5.4.1"} would always mean to use the latest revision).
+# It is however useful to know which version of the metadata is installed.
+# This number should be bumped whenever a pertinent change is made.
+x-revision: "9"
 license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 synopsis: "Official release of OCaml 5.1.1"
 maintainer: [
-  "David Allsopp <david@tarides.com>"
+  "David Allsopp <dra27@dra27.uk>"
   "Florian Angeletti <florian.angeletti@inria.fr>"
 ]
 authors: [

--- a/packages/ocaml-variants/ocaml-variants.5.1.1+options/opam
+++ b/packages/ocaml-variants/ocaml-variants.5.1.1+options/opam
@@ -6,7 +6,7 @@ opam-version: "2.0"
 # where "ocaml" {= "5.4.1"} would always mean to use the latest revision).
 # It is however useful to know which version of the metadata is installed.
 # This number should be bumped whenever a pertinent change is made.
-x-revision: "9"
+x-revision: "10"
 license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 synopsis: "Official release of OCaml 5.1.1"
 maintainer: [
@@ -38,10 +38,10 @@ depends: [
   # Port selection (Windows)
   # amd64 mingw-w64 only
   (("arch-x86_64" {os = "win32" & arch = "x86_64"} &
-     "system-mingw" & "mingw-w64-shims" {os-distribution = "cygwin" & build}) |
+     "system-mingw") |
   # i686 mingw-w64 only
    ("arch-x86_32" {os = "win32"} & "ocaml-option-bytecode-only" {os = "win32"} &
-     "system-mingw" & "mingw-w64-shims" {os-distribution = "cygwin" & build}) |
+     "system-mingw") |
   # Non-Windows systems need to install something to satisfy this formula, so
   # repeat the base-unix dependency
    "base-unix" {os != "win32" & post})

--- a/packages/ocaml-variants/ocaml-variants.5.1.2+trunk/opam
+++ b/packages/ocaml-variants/ocaml-variants.5.1.2+trunk/opam
@@ -6,7 +6,7 @@ opam-version: "2.0"
 # where "ocaml" {= "5.4.1"} would always mean to use the latest revision).
 # It is however useful to know which version of the metadata is installed.
 # This number should be bumped whenever a pertinent change is made.
-x-revision: "8"
+x-revision: "9"
 license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 synopsis: "Latest 5.1 development"
 maintainer: [
@@ -56,10 +56,10 @@ depends: [
   # Port selection (Windows)
   # amd64 mingw-w64 only
   (("arch-x86_64" {os = "win32" & arch = "x86_64"} &
-     "system-mingw" & "mingw-w64-shims" {os-distribution = "cygwin" & build}) |
+     "system-mingw") |
   # i686 mingw-w64 only
    ("arch-x86_32" {os = "win32"} & "ocaml-option-bytecode-only" {os = "win32"} &
-     "system-mingw" & "mingw-w64-shims" {os-distribution = "cygwin" & build}) |
+     "system-mingw") |
   # Non-Windows systems
    "host-system-other" {os != "win32" & post})
 

--- a/packages/ocaml-variants/ocaml-variants.5.1.2+trunk/opam
+++ b/packages/ocaml-variants/ocaml-variants.5.1.2+trunk/opam
@@ -1,8 +1,16 @@
 opam-version: "2.0"
+# These packages are part of the infrastructure for maintaining the OCaml
+# compiler dependencies in opam. It's not possible to version the metadata
+# itself, because opam's versioning provides no mechanism to ignore the
+# revision (i.e. we don't have a way to have two revisions of ocaml.5.4.1 but
+# where "ocaml" {= "5.4.1"} would always mean to use the latest revision).
+# It is however useful to know which version of the metadata is installed.
+# This number should be bumped whenever a pertinent change is made.
+x-revision: "8"
 license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 synopsis: "Latest 5.1 development"
 maintainer: [
-  "David Allsopp <david@tarides.com>"
+  "David Allsopp <dra27@dra27.uk>"
   "Florian Angeletti <florian.angeletti@inria.fr>"
 ]
 authors: [

--- a/packages/ocaml-variants/ocaml-variants.5.2.0+options/opam
+++ b/packages/ocaml-variants/ocaml-variants.5.2.0+options/opam
@@ -6,7 +6,7 @@ opam-version: "2.0"
 # where "ocaml" {= "5.4.1"} would always mean to use the latest revision).
 # It is however useful to know which version of the metadata is installed.
 # This number should be bumped whenever a pertinent change is made.
-x-revision: "9"
+x-revision: "10"
 license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 synopsis: "Official release of OCaml 5.2.0"
 maintainer: [
@@ -38,10 +38,10 @@ depends: [
   # Port selection (Windows)
   # amd64 mingw-w64 only
   (("arch-x86_64" {os = "win32" & arch = "x86_64"} &
-     "system-mingw" & "mingw-w64-shims" {os-distribution = "cygwin" & build}) |
+     "system-mingw") |
   # i686 mingw-w64 only
    ("arch-x86_32" {os = "win32"} & "ocaml-option-bytecode-only" {os = "win32"} &
-     "system-mingw" & "mingw-w64-shims" {os-distribution = "cygwin" & build}) |
+     "system-mingw") |
   # Non-Windows systems need to install something to satisfy this formula, so
   # repeat the base-unix dependency
    "base-unix" {os != "win32" & post})

--- a/packages/ocaml-variants/ocaml-variants.5.2.0+options/opam
+++ b/packages/ocaml-variants/ocaml-variants.5.2.0+options/opam
@@ -1,8 +1,16 @@
 opam-version: "2.0"
+# These packages are part of the infrastructure for maintaining the OCaml
+# compiler dependencies in opam. It's not possible to version the metadata
+# itself, because opam's versioning provides no mechanism to ignore the
+# revision (i.e. we don't have a way to have two revisions of ocaml.5.4.1 but
+# where "ocaml" {= "5.4.1"} would always mean to use the latest revision).
+# It is however useful to know which version of the metadata is installed.
+# This number should be bumped whenever a pertinent change is made.
+x-revision: "9"
 license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 synopsis: "Official release of OCaml 5.2.0"
 maintainer: [
-  "David Allsopp <david@tarides.com>"
+  "David Allsopp <dra27@dra27.uk>"
   "Florian Angeletti <florian.angeletti@inria.fr>"
 ]
 authors: [

--- a/packages/ocaml-variants/ocaml-variants.5.2.0+statmemprof/opam
+++ b/packages/ocaml-variants/ocaml-variants.5.2.0+statmemprof/opam
@@ -6,7 +6,7 @@ opam-version: "2.0"
 # where "ocaml" {= "5.4.1"} would always mean to use the latest revision).
 # It is however useful to know which version of the metadata is installed.
 # This number should be bumped whenever a pertinent change is made.
-x-revision: "7"
+x-revision: "8"
 license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 synopsis: "OCaml 5.2.0, with Statistical Memory Profiler support"
 maintainer: [
@@ -40,10 +40,10 @@ depends: [
   # Port selection (Windows)
   # amd64 mingw-w64 only
   (("arch-x86_64" {os = "win32" & arch = "x86_64"} &
-     "system-mingw" & "mingw-w64-shims" {os-distribution = "cygwin" & build}) |
+     "system-mingw") |
   # i686 mingw-w64 only
    ("arch-x86_32" {os = "win32"} & "ocaml-option-bytecode-only" {os = "win32"} &
-     "system-mingw" & "mingw-w64-shims" {os-distribution = "cygwin" & build}) |
+     "system-mingw") |
   # Non-Windows systems need to install something to satisfy this formula, so
   # repeat the base-unix dependency
    "base-unix" {os != "win32" & post})

--- a/packages/ocaml-variants/ocaml-variants.5.2.0+statmemprof/opam
+++ b/packages/ocaml-variants/ocaml-variants.5.2.0+statmemprof/opam
@@ -1,8 +1,16 @@
 opam-version: "2.0"
+# These packages are part of the infrastructure for maintaining the OCaml
+# compiler dependencies in opam. It's not possible to version the metadata
+# itself, because opam's versioning provides no mechanism to ignore the
+# revision (i.e. we don't have a way to have two revisions of ocaml.5.4.1 but
+# where "ocaml" {= "5.4.1"} would always mean to use the latest revision).
+# It is however useful to know which version of the metadata is installed.
+# This number should be bumped whenever a pertinent change is made.
+x-revision: "7"
 license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 synopsis: "OCaml 5.2.0, with Statistical Memory Profiler support"
 maintainer: [
-  "David Allsopp <david@tarides.com>"
+  "David Allsopp <dra27@dra27.uk>"
   "Florian Angeletti <florian.angeletti@inria.fr>"
 ]
 authors: [

--- a/packages/ocaml-variants/ocaml-variants.5.2.1+options/opam
+++ b/packages/ocaml-variants/ocaml-variants.5.2.1+options/opam
@@ -6,7 +6,7 @@ opam-version: "2.0"
 # where "ocaml" {= "5.4.1"} would always mean to use the latest revision).
 # It is however useful to know which version of the metadata is installed.
 # This number should be bumped whenever a pertinent change is made.
-x-revision: "4"
+x-revision: "5"
 license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 synopsis: "Official release of OCaml 5.2.1"
 maintainer: [
@@ -38,10 +38,10 @@ depends: [
   # Port selection (Windows)
   # amd64 mingw-w64 only
   (("arch-x86_64" {os = "win32" & arch = "x86_64"} &
-     "system-mingw" & "mingw-w64-shims" {os-distribution = "cygwin" & build}) |
+     "system-mingw") |
   # i686 mingw-w64 only
    ("arch-x86_32" {os = "win32"} & "ocaml-option-bytecode-only" {os = "win32"} &
-     "system-mingw" & "mingw-w64-shims" {os-distribution = "cygwin" & build}) |
+     "system-mingw") |
   # Non-Windows systems need to install something to satisfy this formula, so
   # repeat the base-unix dependency
    "base-unix" {os != "win32" & post})

--- a/packages/ocaml-variants/ocaml-variants.5.2.1+options/opam
+++ b/packages/ocaml-variants/ocaml-variants.5.2.1+options/opam
@@ -1,8 +1,16 @@
 opam-version: "2.0"
+# These packages are part of the infrastructure for maintaining the OCaml
+# compiler dependencies in opam. It's not possible to version the metadata
+# itself, because opam's versioning provides no mechanism to ignore the
+# revision (i.e. we don't have a way to have two revisions of ocaml.5.4.1 but
+# where "ocaml" {= "5.4.1"} would always mean to use the latest revision).
+# It is however useful to know which version of the metadata is installed.
+# This number should be bumped whenever a pertinent change is made.
+x-revision: "4"
 license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 synopsis: "Official release of OCaml 5.2.1"
 maintainer: [
-  "David Allsopp <david@tarides.com>"
+  "David Allsopp <dra27@dra27.uk>"
   "Florian Angeletti <florian.angeletti@inria.fr>"
 ]
 authors: [

--- a/packages/ocaml-variants/ocaml-variants.5.2.1~rc1+options/opam
+++ b/packages/ocaml-variants/ocaml-variants.5.2.1~rc1+options/opam
@@ -1,8 +1,16 @@
 opam-version: "2.0"
+# These packages are part of the infrastructure for maintaining the OCaml
+# compiler dependencies in opam. It's not possible to version the metadata
+# itself, because opam's versioning provides no mechanism to ignore the
+# revision (i.e. we don't have a way to have two revisions of ocaml.5.4.1 but
+# where "ocaml" {= "5.4.1"} would always mean to use the latest revision).
+# It is however useful to know which version of the metadata is installed.
+# This number should be bumped whenever a pertinent change is made.
+x-revision: "3"
 license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 synopsis: "First release candidate of OCaml 5.2.1"
 maintainer: [
-  "David Allsopp <david@tarides.com>"
+  "David Allsopp <dra27@dra27.uk>"
   "Florian Angeletti <florian.angeletti@inria.fr>"
 ]
 authors: [

--- a/packages/ocaml-variants/ocaml-variants.5.2.1~rc1+options/opam
+++ b/packages/ocaml-variants/ocaml-variants.5.2.1~rc1+options/opam
@@ -6,7 +6,7 @@ opam-version: "2.0"
 # where "ocaml" {= "5.4.1"} would always mean to use the latest revision).
 # It is however useful to know which version of the metadata is installed.
 # This number should be bumped whenever a pertinent change is made.
-x-revision: "3"
+x-revision: "4"
 license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 synopsis: "First release candidate of OCaml 5.2.1"
 maintainer: [
@@ -56,10 +56,10 @@ depends: [
   # Port selection (Windows)
   # amd64 mingw-w64 only
   (("arch-x86_64" {os = "win32" & arch = "x86_64"} &
-     "system-mingw" & "mingw-w64-shims" {os-distribution = "cygwin" & build}) |
+     "system-mingw") |
   # i686 mingw-w64 only
    ("arch-x86_32" {os = "win32"} & "ocaml-option-bytecode-only" {os = "win32"} &
-     "system-mingw" & "mingw-w64-shims" {os-distribution = "cygwin" & build}) |
+     "system-mingw") |
   # Non-Windows systems
    "host-system-other" {os != "win32" & post})
 

--- a/packages/ocaml-variants/ocaml-variants.5.2.2+trunk/opam
+++ b/packages/ocaml-variants/ocaml-variants.5.2.2+trunk/opam
@@ -1,8 +1,16 @@
 opam-version: "2.0"
+# These packages are part of the infrastructure for maintaining the OCaml
+# compiler dependencies in opam. It's not possible to version the metadata
+# itself, because opam's versioning provides no mechanism to ignore the
+# revision (i.e. we don't have a way to have two revisions of ocaml.5.4.1 but
+# where "ocaml" {= "5.4.1"} would always mean to use the latest revision).
+# It is however useful to know which version of the metadata is installed.
+# This number should be bumped whenever a pertinent change is made.
+x-revision: "2"
 license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 synopsis: "Latest 5.2 development"
 maintainer: [
-  "David Allsopp <david@tarides.com>"
+  "David Allsopp <dra27@dra27.uk>"
   "Florian Angeletti <florian.angeletti@inria.fr>"
 ]
 authors: [

--- a/packages/ocaml-variants/ocaml-variants.5.2.2+trunk/opam
+++ b/packages/ocaml-variants/ocaml-variants.5.2.2+trunk/opam
@@ -6,7 +6,7 @@ opam-version: "2.0"
 # where "ocaml" {= "5.4.1"} would always mean to use the latest revision).
 # It is however useful to know which version of the metadata is installed.
 # This number should be bumped whenever a pertinent change is made.
-x-revision: "2"
+x-revision: "3"
 license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 synopsis: "Latest 5.2 development"
 maintainer: [
@@ -56,10 +56,10 @@ depends: [
   # Port selection (Windows)
   # amd64 mingw-w64 only
   (("arch-x86_64" {os = "win32" & arch = "x86_64"} &
-     "system-mingw" & "mingw-w64-shims" {os-distribution = "cygwin" & build}) |
+     "system-mingw") |
   # i686 mingw-w64 only
    ("arch-x86_32" {os = "win32"} & "ocaml-option-bytecode-only" {os = "win32"} &
-     "system-mingw" & "mingw-w64-shims" {os-distribution = "cygwin" & build}) |
+     "system-mingw") |
   # Non-Windows systems
    "host-system-other" {os != "win32" & post})
 

--- a/packages/ocaml/ocaml.4.13.0/opam
+++ b/packages/ocaml/ocaml.4.13.0/opam
@@ -6,7 +6,7 @@ opam-version: "2.0"
 # where "ocaml" {= "5.4.1"} would always mean to use the latest revision).
 # It is however useful to know which version of the metadata is installed.
 # This number should be bumped whenever a pertinent change is made.
-x-revision: "6"
+x-revision: "7"
 license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 synopsis: "The OCaml compiler (virtual package)"
 description: """
@@ -18,6 +18,8 @@ depends: [
   "ocaml-base-compiler" {>= "4.13.0~" & < "4.13.1~"} |
   "ocaml-variants" {>= "4.13.0~" & < "4.13.1~"} |
   "ocaml-system" {>= "4.13.0" & < "4.13.1~"}
+  ("ocaml-env-mingw64" {os = "win32"} | "ocaml-env-mingw32" {os = "win32"} |
+   "ocaml-env-msvc64" {os = "win32"} | "ocaml-env-msvc32" {os = "win32"})
 ]
 setenv: [
   [OCAMLTOP_INCLUDE_PATH += "%{toplevel}%"]

--- a/packages/ocaml/ocaml.4.13.0/opam
+++ b/packages/ocaml/ocaml.4.13.0/opam
@@ -1,10 +1,18 @@
 opam-version: "2.0"
+# These packages are part of the infrastructure for maintaining the OCaml
+# compiler dependencies in opam. It's not possible to version the metadata
+# itself, because opam's versioning provides no mechanism to ignore the
+# revision (i.e. we don't have a way to have two revisions of ocaml.5.4.1 but
+# where "ocaml" {= "5.4.1"} would always mean to use the latest revision).
+# It is however useful to know which version of the metadata is installed.
+# This number should be bumped whenever a pertinent change is made.
+x-revision: "6"
 license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 synopsis: "The OCaml compiler (virtual package)"
 description: """
 This package requires a matching implementation of OCaml,
 and polls it to initialise specific variables like `ocaml:native-dynlink`"""
-maintainer: "David Allsopp <david@tarides.com>"
+maintainer: "David Allsopp <dra27@dra27.uk>"
 depends: [
   "ocaml-config" {>= "2"}
   "ocaml-base-compiler" {>= "4.13.0~" & < "4.13.1~"} |

--- a/packages/ocaml/ocaml.4.13.1/opam
+++ b/packages/ocaml/ocaml.4.13.1/opam
@@ -1,10 +1,18 @@
 opam-version: "2.0"
+# These packages are part of the infrastructure for maintaining the OCaml
+# compiler dependencies in opam. It's not possible to version the metadata
+# itself, because opam's versioning provides no mechanism to ignore the
+# revision (i.e. we don't have a way to have two revisions of ocaml.5.4.1 but
+# where "ocaml" {= "5.4.1"} would always mean to use the latest revision).
+# It is however useful to know which version of the metadata is installed.
+# This number should be bumped whenever a pertinent change is made.
+x-revision: "4"
 license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 synopsis: "The OCaml compiler (virtual package)"
 description: """
 This package requires a matching implementation of OCaml,
 and polls it to initialise specific variables like `ocaml:native-dynlink`"""
-maintainer: "David Allsopp <david@tarides.com>"
+maintainer: "David Allsopp <dra27@dra27.uk>"
 depends: [
   "ocaml-config" {>= "2"}
   "ocaml-base-compiler" {>= "4.13.1~" & < "4.13.2~"} |

--- a/packages/ocaml/ocaml.4.13.1/opam
+++ b/packages/ocaml/ocaml.4.13.1/opam
@@ -6,7 +6,7 @@ opam-version: "2.0"
 # where "ocaml" {= "5.4.1"} would always mean to use the latest revision).
 # It is however useful to know which version of the metadata is installed.
 # This number should be bumped whenever a pertinent change is made.
-x-revision: "4"
+x-revision: "5"
 license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 synopsis: "The OCaml compiler (virtual package)"
 description: """
@@ -18,6 +18,8 @@ depends: [
   "ocaml-base-compiler" {>= "4.13.1~" & < "4.13.2~"} |
   "ocaml-variants" {>= "4.13.1~" & < "4.13.2~"} |
   "ocaml-system" {>= "4.13.1" & < "4.13.2~"}
+  ("ocaml-env-mingw64" {os = "win32"} | "ocaml-env-mingw32" {os = "win32"} |
+   "ocaml-env-msvc64" {os = "win32"} | "ocaml-env-msvc32" {os = "win32"})
 ]
 setenv: [
   [OCAMLTOP_INCLUDE_PATH += "%{toplevel}%"]

--- a/packages/ocaml/ocaml.4.13.2/opam
+++ b/packages/ocaml/ocaml.4.13.2/opam
@@ -1,10 +1,18 @@
 opam-version: "2.0"
+# These packages are part of the infrastructure for maintaining the OCaml
+# compiler dependencies in opam. It's not possible to version the metadata
+# itself, because opam's versioning provides no mechanism to ignore the
+# revision (i.e. we don't have a way to have two revisions of ocaml.5.4.1 but
+# where "ocaml" {= "5.4.1"} would always mean to use the latest revision).
+# It is however useful to know which version of the metadata is installed.
+# This number should be bumped whenever a pertinent change is made.
+x-revision: "5"
 license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 synopsis: "The OCaml compiler (virtual package)"
 description: """
 This package requires a matching implementation of OCaml,
 and polls it to initialise specific variables like `ocaml:native-dynlink`"""
-maintainer: "David Allsopp <david@tarides.com>"
+maintainer: "David Allsopp <dra27@dra27.uk>"
 depends: [
   "ocaml-config" {>= "2"}
   "ocaml-base-compiler" {>= "4.13.2~" & < "4.13.3~"} |

--- a/packages/ocaml/ocaml.4.13.2/opam
+++ b/packages/ocaml/ocaml.4.13.2/opam
@@ -6,7 +6,7 @@ opam-version: "2.0"
 # where "ocaml" {= "5.4.1"} would always mean to use the latest revision).
 # It is however useful to know which version of the metadata is installed.
 # This number should be bumped whenever a pertinent change is made.
-x-revision: "5"
+x-revision: "6"
 license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 synopsis: "The OCaml compiler (virtual package)"
 description: """
@@ -18,6 +18,8 @@ depends: [
   "ocaml-base-compiler" {>= "4.13.2~" & < "4.13.3~"} |
   "ocaml-variants" {>= "4.13.2~" & < "4.13.3~"} |
   "ocaml-system" {>= "4.13.2" & < "4.13.3~"}
+  ("ocaml-env-mingw64" {os = "win32"} | "ocaml-env-mingw32" {os = "win32"} |
+   "ocaml-env-msvc64" {os = "win32"} | "ocaml-env-msvc32" {os = "win32"})
 ]
 setenv: [
   [OCAMLTOP_INCLUDE_PATH += "%{toplevel}%"]

--- a/packages/ocaml/ocaml.4.14.0/opam
+++ b/packages/ocaml/ocaml.4.14.0/opam
@@ -6,7 +6,7 @@ opam-version: "2.0"
 # where "ocaml" {= "5.4.1"} would always mean to use the latest revision).
 # It is however useful to know which version of the metadata is installed.
 # This number should be bumped whenever a pertinent change is made.
-x-revision: "6"
+x-revision: "7"
 license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 synopsis: "The OCaml compiler (virtual package)"
 description: """
@@ -19,6 +19,8 @@ depends: [
   "ocaml-variants" {>= "4.14.0~" & < "4.14.1~"} |
   "ocaml-system" {>= "4.14.0" & < "4.14.1~"} |
   "dkml-base-compiler" {>= "4.14.0~" & < "4.14.1~"}
+  ("ocaml-env-mingw64" {os = "win32"} | "ocaml-env-mingw32" {os = "win32"} |
+   "ocaml-env-msvc64" {os = "win32"} | "ocaml-env-msvc32" {os = "win32"})
 ]
 setenv: [
   [OCAMLTOP_INCLUDE_PATH += "%{toplevel}%"]

--- a/packages/ocaml/ocaml.4.14.0/opam
+++ b/packages/ocaml/ocaml.4.14.0/opam
@@ -1,10 +1,18 @@
 opam-version: "2.0"
+# These packages are part of the infrastructure for maintaining the OCaml
+# compiler dependencies in opam. It's not possible to version the metadata
+# itself, because opam's versioning provides no mechanism to ignore the
+# revision (i.e. we don't have a way to have two revisions of ocaml.5.4.1 but
+# where "ocaml" {= "5.4.1"} would always mean to use the latest revision).
+# It is however useful to know which version of the metadata is installed.
+# This number should be bumped whenever a pertinent change is made.
+x-revision: "6"
 license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 synopsis: "The OCaml compiler (virtual package)"
 description: """
 This package requires a matching implementation of OCaml,
 and polls it to initialise specific variables like `ocaml:native-dynlink`"""
-maintainer: "David Allsopp <david@tarides.com>"
+maintainer: "David Allsopp <dra27@dra27.uk>"
 depends: [
   "ocaml-config" {>= "2"}
   "ocaml-base-compiler" {>= "4.14.0~" & < "4.14.1~"} |

--- a/packages/ocaml/ocaml.4.14.1/opam
+++ b/packages/ocaml/ocaml.4.14.1/opam
@@ -6,7 +6,7 @@ opam-version: "2.0"
 # where "ocaml" {= "5.4.1"} would always mean to use the latest revision).
 # It is however useful to know which version of the metadata is installed.
 # This number should be bumped whenever a pertinent change is made.
-x-revision: "5"
+x-revision: "6"
 license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 synopsis: "The OCaml compiler (virtual package)"
 description: """
@@ -18,6 +18,8 @@ depends: [
   "ocaml-base-compiler" {>= "4.14.1~" & < "4.14.2~"} |
   "ocaml-variants" {>= "4.14.1~" & < "4.14.2~"} |
   "ocaml-system" {>= "4.14.1" & < "4.14.2~"}
+  ("ocaml-env-mingw64" {os = "win32"} | "ocaml-env-mingw32" {os = "win32"} |
+   "ocaml-env-msvc64" {os = "win32"} | "ocaml-env-msvc32" {os = "win32"})
 ]
 setenv: [
   [OCAMLTOP_INCLUDE_PATH += "%{toplevel}%"]

--- a/packages/ocaml/ocaml.4.14.1/opam
+++ b/packages/ocaml/ocaml.4.14.1/opam
@@ -1,10 +1,18 @@
 opam-version: "2.0"
+# These packages are part of the infrastructure for maintaining the OCaml
+# compiler dependencies in opam. It's not possible to version the metadata
+# itself, because opam's versioning provides no mechanism to ignore the
+# revision (i.e. we don't have a way to have two revisions of ocaml.5.4.1 but
+# where "ocaml" {= "5.4.1"} would always mean to use the latest revision).
+# It is however useful to know which version of the metadata is installed.
+# This number should be bumped whenever a pertinent change is made.
+x-revision: "5"
 license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 synopsis: "The OCaml compiler (virtual package)"
 description: """
 This package requires a matching implementation of OCaml,
 and polls it to initialise specific variables like `ocaml:native-dynlink`"""
-maintainer: "David Allsopp <david@tarides.com>"
+maintainer: "David Allsopp <dra27@dra27.uk>"
 depends: [
   "ocaml-config" {>= "2"}
   "ocaml-base-compiler" {>= "4.14.1~" & < "4.14.2~"} |

--- a/packages/ocaml/ocaml.4.14.2/opam
+++ b/packages/ocaml/ocaml.4.14.2/opam
@@ -6,7 +6,7 @@ opam-version: "2.0"
 # where "ocaml" {= "5.4.1"} would always mean to use the latest revision).
 # It is however useful to know which version of the metadata is installed.
 # This number should be bumped whenever a pertinent change is made.
-x-revision: "4"
+x-revision: "5"
 license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 synopsis: "The OCaml compiler (virtual package)"
 description: """
@@ -19,6 +19,8 @@ depends: [
   "ocaml-variants" {>= "4.14.2~" & < "4.14.3~"} |
   "ocaml-system" {>= "4.14.2" & < "4.14.3~"} |
   "dkml-base-compiler" {>= "4.14.2~" & < "4.14.3~"}
+  ("ocaml-env-mingw64" {os = "win32"} | "ocaml-env-mingw32" {os = "win32"} |
+   "ocaml-env-msvc64" {os = "win32"} | "ocaml-env-msvc32" {os = "win32"})
 ]
 setenv: [
   [OCAMLTOP_INCLUDE_PATH += "%{toplevel}%"]

--- a/packages/ocaml/ocaml.4.14.2/opam
+++ b/packages/ocaml/ocaml.4.14.2/opam
@@ -1,10 +1,18 @@
 opam-version: "2.0"
+# These packages are part of the infrastructure for maintaining the OCaml
+# compiler dependencies in opam. It's not possible to version the metadata
+# itself, because opam's versioning provides no mechanism to ignore the
+# revision (i.e. we don't have a way to have two revisions of ocaml.5.4.1 but
+# where "ocaml" {= "5.4.1"} would always mean to use the latest revision).
+# It is however useful to know which version of the metadata is installed.
+# This number should be bumped whenever a pertinent change is made.
+x-revision: "4"
 license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 synopsis: "The OCaml compiler (virtual package)"
 description: """
 This package requires a matching implementation of OCaml,
 and polls it to initialise specific variables like `ocaml:native-dynlink`"""
-maintainer: "David Allsopp <david@tarides.com>"
+maintainer: "David Allsopp <dra27@dra27.uk>"
 depends: [
   "ocaml-config" {>= "2"}
   "ocaml-base-compiler" {>= "4.14.2~" & < "4.14.3~"} |

--- a/packages/ocaml/ocaml.4.14.3/opam
+++ b/packages/ocaml/ocaml.4.14.3/opam
@@ -1,10 +1,18 @@
 opam-version: "2.0"
+# These packages are part of the infrastructure for maintaining the OCaml
+# compiler dependencies in opam. It's not possible to version the metadata
+# itself, because opam's versioning provides no mechanism to ignore the
+# revision (i.e. we don't have a way to have two revisions of ocaml.5.4.1 but
+# where "ocaml" {= "5.4.1"} would always mean to use the latest revision).
+# It is however useful to know which version of the metadata is installed.
+# This number should be bumped whenever a pertinent change is made.
+x-revision: "5"
 license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 synopsis: "The OCaml compiler (virtual package)"
 description: """
 This package requires a matching implementation of OCaml,
 and polls it to initialise specific variables like `ocaml:native-dynlink`"""
-maintainer: "David Allsopp <david@tarides.com>"
+maintainer: "David Allsopp <dra27@dra27.uk>"
 depends: [
   "ocaml-config" {>= "2"}
   "ocaml-base-compiler" {>= "4.14.3~" & < "4.14.4~"} |

--- a/packages/ocaml/ocaml.4.14.3/opam
+++ b/packages/ocaml/ocaml.4.14.3/opam
@@ -6,7 +6,7 @@ opam-version: "2.0"
 # where "ocaml" {= "5.4.1"} would always mean to use the latest revision).
 # It is however useful to know which version of the metadata is installed.
 # This number should be bumped whenever a pertinent change is made.
-x-revision: "5"
+x-revision: "6"
 license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 synopsis: "The OCaml compiler (virtual package)"
 description: """
@@ -19,6 +19,8 @@ depends: [
   "ocaml-variants" {>= "4.14.3~" & < "4.14.4~"} |
   "ocaml-system" {>= "4.14.3" & < "4.14.4~"} |
   "dkml-base-compiler" {>= "4.14.3~" & < "4.14.4~"}
+  ("ocaml-env-mingw64" {os = "win32"} | "ocaml-env-mingw32" {os = "win32"} |
+   "ocaml-env-msvc64" {os = "win32"} | "ocaml-env-msvc32" {os = "win32"})
 ]
 setenv: [
   [OCAMLTOP_INCLUDE_PATH += "%{toplevel}%"]

--- a/packages/ocaml/ocaml.4.14.4/opam
+++ b/packages/ocaml/ocaml.4.14.4/opam
@@ -1,10 +1,18 @@
 opam-version: "2.0"
+# These packages are part of the infrastructure for maintaining the OCaml
+# compiler dependencies in opam. It's not possible to version the metadata
+# itself, because opam's versioning provides no mechanism to ignore the
+# revision (i.e. we don't have a way to have two revisions of ocaml.5.4.1 but
+# where "ocaml" {= "5.4.1"} would always mean to use the latest revision).
+# It is however useful to know which version of the metadata is installed.
+# This number should be bumped whenever a pertinent change is made.
+x-revision: "1"
 license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 synopsis: "The OCaml compiler (virtual package)"
 description: """
 This package requires a matching implementation of OCaml,
 and polls it to initialise specific variables like `ocaml:native-dynlink`"""
-maintainer: "David Allsopp <david@tarides.com>"
+maintainer: "David Allsopp <dra27@dra27.uk>"
 depends: [
   "ocaml-config" {>= "2"}
   "ocaml-base-compiler" {>= "4.14.4~" & < "4.14.5~"} |

--- a/packages/ocaml/ocaml.4.14.4/opam
+++ b/packages/ocaml/ocaml.4.14.4/opam
@@ -6,7 +6,7 @@ opam-version: "2.0"
 # where "ocaml" {= "5.4.1"} would always mean to use the latest revision).
 # It is however useful to know which version of the metadata is installed.
 # This number should be bumped whenever a pertinent change is made.
-x-revision: "1"
+x-revision: "2"
 license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 synopsis: "The OCaml compiler (virtual package)"
 description: """
@@ -19,6 +19,8 @@ depends: [
   "ocaml-variants" {>= "4.14.4~" & < "4.14.5~"} |
   "ocaml-system" {>= "4.14.4" & < "4.14.5~"} |
   "dkml-base-compiler" {>= "4.14.4~" & < "4.14.5~"}
+  ("ocaml-env-mingw64" {os = "win32"} | "ocaml-env-mingw32" {os = "win32"} |
+   "ocaml-env-msvc64" {os = "win32"} | "ocaml-env-msvc32" {os = "win32"})
 ]
 setenv: [
   [OCAMLTOP_INCLUDE_PATH += "%{toplevel}%"]

--- a/packages/ocaml/ocaml.5.0.0/opam
+++ b/packages/ocaml/ocaml.5.0.0/opam
@@ -6,7 +6,7 @@ opam-version: "2.0"
 # where "ocaml" {= "5.4.1"} would always mean to use the latest revision).
 # It is however useful to know which version of the metadata is installed.
 # This number should be bumped whenever a pertinent change is made.
-x-revision: "8"
+x-revision: "9"
 license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 synopsis: "The OCaml compiler (virtual package)"
 description: """
@@ -18,6 +18,7 @@ depends: [
   "ocaml-base-compiler" {>= "5.0.0~" & < "5.0.1~" } |
   "ocaml-variants" {>= "5.0.0~" & < "5.0.1~"} |
   "ocaml-system" {>= "5.0.0" & < "5.0.1~"}
+  ("ocaml-env-mingw64" {os = "win32"} | "ocaml-env-mingw32" {os = "win32"})
 ]
 setenv: [
   [OCAMLTOP_INCLUDE_PATH += "%{toplevel}%"]

--- a/packages/ocaml/ocaml.5.0.0/opam
+++ b/packages/ocaml/ocaml.5.0.0/opam
@@ -1,10 +1,18 @@
 opam-version: "2.0"
+# These packages are part of the infrastructure for maintaining the OCaml
+# compiler dependencies in opam. It's not possible to version the metadata
+# itself, because opam's versioning provides no mechanism to ignore the
+# revision (i.e. we don't have a way to have two revisions of ocaml.5.4.1 but
+# where "ocaml" {= "5.4.1"} would always mean to use the latest revision).
+# It is however useful to know which version of the metadata is installed.
+# This number should be bumped whenever a pertinent change is made.
+x-revision: "8"
 license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 synopsis: "The OCaml compiler (virtual package)"
 description: """
 This package requires a matching implementation of OCaml,
 and polls it to initialise specific variables like `ocaml:native-dynlink`"""
-maintainer: "David Allsopp <david@tarides.com>"
+maintainer: "David Allsopp <dra27@dra27.uk>"
 depends: [
   "ocaml-config" {>= "3"}
   "ocaml-base-compiler" {>= "5.0.0~" & < "5.0.1~" } |

--- a/packages/ocaml/ocaml.5.0.1/opam
+++ b/packages/ocaml/ocaml.5.0.1/opam
@@ -6,7 +6,7 @@ opam-version: "2.0"
 # where "ocaml" {= "5.4.1"} would always mean to use the latest revision).
 # It is however useful to know which version of the metadata is installed.
 # This number should be bumped whenever a pertinent change is made.
-x-revision: "5"
+x-revision: "6"
 license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 synopsis: "The OCaml compiler (virtual package)"
 description: """
@@ -19,6 +19,7 @@ depends: [
   "ocaml-variants" {>= "5.0.1~" & < "5.0.2~"} |
   "ocaml-system" {>= "5.0.1" & < "5.0.2~"} |
   "dkml-base-compiler" {>= "5.0.1~" & < "5.0.2~"}
+  ("ocaml-env-mingw64" {os = "win32"} | "ocaml-env-mingw32" {os = "win32"})
 ]
 setenv: [
   [OCAMLTOP_INCLUDE_PATH += "%{toplevel}%"]

--- a/packages/ocaml/ocaml.5.0.1/opam
+++ b/packages/ocaml/ocaml.5.0.1/opam
@@ -1,10 +1,18 @@
 opam-version: "2.0"
+# These packages are part of the infrastructure for maintaining the OCaml
+# compiler dependencies in opam. It's not possible to version the metadata
+# itself, because opam's versioning provides no mechanism to ignore the
+# revision (i.e. we don't have a way to have two revisions of ocaml.5.4.1 but
+# where "ocaml" {= "5.4.1"} would always mean to use the latest revision).
+# It is however useful to know which version of the metadata is installed.
+# This number should be bumped whenever a pertinent change is made.
+x-revision: "5"
 license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 synopsis: "The OCaml compiler (virtual package)"
 description: """
 This package requires a matching implementation of OCaml,
 and polls it to initialise specific variables like `ocaml:native-dynlink`"""
-maintainer: "David Allsopp <david@tarides.com>"
+maintainer: "David Allsopp <dra27@dra27.uk>"
 depends: [
   "ocaml-config" {>= "3"}
   "ocaml-base-compiler" {>= "5.0.1~" & < "5.0.2~" } |

--- a/packages/ocaml/ocaml.5.1.0/opam
+++ b/packages/ocaml/ocaml.5.1.0/opam
@@ -6,7 +6,7 @@ opam-version: "2.0"
 # where "ocaml" {= "5.4.1"} would always mean to use the latest revision).
 # It is however useful to know which version of the metadata is installed.
 # This number should be bumped whenever a pertinent change is made.
-x-revision: "7"
+x-revision: "8"
 license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 synopsis: "The OCaml compiler (virtual package)"
 description: """
@@ -19,6 +19,7 @@ depends: [
   "ocaml-variants" {>= "5.1.0~" & < "5.1.1~"} |
   "ocaml-system" {>= "5.1.0~" & < "5.1.1~"} |
   "dkml-base-compiler" {>= "5.1.0~" & < "5.1.1~"}
+  ("ocaml-env-mingw64" {os = "win32"} | "ocaml-env-mingw32" {os = "win32"})
 ]
 setenv: [
   [OCAMLTOP_INCLUDE_PATH += "%{toplevel}%"]

--- a/packages/ocaml/ocaml.5.1.0/opam
+++ b/packages/ocaml/ocaml.5.1.0/opam
@@ -1,10 +1,18 @@
 opam-version: "2.0"
+# These packages are part of the infrastructure for maintaining the OCaml
+# compiler dependencies in opam. It's not possible to version the metadata
+# itself, because opam's versioning provides no mechanism to ignore the
+# revision (i.e. we don't have a way to have two revisions of ocaml.5.4.1 but
+# where "ocaml" {= "5.4.1"} would always mean to use the latest revision).
+# It is however useful to know which version of the metadata is installed.
+# This number should be bumped whenever a pertinent change is made.
+x-revision: "7"
 license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 synopsis: "The OCaml compiler (virtual package)"
 description: """
 This package requires a matching implementation of OCaml,
 and polls it to initialise specific variables like `ocaml:native-dynlink`"""
-maintainer: "David Allsopp <david@tarides.com>"
+maintainer: "David Allsopp <dra27@dra27.uk>"
 depends: [
   "ocaml-config" {>= "3"}
   "ocaml-base-compiler" {>= "5.1.0~" & < "5.1.1~" } |

--- a/packages/ocaml/ocaml.5.1.1/opam
+++ b/packages/ocaml/ocaml.5.1.1/opam
@@ -1,10 +1,18 @@
 opam-version: "2.0"
+# These packages are part of the infrastructure for maintaining the OCaml
+# compiler dependencies in opam. It's not possible to version the metadata
+# itself, because opam's versioning provides no mechanism to ignore the
+# revision (i.e. we don't have a way to have two revisions of ocaml.5.4.1 but
+# where "ocaml" {= "5.4.1"} would always mean to use the latest revision).
+# It is however useful to know which version of the metadata is installed.
+# This number should be bumped whenever a pertinent change is made.
+x-revision: "3"
 license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 synopsis: "The OCaml compiler (virtual package)"
 description: """
 This package requires a matching implementation of OCaml,
 and polls it to initialise specific variables like `ocaml:native-dynlink`"""
-maintainer: "David Allsopp <david@tarides.com>"
+maintainer: "David Allsopp <dra27@dra27.uk>"
 depends: [
   "ocaml-config" {>= "3"}
   "ocaml-base-compiler" {>= "5.1.1~" & < "5.1.2~" } |

--- a/packages/ocaml/ocaml.5.1.1/opam
+++ b/packages/ocaml/ocaml.5.1.1/opam
@@ -6,7 +6,7 @@ opam-version: "2.0"
 # where "ocaml" {= "5.4.1"} would always mean to use the latest revision).
 # It is however useful to know which version of the metadata is installed.
 # This number should be bumped whenever a pertinent change is made.
-x-revision: "3"
+x-revision: "4"
 license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 synopsis: "The OCaml compiler (virtual package)"
 description: """
@@ -19,6 +19,7 @@ depends: [
   "ocaml-variants" {>= "5.1.1~" & < "5.1.2~"} |
   "ocaml-system" {>= "5.1.1~" & < "5.1.2~"} |
   "dkml-base-compiler" {>= "5.1.1~" & < "5.1.2~"}
+  ("ocaml-env-mingw64" {os = "win32"} | "ocaml-env-mingw32" {os = "win32"})
 ]
 setenv: [
   [OCAMLTOP_INCLUDE_PATH += "%{toplevel}%"]

--- a/packages/ocaml/ocaml.5.1.2/opam
+++ b/packages/ocaml/ocaml.5.1.2/opam
@@ -6,7 +6,7 @@ opam-version: "2.0"
 # where "ocaml" {= "5.4.1"} would always mean to use the latest revision).
 # It is however useful to know which version of the metadata is installed.
 # This number should be bumped whenever a pertinent change is made.
-x-revision: "4"
+x-revision: "5"
 license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 synopsis: "The OCaml compiler (virtual package)"
 description: """
@@ -19,6 +19,7 @@ depends: [
   "ocaml-variants" {>= "5.1.2~" & < "5.1.3~"} |
   "ocaml-system" {>= "5.1.2~" & < "5.1.3~"} |
   "dkml-base-compiler" {>= "5.1.2~" & < "5.1.3~"}
+  ("ocaml-env-mingw64" {os = "win32"} | "ocaml-env-mingw32" {os = "win32"})
 ]
 setenv: [
   [OCAMLTOP_INCLUDE_PATH += "%{toplevel}%"]

--- a/packages/ocaml/ocaml.5.1.2/opam
+++ b/packages/ocaml/ocaml.5.1.2/opam
@@ -1,10 +1,18 @@
 opam-version: "2.0"
+# These packages are part of the infrastructure for maintaining the OCaml
+# compiler dependencies in opam. It's not possible to version the metadata
+# itself, because opam's versioning provides no mechanism to ignore the
+# revision (i.e. we don't have a way to have two revisions of ocaml.5.4.1 but
+# where "ocaml" {= "5.4.1"} would always mean to use the latest revision).
+# It is however useful to know which version of the metadata is installed.
+# This number should be bumped whenever a pertinent change is made.
+x-revision: "4"
 license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 synopsis: "The OCaml compiler (virtual package)"
 description: """
 This package requires a matching implementation of OCaml,
 and polls it to initialise specific variables like `ocaml:native-dynlink`"""
-maintainer: "David Allsopp <david@tarides.com>"
+maintainer: "David Allsopp <dra27@dra27.uk>"
 depends: [
   "ocaml-config" {>= "3"}
   "ocaml-base-compiler" {>= "5.1.2~" & < "5.1.3~" } |

--- a/packages/ocaml/ocaml.5.2.0/opam
+++ b/packages/ocaml/ocaml.5.2.0/opam
@@ -6,7 +6,7 @@ opam-version: "2.0"
 # where "ocaml" {= "5.4.1"} would always mean to use the latest revision).
 # It is however useful to know which version of the metadata is installed.
 # This number should be bumped whenever a pertinent change is made.
-x-revision: "4"
+x-revision: "5"
 license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 synopsis: "The OCaml compiler (virtual package)"
 description: """
@@ -19,6 +19,7 @@ depends: [
   "ocaml-variants" {>= "5.2.0~" & < "5.2.1~"} |
   "ocaml-system" {>= "5.2.0~" & < "5.2.1~"} |
   "dkml-base-compiler" {>= "5.2.0~" & < "5.2.1~"}
+  ("ocaml-env-mingw64" {os = "win32"} | "ocaml-env-mingw32" {os = "win32"})
 ]
 setenv: [
   [OCAMLTOP_INCLUDE_PATH += "%{toplevel}%"]

--- a/packages/ocaml/ocaml.5.2.0/opam
+++ b/packages/ocaml/ocaml.5.2.0/opam
@@ -1,10 +1,18 @@
 opam-version: "2.0"
+# These packages are part of the infrastructure for maintaining the OCaml
+# compiler dependencies in opam. It's not possible to version the metadata
+# itself, because opam's versioning provides no mechanism to ignore the
+# revision (i.e. we don't have a way to have two revisions of ocaml.5.4.1 but
+# where "ocaml" {= "5.4.1"} would always mean to use the latest revision).
+# It is however useful to know which version of the metadata is installed.
+# This number should be bumped whenever a pertinent change is made.
+x-revision: "4"
 license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 synopsis: "The OCaml compiler (virtual package)"
 description: """
 This package requires a matching implementation of OCaml,
 and polls it to initialise specific variables like `ocaml:native-dynlink`"""
-maintainer: "David Allsopp <david@tarides.com>"
+maintainer: "David Allsopp <dra27@dra27.uk>"
 depends: [
   "ocaml-config" {>= "3"}
   "ocaml-base-compiler" {>= "5.2.0~" & < "5.2.1~" } |

--- a/packages/ocaml/ocaml.5.2.1/opam
+++ b/packages/ocaml/ocaml.5.2.1/opam
@@ -6,7 +6,7 @@ opam-version: "2.0"
 # where "ocaml" {= "5.4.1"} would always mean to use the latest revision).
 # It is however useful to know which version of the metadata is installed.
 # This number should be bumped whenever a pertinent change is made.
-x-revision: "3"
+x-revision: "4"
 license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 synopsis: "The OCaml compiler (virtual package)"
 description: """
@@ -19,6 +19,7 @@ depends: [
   "ocaml-variants" {>= "5.2.1~" & < "5.2.2~"} |
   "ocaml-system" {>= "5.2.1~" & < "5.2.2~"} |
   "dkml-base-compiler" {>= "5.2.1~" & < "5.2.2~"}
+  ("ocaml-env-mingw64" {os = "win32"} | "ocaml-env-mingw32" {os = "win32"})
 ]
 setenv: [
   [OCAMLTOP_INCLUDE_PATH += "%{toplevel}%"]

--- a/packages/ocaml/ocaml.5.2.1/opam
+++ b/packages/ocaml/ocaml.5.2.1/opam
@@ -1,10 +1,18 @@
 opam-version: "2.0"
+# These packages are part of the infrastructure for maintaining the OCaml
+# compiler dependencies in opam. It's not possible to version the metadata
+# itself, because opam's versioning provides no mechanism to ignore the
+# revision (i.e. we don't have a way to have two revisions of ocaml.5.4.1 but
+# where "ocaml" {= "5.4.1"} would always mean to use the latest revision).
+# It is however useful to know which version of the metadata is installed.
+# This number should be bumped whenever a pertinent change is made.
+x-revision: "3"
 license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 synopsis: "The OCaml compiler (virtual package)"
 description: """
 This package requires a matching implementation of OCaml,
 and polls it to initialise specific variables like `ocaml:native-dynlink`"""
-maintainer: "David Allsopp <david@tarides.com>"
+maintainer: "David Allsopp <dra27@dra27.uk>"
 depends: [
   "ocaml-config" {>= "3"}
   "ocaml-base-compiler" {>= "5.2.1~" & < "5.2.2~" } |

--- a/packages/ocaml/ocaml.5.2.2/opam
+++ b/packages/ocaml/ocaml.5.2.2/opam
@@ -1,10 +1,18 @@
 opam-version: "2.0"
+# These packages are part of the infrastructure for maintaining the OCaml
+# compiler dependencies in opam. It's not possible to version the metadata
+# itself, because opam's versioning provides no mechanism to ignore the
+# revision (i.e. we don't have a way to have two revisions of ocaml.5.4.1 but
+# where "ocaml" {= "5.4.1"} would always mean to use the latest revision).
+# It is however useful to know which version of the metadata is installed.
+# This number should be bumped whenever a pertinent change is made.
+x-revision: "4"
 license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 synopsis: "The OCaml compiler (virtual package)"
 description: """
 This package requires a matching implementation of OCaml,
 and polls it to initialise specific variables like `ocaml:native-dynlink`"""
-maintainer: "David Allsopp <david@tarides.com>"
+maintainer: "David Allsopp <dra27@dra27.uk>"
 depends: [
   "ocaml-config" {>= "3"}
   "ocaml-base-compiler" {>= "5.2.2~" & < "5.2.3~" } |

--- a/packages/ocaml/ocaml.5.2.2/opam
+++ b/packages/ocaml/ocaml.5.2.2/opam
@@ -6,7 +6,7 @@ opam-version: "2.0"
 # where "ocaml" {= "5.4.1"} would always mean to use the latest revision).
 # It is however useful to know which version of the metadata is installed.
 # This number should be bumped whenever a pertinent change is made.
-x-revision: "4"
+x-revision: "5"
 license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 synopsis: "The OCaml compiler (virtual package)"
 description: """
@@ -19,6 +19,7 @@ depends: [
   "ocaml-variants" {>= "5.2.2~" & < "5.2.3~"} |
   "ocaml-system" {>= "5.2.2~" & < "5.2.3~"} |
   "dkml-base-compiler" {>= "5.2.2~" & < "5.2.3~"}
+  ("ocaml-env-mingw64" {os = "win32"} | "ocaml-env-mingw32" {os = "win32"})
 ]
 setenv: [
   [OCAMLTOP_INCLUDE_PATH += "%{toplevel}%"]

--- a/packages/ocaml/ocaml.5.3.0/opam
+++ b/packages/ocaml/ocaml.5.3.0/opam
@@ -6,7 +6,7 @@ opam-version: "2.0"
 # where "ocaml" {= "5.4.1"} would always mean to use the latest revision).
 # It is however useful to know which version of the metadata is installed.
 # This number should be bumped whenever a pertinent change is made.
-x-revision: "3"
+x-revision: "4"
 license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 synopsis: "The OCaml compiler (virtual package)"
 description: """
@@ -30,6 +30,8 @@ depends: [
   "ocaml-variants" {>= "5.3.0~" & < "5.3.1~"} |
   "ocaml-system" {>= "5.3.0~" & < "5.3.1~"} |
   "dkml-base-compiler" {>= "5.3.0~" & < "5.3.1~"}
+  ("ocaml-env-mingw64" {os = "win32"} | "ocaml-env-mingw32" {os = "win32"} |
+   "ocaml-env-msvc64" {os = "win32"} | "ocaml-env-msvc32" {os = "win32"})
 ]
 flags: conf
 setenv: [

--- a/packages/ocaml/ocaml.5.3.0/opam
+++ b/packages/ocaml/ocaml.5.3.0/opam
@@ -1,10 +1,18 @@
 opam-version: "2.0"
+# These packages are part of the infrastructure for maintaining the OCaml
+# compiler dependencies in opam. It's not possible to version the metadata
+# itself, because opam's versioning provides no mechanism to ignore the
+# revision (i.e. we don't have a way to have two revisions of ocaml.5.4.1 but
+# where "ocaml" {= "5.4.1"} would always mean to use the latest revision).
+# It is however useful to know which version of the metadata is installed.
+# This number should be bumped whenever a pertinent change is made.
+x-revision: "3"
 license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 synopsis: "The OCaml compiler (virtual package)"
 description: """
 This package requires a matching implementation of OCaml,
 and polls it to initialise specific variables like `ocaml:native-dynlink`"""
-maintainer: "David Allsopp <david@tarides.com>"
+maintainer: "David Allsopp <dra27@dra27.uk>"
 authors: [
   "Xavier Leroy"
   "Damien Doligez"

--- a/packages/ocaml/ocaml.5.3.1/opam
+++ b/packages/ocaml/ocaml.5.3.1/opam
@@ -1,10 +1,18 @@
 opam-version: "2.0"
+# These packages are part of the infrastructure for maintaining the OCaml
+# compiler dependencies in opam. It's not possible to version the metadata
+# itself, because opam's versioning provides no mechanism to ignore the
+# revision (i.e. we don't have a way to have two revisions of ocaml.5.4.1 but
+# where "ocaml" {= "5.4.1"} would always mean to use the latest revision).
+# It is however useful to know which version of the metadata is installed.
+# This number should be bumped whenever a pertinent change is made.
+x-revision: "2"
 license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 synopsis: "The OCaml compiler (virtual package)"
 description: """
 This package requires a matching implementation of OCaml,
 and polls it to initialise specific variables like `ocaml:native-dynlink`"""
-maintainer: "David Allsopp <david@tarides.com>"
+maintainer: "David Allsopp <dra27@dra27.uk>"
 authors: [
   "Xavier Leroy"
   "Damien Doligez"

--- a/packages/ocaml/ocaml.5.3.1/opam
+++ b/packages/ocaml/ocaml.5.3.1/opam
@@ -6,7 +6,7 @@ opam-version: "2.0"
 # where "ocaml" {= "5.4.1"} would always mean to use the latest revision).
 # It is however useful to know which version of the metadata is installed.
 # This number should be bumped whenever a pertinent change is made.
-x-revision: "2"
+x-revision: "3"
 license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 synopsis: "The OCaml compiler (virtual package)"
 description: """
@@ -30,6 +30,8 @@ depends: [
   "ocaml-variants" {>= "5.3.1~" & < "5.3.2~"} |
   "ocaml-system" {>= "5.3.1~" & < "5.3.2~"} |
   "dkml-base-compiler" {>= "5.3.1~" & < "5.3.2~"}
+  ("ocaml-env-mingw64" {os = "win32"} | "ocaml-env-mingw32" {os = "win32"} |
+   "ocaml-env-msvc64" {os = "win32"} | "ocaml-env-msvc32" {os = "win32"})
 ]
 flags: [conf avoid-version]
 setenv: [

--- a/packages/ocaml/ocaml.5.4.0/opam
+++ b/packages/ocaml/ocaml.5.4.0/opam
@@ -6,7 +6,7 @@ opam-version: "2.0"
 # where "ocaml" {= "5.4.1"} would always mean to use the latest revision).
 # It is however useful to know which version of the metadata is installed.
 # This number should be bumped whenever a pertinent change is made.
-x-revision: "4"
+x-revision: "5"
 license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 synopsis: "The OCaml compiler (virtual package)"
 description: """
@@ -30,6 +30,8 @@ depends: [
   "ocaml-variants" {>= "5.4.0~" & < "5.4.1~"} |
   "ocaml-system" {>= "5.4.0~" & < "5.4.1~"} |
   "dkml-base-compiler" {>= "5.4.0~" & < "5.4.1~"}
+  ("ocaml-env-mingw64" {os = "win32"} | "ocaml-env-mingw32" {os = "win32"} |
+   "ocaml-env-msvc64" {os = "win32"} | "ocaml-env-msvc32" {os = "win32"})
 ]
 flags: [conf]
 setenv: [

--- a/packages/ocaml/ocaml.5.4.0/opam
+++ b/packages/ocaml/ocaml.5.4.0/opam
@@ -1,10 +1,18 @@
 opam-version: "2.0"
+# These packages are part of the infrastructure for maintaining the OCaml
+# compiler dependencies in opam. It's not possible to version the metadata
+# itself, because opam's versioning provides no mechanism to ignore the
+# revision (i.e. we don't have a way to have two revisions of ocaml.5.4.1 but
+# where "ocaml" {= "5.4.1"} would always mean to use the latest revision).
+# It is however useful to know which version of the metadata is installed.
+# This number should be bumped whenever a pertinent change is made.
+x-revision: "4"
 license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 synopsis: "The OCaml compiler (virtual package)"
 description: """
 This package requires a matching implementation of OCaml,
 and polls it to initialise specific variables like `ocaml:native-dynlink`"""
-maintainer: "David Allsopp <david@tarides.com>"
+maintainer: "David Allsopp <dra27@dra27.uk>"
 authors: [
   "Xavier Leroy"
   "Damien Doligez"

--- a/packages/ocaml/ocaml.5.4.1/opam
+++ b/packages/ocaml/ocaml.5.4.1/opam
@@ -6,7 +6,7 @@ opam-version: "2.0"
 # where "ocaml" {= "5.4.1"} would always mean to use the latest revision).
 # It is however useful to know which version of the metadata is installed.
 # This number should be bumped whenever a pertinent change is made.
-x-revision: "3"
+x-revision: "4"
 license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 synopsis: "The OCaml compiler (virtual package)"
 description: """
@@ -30,6 +30,8 @@ depends: [
   "ocaml-variants" {>= "5.4.1~" & < "5.4.2~"} |
   "ocaml-system" {>= "5.4.1~" & < "5.4.2~"} |
   "dkml-base-compiler" {>= "5.4.1~" & < "5.4.2~"}
+  ("ocaml-env-mingw64" {os = "win32"} | "ocaml-env-mingw32" {os = "win32"} |
+   "ocaml-env-msvc64" {os = "win32"} | "ocaml-env-msvc32" {os = "win32"})
 ]
 flags: conf
 setenv: [

--- a/packages/ocaml/ocaml.5.4.1/opam
+++ b/packages/ocaml/ocaml.5.4.1/opam
@@ -1,10 +1,18 @@
 opam-version: "2.0"
+# These packages are part of the infrastructure for maintaining the OCaml
+# compiler dependencies in opam. It's not possible to version the metadata
+# itself, because opam's versioning provides no mechanism to ignore the
+# revision (i.e. we don't have a way to have two revisions of ocaml.5.4.1 but
+# where "ocaml" {= "5.4.1"} would always mean to use the latest revision).
+# It is however useful to know which version of the metadata is installed.
+# This number should be bumped whenever a pertinent change is made.
+x-revision: "3"
 license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 synopsis: "The OCaml compiler (virtual package)"
 description: """
 This package requires a matching implementation of OCaml,
 and polls it to initialise specific variables like `ocaml:native-dynlink`"""
-maintainer: "David Allsopp <david@tarides.com>"
+maintainer: "David Allsopp <dra27@dra27.uk>"
 authors: [
   "Xavier Leroy"
   "Damien Doligez"

--- a/packages/ocaml/ocaml.5.4.2/opam
+++ b/packages/ocaml/ocaml.5.4.2/opam
@@ -6,7 +6,7 @@ opam-version: "2.0"
 # where "ocaml" {= "5.4.1"} would always mean to use the latest revision).
 # It is however useful to know which version of the metadata is installed.
 # This number should be bumped whenever a pertinent change is made.
-x-revision: "1"
+x-revision: "2"
 license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 synopsis: "The OCaml compiler (virtual package)"
 description: """
@@ -30,6 +30,8 @@ depends: [
   "ocaml-variants" {>= "5.4.2~" & < "5.4.3~"} |
   "ocaml-system" {>= "5.4.2~" & < "5.4.3~"} |
   "dkml-base-compiler" {>= "5.4.2~" & < "5.4.3~"}
+  ("ocaml-env-mingw64" {os = "win32"} | "ocaml-env-mingw32" {os = "win32"} |
+   "ocaml-env-msvc64" {os = "win32"} | "ocaml-env-msvc32" {os = "win32"})
 ]
 flags: [conf avoid-version]
 setenv: [

--- a/packages/ocaml/ocaml.5.4.2/opam
+++ b/packages/ocaml/ocaml.5.4.2/opam
@@ -1,10 +1,18 @@
 opam-version: "2.0"
+# These packages are part of the infrastructure for maintaining the OCaml
+# compiler dependencies in opam. It's not possible to version the metadata
+# itself, because opam's versioning provides no mechanism to ignore the
+# revision (i.e. we don't have a way to have two revisions of ocaml.5.4.1 but
+# where "ocaml" {= "5.4.1"} would always mean to use the latest revision).
+# It is however useful to know which version of the metadata is installed.
+# This number should be bumped whenever a pertinent change is made.
+x-revision: "1"
 license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 synopsis: "The OCaml compiler (virtual package)"
 description: """
 This package requires a matching implementation of OCaml,
 and polls it to initialise specific variables like `ocaml:native-dynlink`"""
-maintainer: "David Allsopp <david@tarides.com>"
+maintainer: "David Allsopp <dra27@dra27.uk>"
 authors: [
   "Xavier Leroy"
   "Damien Doligez"

--- a/packages/ocaml/ocaml.5.5.0/opam
+++ b/packages/ocaml/ocaml.5.5.0/opam
@@ -1,4 +1,12 @@
 opam-version: "2.0"
+# These packages are part of the infrastructure for maintaining the OCaml
+# compiler dependencies in opam. It's not possible to version the metadata
+# itself, because opam's versioning provides no mechanism to ignore the
+# revision (i.e. we don't have a way to have two revisions of ocaml.5.4.1 but
+# where "ocaml" {= "5.4.1"} would always mean to use the latest revision).
+# It is however useful to know which version of the metadata is installed.
+# This number should be bumped whenever a pertinent change is made.
+x-revision: "7"
 license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 synopsis: "The OCaml compiler (virtual package)"
 description: """

--- a/packages/ocaml/ocaml.5.5.0/opam
+++ b/packages/ocaml/ocaml.5.5.0/opam
@@ -6,7 +6,7 @@ opam-version: "2.0"
 # where "ocaml" {= "5.4.1"} would always mean to use the latest revision).
 # It is however useful to know which version of the metadata is installed.
 # This number should be bumped whenever a pertinent change is made.
-x-revision: "7"
+x-revision: "8"
 license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 synopsis: "The OCaml compiler (virtual package)"
 description: """
@@ -29,6 +29,8 @@ depends: [
   "ocaml-variants" {>= "5.5.0~" & < "5.5.1~"} |
   "ocaml-system" {>= "5.5.0~" & < "5.5.1~"} |
   "dkml-base-compiler" {>= "5.5.0~" & < "5.5.1~"}
+  ("ocaml-env-mingw64" {os = "win32"} | "ocaml-env-mingw32" {os = "win32"} |
+   "ocaml-env-msvc64" {os = "win32"} | "ocaml-env-msvc32" {os = "win32"})
 ]
 setenv: [
   [OCAMLTOP_INCLUDE_PATH += "%{toplevel}%"]

--- a/packages/ocaml/ocaml.5.6.0/opam
+++ b/packages/ocaml/ocaml.5.6.0/opam
@@ -1,10 +1,18 @@
 opam-version: "2.0"
+# These packages are part of the infrastructure for maintaining the OCaml
+# compiler dependencies in opam. It's not possible to version the metadata
+# itself, because opam's versioning provides no mechanism to ignore the
+# revision (i.e. we don't have a way to have two revisions of ocaml.5.4.1 but
+# where "ocaml" {= "5.4.1"} would always mean to use the latest revision).
+# It is however useful to know which version of the metadata is installed.
+# This number should be bumped whenever a pertinent change is made.
+x-revision: "2"
 license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 synopsis: "The OCaml compiler (virtual package)"
 description: """
 This package requires a matching implementation of OCaml,
 and polls it to initialise specific variables like `ocaml:native-dynlink`"""
-maintainer: "David Allsopp <david@tarides.com>"
+maintainer: "David Allsopp <dra27@dra27.uk>"
 authors: [
   "Xavier Leroy"
   "Damien Doligez"

--- a/packages/ocaml/ocaml.5.6.0/opam
+++ b/packages/ocaml/ocaml.5.6.0/opam
@@ -6,7 +6,7 @@ opam-version: "2.0"
 # where "ocaml" {= "5.4.1"} would always mean to use the latest revision).
 # It is however useful to know which version of the metadata is installed.
 # This number should be bumped whenever a pertinent change is made.
-x-revision: "2"
+x-revision: "3"
 license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 synopsis: "The OCaml compiler (virtual package)"
 description: """
@@ -29,6 +29,8 @@ depends: [
   "ocaml-variants" {>= "5.6.0~" & < "5.6.1~"} |
   "ocaml-system" {>= "5.6.0~" & < "5.6.1~"} |
   "dkml-base-compiler" {>= "5.6.0~" & < "5.6.1~"}
+  ("ocaml-env-mingw64" {os = "win32"} | "ocaml-env-mingw32" {os = "win32"} |
+   "ocaml-env-msvc64" {os = "win32"} | "ocaml-env-msvc32" {os = "win32"})
 ]
 flags: avoid-version
 setenv: [

--- a/packages/system-mingw/system-mingw.1/opam
+++ b/packages/system-mingw/system-mingw.1/opam
@@ -1,4 +1,11 @@
 opam-version: "2.0"
+# This package is part of the infrastructure for maintaining the OCaml compiler
+# dependencies in opam. It's not meaningful or helpful to version the package
+# itself, as its more part of the logical infrastructure providing the
+# repository, rather than a particular version of some code.
+# It is however useful to know which version of the metadata is installed.
+# This number should be bumped whenever a pertinent change is made.
+x-revision: "2"
 synopsis: "Build OCaml for mingw-w64"
 description: """
 This package specifies OCaml built with the mingw-w64 GCC compiler and is
@@ -6,7 +13,7 @@ presently available for i386/x86_32 and amd64/x86_64.
 
 This package corresponds to the `mingw` and `mingw64` values given by
 `ocamlopt -config-var system`."""
-maintainer: "David Allsopp <david@tarides.com>"
+maintainer: "David Allsopp <dra27@dra27.uk>"
 authors: "David Allsopp"
 license: "CC0-1.0+"
 homepage: "https://opam.ocaml.org"
@@ -15,6 +22,6 @@ flags: compiler
 available: os = "win32"
 depends: [
   ("ocaml-base-compiler" {post & >= "4.13.0~"} | "ocaml-variants" {post & >= "4.13.0~"})
-  ("ocaml-env-mingw32" | "ocaml-env-mingw64")
+  ("ocaml-env-mingw32" {build} | "ocaml-env-mingw64" {build})
 ]
 conflict-class: "ocaml-system"

--- a/packages/system-mingw/system-mingw.1/opam
+++ b/packages/system-mingw/system-mingw.1/opam
@@ -1,11 +1,4 @@
 opam-version: "2.0"
-# This package is part of the infrastructure for maintaining the OCaml compiler
-# dependencies in opam. It's not meaningful or helpful to version the package
-# itself, as its more part of the logical infrastructure providing the
-# repository, rather than a particular version of some code.
-# It is however useful to know which version of the metadata is installed.
-# This number should be bumped whenever a pertinent change is made.
-x-revision: "2"
 synopsis: "Build OCaml for mingw-w64"
 description: """
 This package specifies OCaml built with the mingw-w64 GCC compiler and is
@@ -13,7 +6,7 @@ presently available for i386/x86_32 and amd64/x86_64.
 
 This package corresponds to the `mingw` and `mingw64` values given by
 `ocamlopt -config-var system`."""
-maintainer: "David Allsopp <dra27@dra27.uk>"
+maintainer: "David Allsopp <david@tarides.com>"
 authors: "David Allsopp"
 license: "CC0-1.0+"
 homepage: "https://opam.ocaml.org"
@@ -22,6 +15,6 @@ flags: compiler
 available: os = "win32"
 depends: [
   ("ocaml-base-compiler" {post & >= "4.13.0~"} | "ocaml-variants" {post & >= "4.13.0~"})
-  ("ocaml-env-mingw32" {build} | "ocaml-env-mingw64" {build})
+  ("ocaml-env-mingw32" | "ocaml-env-mingw64")
 ]
 conflict-class: "ocaml-system"

--- a/packages/system-msvc/system-msvc.1/opam
+++ b/packages/system-msvc/system-msvc.1/opam
@@ -1,4 +1,11 @@
 opam-version: "2.0"
+# This package is part of the infrastructure for maintaining the OCaml compiler
+# dependencies in opam. It's not meaningful or helpful to version the package
+# itself, as its more part of the logical infrastructure providing the
+# repository, rather than a particular version of some code.
+# It is however useful to know which version of the metadata is installed.
+# This number should be bumped whenever a pertinent change is made.
+x-revision: "2"
 synopsis: "Build OCaml for Microsoft Visual Studio"
 description: """
 This package specifies OCaml built with Microsoft Visual Studio and is presently
@@ -6,7 +13,7 @@ available for i386/x86_32 and amd64/x86_64.
 
 This package corresponds to the `win32` and `win64` values given by
 `ocamlopt -config-var system`."""
-maintainer: "David Allsopp <david@tarides.com>"
+maintainer: "David Allsopp <dra27@dra27.uk>"
 authors: "David Allsopp"
 license: "CC0-1.0+"
 homepage: "https://opam.ocaml.org"
@@ -15,6 +22,6 @@ flags: compiler
 available: os = "win32"
 depends: [
   ("ocaml-base-compiler" {post & >= "4.13.0~"} | "ocaml-variants" {post & >= "4.13.0~"})
-  ("ocaml-env-msvc32" | "ocaml-env-msvc64")
+  ("ocaml-env-msvc32" {build} | "ocaml-env-msvc64" {build})
 ]
 conflict-class: "ocaml-system"

--- a/packages/system-msvc/system-msvc.1/opam
+++ b/packages/system-msvc/system-msvc.1/opam
@@ -1,11 +1,4 @@
 opam-version: "2.0"
-# This package is part of the infrastructure for maintaining the OCaml compiler
-# dependencies in opam. It's not meaningful or helpful to version the package
-# itself, as its more part of the logical infrastructure providing the
-# repository, rather than a particular version of some code.
-# It is however useful to know which version of the metadata is installed.
-# This number should be bumped whenever a pertinent change is made.
-x-revision: "2"
 synopsis: "Build OCaml for Microsoft Visual Studio"
 description: """
 This package specifies OCaml built with Microsoft Visual Studio and is presently
@@ -13,7 +6,7 @@ available for i386/x86_32 and amd64/x86_64.
 
 This package corresponds to the `win32` and `win64` values given by
 `ocamlopt -config-var system`."""
-maintainer: "David Allsopp <dra27@dra27.uk>"
+maintainer: "David Allsopp <david@tarides.com>"
 authors: "David Allsopp"
 license: "CC0-1.0+"
 homepage: "https://opam.ocaml.org"
@@ -22,6 +15,6 @@ flags: compiler
 available: os = "win32"
 depends: [
   ("ocaml-base-compiler" {post & >= "4.13.0~"} | "ocaml-variants" {post & >= "4.13.0~"})
-  ("ocaml-env-msvc32" {build} | "ocaml-env-msvc64" {build})
+  ("ocaml-env-msvc32" | "ocaml-env-msvc64")
 ]
 conflict-class: "ocaml-system"


### PR DESCRIPTION
It's a while since I exploded our CI systems, so here goes. This PR contains two highly related fixes which are relatively easily hit on Windows, and are particularly exacerbated in CI by the ill-advised https://github.com/ocaml/setup-ocaml/pull/974.

Selection between the Windows ports of OCaml is expressed by the _compulsory_ presence of either `host-arch-x86_64` or `host-arch-x86_32` and similarly either `host-system-mingw` or `host-system-msvc`. The _compulsory_ presence of these packages allows other packages to conflict/depend on specific configurations, which is particularly important for the depext support provided with Cygwin.

There is a bug, which I think has been present since I first added these packages, in that if you attempt to uninstall the `host-arch-` or `host-system-` package in a switch, then opam will dutifully attempt to install the _other_ package (i.e. if you uninstall `host-arch-x86_64` then opam will insist that `host-arch-x86_32` must be installed). What doesn't happen is a rebuild of the compiler to match that change, which breaks the dependency invariant. The first commit fixes this by removing the incorrect `{post}` dependencies in the four `ocaml-env-` packages. With that change, removing these packages (or, more accurately, installing the opposite package) now correctly triggers a rebuild of the compiler.

~~There was also a much more minor bug in that reinstalling the C compiler metadata package (or the host-arch- and host-system- packages) incorrectly triggers a rebuild of the compiler. The second commit fixes that by declaring the dependency on the `ocaml-env-` packages from the `system-` packages to be `{build}` (i.e. they must be installed prior to compilation of the compiler, but changes in them do not affect the compiler).~~

We then get to the largest part of the bug, originally tracked in https://github.com/ocaml-windows/papercuts/issues/2 and https://github.com/dra27/mingw-w64-shims/issues/1. Related issues and PRs include https://github.com/ocaml-windows/papercuts/issues/15, https://github.com/ocaml/opam-repository/pull/27913 and https://github.com/ocaml/opam-repository/pull/29691. Packages which use OCaml require the C compiler, assembler, and linker to be available at all times in the switch. Responsibility for this falls on a mix of `msvs-detect` and `mingw-w64-shims`. The packages are presently engineered to ensure that changes in these packages do not trigger the compiler itself to rebuild (because it's both unnecessary and very costly) but if these packages alter (especially for mingw-w64-shims) then there is a point where the old package is being - or has been - removed and the new package is not yet installed. These actions must not be allowed to race with any package which uses OCaml itself (which may at any moment invoke the assembler, the linker, or even the C compiler).

The fix for this is in two parts - the fourth commit _repeats_ the dependency on the `ocaml-env-` packages in the `ocaml` package, but this time as a standard dependency. Combined with the removal of the incorrect `post` dependencies, that now means that the `ocaml` package (on Windows) always has a direct dependency on the configuration of the C compiler. The fifth commit then completes the fix by moving `mingw-w64-shims` from the compiler packages themselves into the `ocaml-env-mingw` packages (which, in hindsight, is probably where they should have been in the first place).

With this change, installing `conf-pkg-config`, `conf-mingw-w64-g++-x86_64`, etc. (i.e. packages which will trigger a recompile of `mingw-w64-shims`) triggers a full recompilation of packages in the switch (but not of OCaml itself). The full recompilation is unfortunate, but that's what the various stop-gap PRs have been doing already. I have a follow-up PR to tidy things further which removes the recompilations, but the corrections in this PR remain necessary for that, which is why I've separated them.

Finally, I've included an idea for these various packages which get updated periodically, but for which we mustn't introduce additional versions, and added an `x-revision` field, which I initialised to the correct value for each package, and then bumped in this PR.