### PR TITLE
21 packages from gitlab.com/dkml/build-tools/MlFront/-/releases/2.4.2.160/downloads/MlFront.tar.gz

### DIFF
--- a/packages/DkZero_Base/DkZero_Base.2.4.2.160/opam
+++ b/packages/DkZero_Base/DkZero_Base.2.4.2.160/opam
@@ -1,0 +1,50 @@
+opam-version: "2.0"
+synopsis: "Base modules for dk0"
+maintainer: "Diskuv, Inc. <opensource+dkml@support.diskuv.com>"
+authors: "Diskuv, Inc. <opensource+dkml@support.diskuv.com>"
+license:
+  "(OSL-3.0 OR LicenseRef-DkSDK-SOFTWARE-DEVELOPMENT-KIT-LICENSE-AGREEMENT)"
+homepage: "https://github.com/diskuv/dk"
+bug-reports: "https://gitlab.com/dkml/build-tools/MlFront/-/issues"
+depends: [
+  "dune" {>= "3.18"}
+  "ocaml" {>= "4.14"}
+  "MlFront_Cache" {= version}
+  "MlFront_Signify" {= version}
+  "MlFront_Thunk" {= version}
+  "MlFront_ZipFile" {= version}
+  "UnifiedScript_Std" {= version}
+  "dkml-c-probe" {>= "3.2.0"}
+  "ptime" {>= "1.1.0"}
+  "ppx_deriving" {>= "6.0.2"}
+  "xdg" {>= "3.12.1"}
+  "capnp" {with-test & >= "3.6.0"}
+  "tezt" {with-test & >= "4.1.0"}
+  "odoc" {with-doc}
+]
+depopts: [
+  "ocaml-protoc" {with-test & >= "3.1.0"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://gitlab.com/dkml/build-tools/MlFront.git"
+url {
+  src:
+    "https://gitlab.com/dkml/build-tools/MlFront/-/releases/2.4.2.160/downloads/MlFront.tar.gz"
+  checksum: [
+    "md5=c6ca8e00038e5d519a0ea333b919ff3b"
+    "sha512=b0dc90e454454e8a7f11c1a7d729d493e9eb42ff6c0bdad81932cc0d5d32d0cfe48700ad0b60b24ea3053828e1034797e9d35dc2b38deb112c1dcf6dfe1e5abc"
+  ]
+}

--- a/packages/DkZero_Exec/DkZero_Exec.2.4.2.160/opam
+++ b/packages/DkZero_Exec/DkZero_Exec.2.4.2.160/opam
@@ -1,0 +1,45 @@
+opam-version: "2.0"
+synopsis: "The single-threaded dk0 build system"
+maintainer: "Diskuv, Inc. <opensource+dkml@support.diskuv.com>"
+authors: "Diskuv, Inc. <opensource+dkml@support.diskuv.com>"
+license:
+  "(OSL-3.0 OR LicenseRef-DkSDK-SOFTWARE-DEVELOPMENT-KIT-LICENSE-AGREEMENT)"
+homepage: "https://github.com/diskuv/dk"
+bug-reports: "https://gitlab.com/dkml/build-tools/MlFront/-/issues"
+depends: [
+  "dune" {>= "3.18"}
+  "ocaml" {>= "4.14"}
+  "MlFront_Console" {= version}
+  "MlFront_Logs" {= version}
+  "MlFront_ProgressPeriod" {= version}
+  "MlFront_ProgressZig" {= version}
+  "UnifiedScript_Std" {= version}
+  "DkZero_Base" {= version}
+  "DkZero_RuntimeC" {= version}
+  "tezt" {with-test & >= "4.1.0"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://gitlab.com/dkml/build-tools/MlFront.git"
+url {
+  src:
+    "https://gitlab.com/dkml/build-tools/MlFront/-/releases/2.4.2.160/downloads/MlFront.tar.gz"
+  checksum: [
+    "md5=c6ca8e00038e5d519a0ea333b919ff3b"
+    "sha512=b0dc90e454454e8a7f11c1a7d729d493e9eb42ff6c0bdad81932cc0d5d32d0cfe48700ad0b60b24ea3053828e1034797e9d35dc2b38deb112c1dcf6dfe1e5abc"
+  ]
+}
+x-maintenance-intent: ["(latest)"]

--- a/packages/DkZero_RuntimeC/DkZero_RuntimeC.2.4.2.160/opam
+++ b/packages/DkZero_RuntimeC/DkZero_RuntimeC.2.4.2.160/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+synopsis: "C runtime functions for dk0"
+maintainer: "Diskuv, Inc. <opensource+dkml@support.diskuv.com>"
+authors: "Diskuv, Inc. <opensource+dkml@support.diskuv.com>"
+license:
+  "(OSL-3.0 OR LicenseRef-DkSDK-SOFTWARE-DEVELOPMENT-KIT-LICENSE-AGREEMENT)"
+homepage: "https://github.com/diskuv/dk"
+bug-reports: "https://gitlab.com/dkml/build-tools/MlFront/-/issues"
+depends: [
+  "dune" {>= "3.18"}
+  "ocaml" {>= "4.14"}
+  "DkZero_Base" {= version}
+  "spawn" {>= "v0.15.1"}
+  "MlFront_ProgressZig" {= version}
+  "MlFront_ProgressPeriod" {with-test & = version}
+  "tezt" {with-test & >= "4.1.0"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://gitlab.com/dkml/build-tools/MlFront.git"
+url {
+  src:
+    "https://gitlab.com/dkml/build-tools/MlFront/-/releases/2.4.2.160/downloads/MlFront.tar.gz"
+  checksum: [
+    "md5=c6ca8e00038e5d519a0ea333b919ff3b"
+    "sha512=b0dc90e454454e8a7f11c1a7d729d493e9eb42ff6c0bdad81932cc0d5d32d0cfe48700ad0b60b24ea3053828e1034797e9d35dc2b38deb112c1dcf6dfe1e5abc"
+  ]
+}

--- a/packages/MlFront_Cache/MlFront_Cache.2.4.2.160/opam
+++ b/packages/MlFront_Cache/MlFront_Cache.2.4.2.160/opam
@@ -1,0 +1,42 @@
+opam-version: "2.0"
+synopsis: "Caching for MlFront"
+maintainer: "Diskuv, Inc. <opensource+dkml@support.diskuv.com>"
+authors: "Diskuv, Inc. <opensource+dkml@support.diskuv.com>"
+license: "Apache-2.0"
+homepage: "https://github.com/diskuv/dk?tab=readme-ov-file"
+bug-reports: "https://gitlab.com/dkml/build-tools/MlFront/-/issues"
+depends: [
+  "dune" {>= "3.18"}
+  "ocaml" {>= "4.14"}
+  "fmt" {>= "0.9.0"}
+  "mirage-crypto-rng" {>= "2.0.0"}
+  "uuidm" {>= "0.9.8"}
+  "MlFront_Core" {= version}
+  "UnifiedScript_Top" {with-test & = version}
+  "tezt" {with-test & >= "4.1.0"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://gitlab.com/dkml/build-tools/MlFront.git"
+url {
+  src:
+    "https://gitlab.com/dkml/build-tools/MlFront/-/releases/2.4.2.160/downloads/MlFront.tar.gz"
+  checksum: [
+    "md5=c6ca8e00038e5d519a0ea333b919ff3b"
+    "sha512=b0dc90e454454e8a7f11c1a7d729d493e9eb42ff6c0bdad81932cc0d5d32d0cfe48700ad0b60b24ea3053828e1034797e9d35dc2b38deb112c1dcf6dfe1e5abc"
+  ]
+}
+x-maintenance-intent: ["(latest)"]

--- a/packages/MlFront_Codept/MlFront_Codept.2.4.2.160/opam
+++ b/packages/MlFront_Codept/MlFront_Codept.2.4.2.160/opam
@@ -1,0 +1,50 @@
+opam-version: "2.0"
+synopsis: "Utilities built on top of codept_lib"
+maintainer: "Diskuv, Inc. <opensource+dkml@support.diskuv.com>"
+authors: "Diskuv, Inc. <opensource+dkml@support.diskuv.com>"
+license: "Apache-2.0"
+homepage: "https://github.com/diskuv/dk?tab=readme-ov-file"
+bug-reports: "https://gitlab.com/dkml/build-tools/MlFront/-/issues"
+depends: [
+  "dune" {>= "3.18"}
+  "ocaml" {>= "4.14"}
+  "bos" {>= "0.2.1"}
+  "codept-lib" {>= "0.12.1"}
+  "ezjsonm" {>= "1.3.0"}
+  "fmt" {>= "0.9.0"}
+  "fpath" {>= "0.7.3"}
+  "logs" {>= "0.7.0"}
+  "ppx_deriving" {>= "6.0.2"}
+  "stringext" {>= "1.6.0"}
+  "MlFront_Core" {= version}
+  "MlFront_Config" {= version}
+  "MlFront_Errors" {= version}
+  "containers-data" {with-test & >= "3.13.1"}
+  "tezt" {with-test & >= "4.1.0"}
+  "tyre" {with-test & >= "0.5"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://gitlab.com/dkml/build-tools/MlFront.git"
+url {
+  src:
+    "https://gitlab.com/dkml/build-tools/MlFront/-/releases/2.4.2.160/downloads/MlFront.tar.gz"
+  checksum: [
+    "md5=c6ca8e00038e5d519a0ea333b919ff3b"
+    "sha512=b0dc90e454454e8a7f11c1a7d729d493e9eb42ff6c0bdad81932cc0d5d32d0cfe48700ad0b60b24ea3053828e1034797e9d35dc2b38deb112c1dcf6dfe1e5abc"
+  ]
+}
+x-maintenance-intent: ["(latest)"]

--- a/packages/MlFront_Config/MlFront_Config.2.4.2.160/opam
+++ b/packages/MlFront_Config/MlFront_Config.2.4.2.160/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+synopsis: "Configuration for MlFront"
+maintainer: "Diskuv, Inc. <opensource+dkml@support.diskuv.com>"
+authors: "Diskuv, Inc. <opensource+dkml@support.diskuv.com>"
+license: "Apache-2.0"
+homepage: "https://github.com/diskuv/dk?tab=readme-ov-file"
+bug-reports: "https://gitlab.com/dkml/build-tools/MlFront/-/issues"
+depends: [
+  "dune" {>= "3.18"}
+  "ocaml" {>= "4.14"}
+  "cppo" {>= "1.6.8"}
+  "MlFront_Core" {= version}
+  "ppxlib" {with-test & >= "0.30.0"}
+  "tezt" {with-test & >= "4.1.0"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://gitlab.com/dkml/build-tools/MlFront.git"
+url {
+  src:
+    "https://gitlab.com/dkml/build-tools/MlFront/-/releases/2.4.2.160/downloads/MlFront.tar.gz"
+  checksum: [
+    "md5=c6ca8e00038e5d519a0ea333b919ff3b"
+    "sha512=b0dc90e454454e8a7f11c1a7d729d493e9eb42ff6c0bdad81932cc0d5d32d0cfe48700ad0b60b24ea3053828e1034797e9d35dc2b38deb112c1dcf6dfe1e5abc"
+  ]
+}
+x-maintenance-intent: ["(latest)"]

--- a/packages/MlFront_Console/MlFront_Console.2.4.2.160/opam
+++ b/packages/MlFront_Console/MlFront_Console.2.4.2.160/opam
@@ -34,3 +34,7 @@ url {
   ]
 }
 x-maintenance-intent: ["(latest)"]
+extra-source "src/MlFront_Console/c/mlfront_console_stubs.c" {
+  src: "https://github.com/diskuv/dk/releases/download/2.5.202605160700/mlfront_console_stubs.c"
+  checksum: "sha256=e8e8049b81285433339c5dfb202126f59dfc1a41b03dd0fd1a327e617cdb57d9"
+}

--- a/packages/MlFront_Console/MlFront_Console.2.4.2.160/opam
+++ b/packages/MlFront_Console/MlFront_Console.2.4.2.160/opam
@@ -1,0 +1,36 @@
+opam-version: "2.0"
+synopsis: "Console access for MlFront"
+maintainer: "Diskuv, Inc. <opensource+dkml@support.diskuv.com>"
+authors: "Diskuv, Inc. <opensource+dkml@support.diskuv.com>"
+license: "Apache-2.0"
+homepage: "https://github.com/diskuv/dk?tab=readme-ov-file"
+bug-reports: "https://gitlab.com/dkml/build-tools/MlFront/-/issues"
+depends: [
+  "dune" {>= "3.18"}
+  "ocaml" {>= "4.14"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://gitlab.com/dkml/build-tools/MlFront.git"
+url {
+  src:
+    "https://gitlab.com/dkml/build-tools/MlFront/-/releases/2.4.2.160/downloads/MlFront.tar.gz"
+  checksum: [
+    "md5=c6ca8e00038e5d519a0ea333b919ff3b"
+    "sha512=b0dc90e454454e8a7f11c1a7d729d493e9eb42ff6c0bdad81932cc0d5d32d0cfe48700ad0b60b24ea3053828e1034797e9d35dc2b38deb112c1dcf6dfe1e5abc"
+  ]
+}
+x-maintenance-intent: ["(latest)"]

--- a/packages/MlFront_Console/MlFront_Console.2.4.2.160/opam
+++ b/packages/MlFront_Console/MlFront_Console.2.4.2.160/opam
@@ -36,5 +36,5 @@ url {
 x-maintenance-intent: ["(latest)"]
 extra-source "src/MlFront_Console/c/mlfront_console_stubs.c" {
   src: "https://github.com/diskuv/dk/releases/download/2.5.202605160700/mlfront_console_stubs.c"
-  checksum: "sha256=e8e8049b81285433339c5dfb202126f59dfc1a41b03dd0fd1a327e617cdb57d9"
+  checksum: "sha256=a2ae34b416bb26a2997e0e9dd36b4f0e00c10b88a88b21377931c40168370c2f"
 }

--- a/packages/MlFront_Core/MlFront_Core.2.4.2.160/opam
+++ b/packages/MlFront_Core/MlFront_Core.2.4.2.160/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+synopsis: "Module and library identification for MlFront"
+maintainer: "Diskuv, Inc. <opensource+dkml@support.diskuv.com>"
+authors: "Diskuv, Inc. <opensource+dkml@support.diskuv.com>"
+license: "Apache-2.0"
+homepage: "https://github.com/diskuv/dk?tab=readme-ov-file"
+bug-reports: "https://gitlab.com/dkml/build-tools/MlFront/-/issues"
+depends: [
+  "dune" {>= "3.18"}
+  "ocaml" {>= "4.14"}
+  "digestif" {>= "1.1.4"}
+  "stringext" {>= "1.6.0"}
+  "crowbar" {with-test & >= "0.2.1"}
+  "re" {with-test & >= "1.11.0"}
+  "tezt" {with-test & >= "4.1.0"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://gitlab.com/dkml/build-tools/MlFront.git"
+url {
+  src:
+    "https://gitlab.com/dkml/build-tools/MlFront/-/releases/2.4.2.160/downloads/MlFront.tar.gz"
+  checksum: [
+    "md5=c6ca8e00038e5d519a0ea333b919ff3b"
+    "sha512=b0dc90e454454e8a7f11c1a7d729d493e9eb42ff6c0bdad81932cc0d5d32d0cfe48700ad0b60b24ea3053828e1034797e9d35dc2b38deb112c1dcf6dfe1e5abc"
+  ]
+}
+x-maintenance-intent: ["(latest)"]

--- a/packages/MlFront_Errors/MlFront_Errors.2.4.2.160/opam
+++ b/packages/MlFront_Errors/MlFront_Errors.2.4.2.160/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+synopsis: "Error handling for MlFront"
+maintainer: "Diskuv, Inc. <opensource+dkml@support.diskuv.com>"
+authors: "Diskuv, Inc. <opensource+dkml@support.diskuv.com>"
+license: "Apache-2.0"
+homepage: "https://github.com/diskuv/dk?tab=readme-ov-file"
+bug-reports: "https://gitlab.com/dkml/build-tools/MlFront/-/issues"
+depends: [
+  "dune" {>= "3.18"}
+  "ocaml" {>= "4.14"}
+  "fmt" {>= "0.9.0"}
+  "logs" {>= "0.7.0"}
+  "stringext" {>= "1.6.0"}
+  "tezt" {with-test & >= "4.1.0"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://gitlab.com/dkml/build-tools/MlFront.git"
+url {
+  src:
+    "https://gitlab.com/dkml/build-tools/MlFront/-/releases/2.4.2.160/downloads/MlFront.tar.gz"
+  checksum: [
+    "md5=c6ca8e00038e5d519a0ea333b919ff3b"
+    "sha512=b0dc90e454454e8a7f11c1a7d729d493e9eb42ff6c0bdad81932cc0d5d32d0cfe48700ad0b60b24ea3053828e1034797e9d35dc2b38deb112c1dcf6dfe1e5abc"
+  ]
+}
+x-maintenance-intent: ["(latest)"]

--- a/packages/MlFront_Logs/MlFront_Logs.2.4.2.160/opam
+++ b/packages/MlFront_Logs/MlFront_Logs.2.4.2.160/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+synopsis: "Logging for MlFront"
+maintainer: "Diskuv, Inc. <opensource+dkml@support.diskuv.com>"
+authors: "Diskuv, Inc. <opensource+dkml@support.diskuv.com>"
+license: "Apache-2.0"
+homepage: "https://github.com/diskuv/dk?tab=readme-ov-file"
+bug-reports: "https://gitlab.com/dkml/build-tools/MlFront/-/issues"
+depends: [
+  "dune" {>= "3.18"}
+  "ocaml" {>= "4.14"}
+  "MlFront_Console" {= version}
+  "cmdliner" {>= "1.2.0"}
+  "fmt" {>= "0.9.0"}
+  "logs" {>= "0.7.0"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://gitlab.com/dkml/build-tools/MlFront.git"
+url {
+  src:
+    "https://gitlab.com/dkml/build-tools/MlFront/-/releases/2.4.2.160/downloads/MlFront.tar.gz"
+  checksum: [
+    "md5=c6ca8e00038e5d519a0ea333b919ff3b"
+    "sha512=b0dc90e454454e8a7f11c1a7d729d493e9eb42ff6c0bdad81932cc0d5d32d0cfe48700ad0b60b24ea3053828e1034797e9d35dc2b38deb112c1dcf6dfe1e5abc"
+  ]
+}
+x-maintenance-intent: ["(latest)"]

--- a/packages/MlFront_Lua/MlFront_Lua.2.4.2.160/opam
+++ b/packages/MlFront_Lua/MlFront_Lua.2.4.2.160/opam
@@ -1,0 +1,43 @@
+opam-version: "2.0"
+synopsis:
+  "Lua 2.5 embedded interpreter with no built-in globals and libraries"
+description:
+  "MlFront_Lua has the same pure OCaml embedding design and Lua 2.5 syntax as https://github.com/lindig/lua-ml.git. Early versions will reuse the Lua 2.5 syntax of lua-ml, but eventually the Lua syntax will be upgraded to Lua 5.1+."
+maintainer: "Diskuv, Inc. <opensource+dkml@support.diskuv.com>"
+authors: "Diskuv, Inc. <opensource+dkml@support.diskuv.com>"
+license: "Apache-2.0"
+homepage: "https://github.com/diskuv/dk?tab=readme-ov-file"
+bug-reports: "https://gitlab.com/dkml/build-tools/MlFront/-/issues"
+depends: [
+  "dune" {>= "3.18"}
+  "ocaml" {>= "4.14"}
+  "fmlib_parse" {>= "0.6.2"}
+  "menhir" {>= "20180528"}
+  "UnifiedScript_Top" {with-test & = version}
+  "tezt" {with-test & >= "4.1.0"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://gitlab.com/dkml/build-tools/MlFront.git"
+url {
+  src:
+    "https://gitlab.com/dkml/build-tools/MlFront/-/releases/2.4.2.160/downloads/MlFront.tar.gz"
+  checksum: [
+    "md5=c6ca8e00038e5d519a0ea333b919ff3b"
+    "sha512=b0dc90e454454e8a7f11c1a7d729d493e9eb42ff6c0bdad81932cc0d5d32d0cfe48700ad0b60b24ea3053828e1034797e9d35dc2b38deb112c1dcf6dfe1e5abc"
+  ]
+}
+x-maintenance-intent: ["(latest)"]

--- a/packages/MlFront_Manip/MlFront_Manip.2.4.2.160/opam
+++ b/packages/MlFront_Manip/MlFront_Manip.2.4.2.160/opam
@@ -1,0 +1,38 @@
+opam-version: "2.0"
+synopsis: "Binary manipulation tools for MlFront"
+maintainer: "Diskuv, Inc. <opensource+dkml@support.diskuv.com>"
+authors: "Diskuv, Inc. <opensource+dkml@support.diskuv.com>"
+license: "Apache-2.0"
+homepage: "https://github.com/diskuv/dk?tab=readme-ov-file"
+bug-reports: "https://gitlab.com/dkml/build-tools/MlFront/-/issues"
+depends: [
+  "dune" {>= "3.18"}
+  "ocaml" {>= "4.14"}
+  "tezt" {with-test & >= "4.1.0"}
+  "ppxlib" {with-test & >= "0.30.0"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://gitlab.com/dkml/build-tools/MlFront.git"
+url {
+  src:
+    "https://gitlab.com/dkml/build-tools/MlFront/-/releases/2.4.2.160/downloads/MlFront.tar.gz"
+  checksum: [
+    "md5=c6ca8e00038e5d519a0ea333b919ff3b"
+    "sha512=b0dc90e454454e8a7f11c1a7d729d493e9eb42ff6c0bdad81932cc0d5d32d0cfe48700ad0b60b24ea3053828e1034797e9d35dc2b38deb112c1dcf6dfe1e5abc"
+  ]
+}
+x-maintenance-intent: ["(latest)"]

--- a/packages/MlFront_Progress/MlFront_Progress.2.4.2.160/opam
+++ b/packages/MlFront_Progress/MlFront_Progress.2.4.2.160/opam
@@ -1,0 +1,36 @@
+opam-version: "2.0"
+synopsis: "Progress reporting API and builtin backends"
+maintainer: "Diskuv, Inc. <opensource+dkml@support.diskuv.com>"
+authors: "Diskuv, Inc. <opensource+dkml@support.diskuv.com>"
+license: "Apache-2.0"
+homepage: "https://github.com/diskuv/dk?tab=readme-ov-file"
+bug-reports: "https://gitlab.com/dkml/build-tools/MlFront/-/issues"
+depends: [
+  "dune" {>= "3.18"}
+  "ocaml" {>= "4.14"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://gitlab.com/dkml/build-tools/MlFront.git"
+url {
+  src:
+    "https://gitlab.com/dkml/build-tools/MlFront/-/releases/2.4.2.160/downloads/MlFront.tar.gz"
+  checksum: [
+    "md5=c6ca8e00038e5d519a0ea333b919ff3b"
+    "sha512=b0dc90e454454e8a7f11c1a7d729d493e9eb42ff6c0bdad81932cc0d5d32d0cfe48700ad0b60b24ea3053828e1034797e9d35dc2b38deb112c1dcf6dfe1e5abc"
+  ]
+}
+x-maintenance-intent: ["(latest)"]

--- a/packages/MlFront_ProgressPeriod/MlFront_ProgressPeriod.2.4.2.160/opam
+++ b/packages/MlFront_ProgressPeriod/MlFront_ProgressPeriod.2.4.2.160/opam
@@ -1,0 +1,38 @@
+opam-version: "2.0"
+synopsis:
+  "Periodic progress reporting for headless and accessible environments"
+maintainer: "Diskuv, Inc. <opensource+dkml@support.diskuv.com>"
+authors: "Diskuv, Inc. <opensource+dkml@support.diskuv.com>"
+license: "Apache-2.0"
+homepage: "https://github.com/diskuv/dk?tab=readme-ov-file"
+bug-reports: "https://gitlab.com/dkml/build-tools/MlFront/-/issues"
+depends: [
+  "dune" {>= "3.18"}
+  "ocaml" {>= "4.14"}
+  "MlFront_Progress" {= version}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://gitlab.com/dkml/build-tools/MlFront.git"
+url {
+  src:
+    "https://gitlab.com/dkml/build-tools/MlFront/-/releases/2.4.2.160/downloads/MlFront.tar.gz"
+  checksum: [
+    "md5=c6ca8e00038e5d519a0ea333b919ff3b"
+    "sha512=b0dc90e454454e8a7f11c1a7d729d493e9eb42ff6c0bdad81932cc0d5d32d0cfe48700ad0b60b24ea3053828e1034797e9d35dc2b38deb112c1dcf6dfe1e5abc"
+  ]
+}
+x-maintenance-intent: ["(latest)"]

--- a/packages/MlFront_ProgressZig/MlFront_ProgressZig.2.4.2.160/opam
+++ b/packages/MlFront_ProgressZig/MlFront_ProgressZig.2.4.2.160/opam
@@ -1,0 +1,43 @@
+opam-version: "2.0"
+synopsis: "Zig compatible progress reporting for TUIs"
+description:
+  "A pure OCaml implementation of Zig's std Progress library: https://andrewkelley.me/post/zig-new-cli-progress-bar-explained.html"
+maintainer: "Diskuv, Inc. <opensource+dkml@support.diskuv.com>"
+authors: "Diskuv, Inc. <opensource+dkml@support.diskuv.com>"
+license: "Apache-2.0"
+homepage: "https://github.com/diskuv/dk?tab=readme-ov-file"
+bug-reports: "https://gitlab.com/dkml/build-tools/MlFront/-/issues"
+depends: [
+  "dune" {>= "3.18"}
+  "ocaml" {>= "4.14"}
+  "uucp" {>= "15.0.0"}
+  "MlFront_Progress" {= version}
+  "MlFront_Thunk" {= version}
+  "MlFront_Core" {= version}
+  "MlFront_Console" {= version}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://gitlab.com/dkml/build-tools/MlFront.git"
+url {
+  src:
+    "https://gitlab.com/dkml/build-tools/MlFront/-/releases/2.4.2.160/downloads/MlFront.tar.gz"
+  checksum: [
+    "md5=c6ca8e00038e5d519a0ea333b919ff3b"
+    "sha512=b0dc90e454454e8a7f11c1a7d729d493e9eb42ff6c0bdad81932cc0d5d32d0cfe48700ad0b60b24ea3053828e1034797e9d35dc2b38deb112c1dcf6dfe1e5abc"
+  ]
+}
+x-maintenance-intent: ["(latest)"]

--- a/packages/MlFront_Signify/MlFront_Signify.2.4.2.160/opam
+++ b/packages/MlFront_Signify/MlFront_Signify.2.4.2.160/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+synopsis: "OpenBSD compatible signify for MlFront"
+maintainer: "Diskuv, Inc. <opensource+dkml@support.diskuv.com>"
+authors: "Diskuv, Inc. <opensource+dkml@support.diskuv.com>"
+license: "Apache-2.0"
+homepage: "https://github.com/diskuv/dk?tab=readme-ov-file"
+bug-reports: "https://gitlab.com/dkml/build-tools/MlFront/-/issues"
+depends: [
+  "dune" {>= "3.18"}
+  "ocaml" {>= "4.14"}
+  "mirage-crypto-rng" {>= "2.0.0"}
+  "stringext" {with-test & >= "1.6.0"}
+  "tezt" {with-test & >= "4.1.0"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://gitlab.com/dkml/build-tools/MlFront.git"
+url {
+  src:
+    "https://gitlab.com/dkml/build-tools/MlFront/-/releases/2.4.2.160/downloads/MlFront.tar.gz"
+  checksum: [
+    "md5=c6ca8e00038e5d519a0ea333b919ff3b"
+    "sha512=b0dc90e454454e8a7f11c1a7d729d493e9eb42ff6c0bdad81932cc0d5d32d0cfe48700ad0b60b24ea3053828e1034797e9d35dc2b38deb112c1dcf6dfe1e5abc"
+  ]
+}
+x-maintenance-intent: ["(latest)"]

--- a/packages/MlFront_Thunk/MlFront_Thunk.2.4.2.160/opam
+++ b/packages/MlFront_Thunk/MlFront_Thunk.2.4.2.160/opam
@@ -1,0 +1,47 @@
+opam-version: "2.0"
+synopsis: "Describes and runs reproducible units of work called thunks"
+maintainer: "Diskuv, Inc. <opensource+dkml@support.diskuv.com>"
+authors: "Diskuv, Inc. <opensource+dkml@support.diskuv.com>"
+license: "Apache-2.0"
+homepage: "https://github.com/diskuv/dk?tab=readme-ov-file"
+bug-reports: "https://gitlab.com/dkml/build-tools/MlFront/-/issues"
+depends: [
+  "dune" {>= "3.18"}
+  "ocaml" {>= "4.14"}
+  "MlFront_Core" {= version}
+  "MlFront_Lua" {= version}
+  "MlFront_Progress" {= version}
+  "MlFront_ZipFile" {= version}
+  "UnifiedScript_Std" {= version}
+  "digestif" {>= "1.1.4"}
+  "fmlib_parse" {>= "0.6.2"}
+  "fmlib_pretty" {>= "0.6.2"}
+  "fmlib_std" {>= "0.6.2"}
+  "ppx_deriving" {>= "6.0.2"}
+  "tezt" {with-test & >= "4.1.0"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://gitlab.com/dkml/build-tools/MlFront.git"
+url {
+  src:
+    "https://gitlab.com/dkml/build-tools/MlFront/-/releases/2.4.2.160/downloads/MlFront.tar.gz"
+  checksum: [
+    "md5=c6ca8e00038e5d519a0ea333b919ff3b"
+    "sha512=b0dc90e454454e8a7f11c1a7d729d493e9eb42ff6c0bdad81932cc0d5d32d0cfe48700ad0b60b24ea3053828e1034797e9d35dc2b38deb112c1dcf6dfe1e5abc"
+  ]
+}
+x-maintenance-intent: ["(latest)"]

--- a/packages/MlFront_Tools/MlFront_Tools.2.4.2.160/opam
+++ b/packages/MlFront_Tools/MlFront_Tools.2.4.2.160/opam
@@ -1,0 +1,48 @@
+opam-version: "2.0"
+synopsis: "Console access for MlFront"
+maintainer: "Diskuv, Inc. <opensource+dkml@support.diskuv.com>"
+authors: "Diskuv, Inc. <opensource+dkml@support.diskuv.com>"
+license: "Apache-2.0"
+homepage: "https://github.com/diskuv/dk?tab=readme-ov-file"
+bug-reports: "https://gitlab.com/dkml/build-tools/MlFront/-/issues"
+depends: [
+  "dune" {>= "3.18"}
+  "ocaml" {>= "4.14"}
+  "bos" {>= "0.2.1"}
+  "cmdliner" {>= "1.2.0"}
+  "crunch" {>= "3.3.1"}
+  "fmt" {>= "0.9.0"}
+  "fpath" {>= "0.7.3"}
+  "logs" {>= "0.7.0"}
+  "ppx_deriving" {>= "6.0.2"}
+  "stringext" {>= "1.6.0"}
+  "diskuvbox" {with-test & >= "0.2.0"}
+  "MlFront_Codept" {= version}
+  "MlFront_Errors" {= version}
+  "MlFront_Logs" {= version}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://gitlab.com/dkml/build-tools/MlFront.git"
+url {
+  src:
+    "https://gitlab.com/dkml/build-tools/MlFront/-/releases/2.4.2.160/downloads/MlFront.tar.gz"
+  checksum: [
+    "md5=c6ca8e00038e5d519a0ea333b919ff3b"
+    "sha512=b0dc90e454454e8a7f11c1a7d729d493e9eb42ff6c0bdad81932cc0d5d32d0cfe48700ad0b60b24ea3053828e1034797e9d35dc2b38deb112c1dcf6dfe1e5abc"
+  ]
+}
+x-maintenance-intent: ["(latest)"]

--- a/packages/MlFront_ZipFile/MlFront_ZipFile.2.4.2.160/opam
+++ b/packages/MlFront_ZipFile/MlFront_ZipFile.2.4.2.160/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+synopsis: "Zip files for MlFront"
+maintainer: "Diskuv, Inc. <opensource+dkml@support.diskuv.com>"
+authors: "Diskuv, Inc. <opensource+dkml@support.diskuv.com>"
+license: "Apache-2.0"
+homepage: "https://github.com/diskuv/dk?tab=readme-ov-file"
+bug-reports: "https://gitlab.com/dkml/build-tools/MlFront/-/issues"
+depends: [
+  "dune" {>= "3.18"}
+  "ocaml" {>= "4.14"}
+  "re" {>= "1.11.0"}
+  "digestif" {with-test & >= "1.1.4"}
+  "stringext" {with-test & >= "1.6.0"}
+  "tezt" {with-test & >= "4.1.0"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://gitlab.com/dkml/build-tools/MlFront.git"
+url {
+  src:
+    "https://gitlab.com/dkml/build-tools/MlFront/-/releases/2.4.2.160/downloads/MlFront.tar.gz"
+  checksum: [
+    "md5=c6ca8e00038e5d519a0ea333b919ff3b"
+    "sha512=b0dc90e454454e8a7f11c1a7d729d493e9eb42ff6c0bdad81932cc0d5d32d0cfe48700ad0b60b24ea3053828e1034797e9d35dc2b38deb112c1dcf6dfe1e5abc"
+  ]
+}
+x-maintenance-intent: ["(latest)"]

--- a/packages/UnifiedScript_Std/UnifiedScript_Std.2.4.2.160/opam
+++ b/packages/UnifiedScript_Std/UnifiedScript_Std.2.4.2.160/opam
@@ -1,0 +1,36 @@
+opam-version: "2.0"
+synopsis: "Unified scripts"
+maintainer: "Diskuv, Inc. <opensource+dkml@support.diskuv.com>"
+authors: "Diskuv, Inc. <opensource+dkml@support.diskuv.com>"
+license: "Apache-2.0"
+homepage: "https://github.com/diskuv/dk?tab=readme-ov-file"
+bug-reports: "https://gitlab.com/dkml/build-tools/MlFront/-/issues"
+depends: [
+  "dune" {>= "3.18"}
+  "ocaml" {>= "4.14"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://gitlab.com/dkml/build-tools/MlFront.git"
+url {
+  src:
+    "https://gitlab.com/dkml/build-tools/MlFront/-/releases/2.4.2.160/downloads/MlFront.tar.gz"
+  checksum: [
+    "md5=c6ca8e00038e5d519a0ea333b919ff3b"
+    "sha512=b0dc90e454454e8a7f11c1a7d729d493e9eb42ff6c0bdad81932cc0d5d32d0cfe48700ad0b60b24ea3053828e1034797e9d35dc2b38deb112c1dcf6dfe1e5abc"
+  ]
+}
+x-maintenance-intent: ["(latest)"]

--- a/packages/UnifiedScript_Top/UnifiedScript_Top.2.4.2.160/opam
+++ b/packages/UnifiedScript_Top/UnifiedScript_Top.2.4.2.160/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+synopsis: "OCaml toplevel unified tests"
+maintainer: "Diskuv, Inc. <opensource+dkml@support.diskuv.com>"
+authors: "Diskuv, Inc. <opensource+dkml@support.diskuv.com>"
+license: "Apache-2.0"
+homepage: "https://github.com/diskuv/dk?tab=readme-ov-file"
+bug-reports: "https://gitlab.com/dkml/build-tools/MlFront/-/issues"
+depends: [
+  "dune" {>= "3.18"}
+  "ocaml" {>= "4.14"}
+  "UnifiedScript_Std" {= version}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://gitlab.com/dkml/build-tools/MlFront.git"
+url {
+  src:
+    "https://gitlab.com/dkml/build-tools/MlFront/-/releases/2.4.2.160/downloads/MlFront.tar.gz"
+  checksum: [
+    "md5=c6ca8e00038e5d519a0ea333b919ff3b"
+    "sha512=b0dc90e454454e8a7f11c1a7d729d493e9eb42ff6c0bdad81932cc0d5d32d0cfe48700ad0b60b24ea3053828e1034797e9d35dc2b38deb112c1dcf6dfe1e5abc"
+  ]
+}
+x-maintenance-intent: ["(latest)"]


### PR DESCRIPTION
This pull-request concerns:
- `DkZero_Base.2.4.2.160`: Base modules for dk0
- `DkZero_Exec.2.4.2.160`: The single-threaded dk0 build system
- `DkZero_RuntimeC.2.4.2.160`: C runtime functions for dk0
- `MlFront_Cache.2.4.2.160`: Caching for MlFront
- `MlFront_Codept.2.4.2.160`: Utilities built on top of codept_lib
- `MlFront_Config.2.4.2.160`: Configuration for MlFront
- `MlFront_Console.2.4.2.160`: Console access for MlFront
- `MlFront_Core.2.4.2.160`: Module and library identification for MlFront
- `MlFront_Errors.2.4.2.160`: Error handling for MlFront
- `MlFront_Logs.2.4.2.160`: Logging for MlFront
- `MlFront_Lua.2.4.2.160`: Lua 2.5 embedded interpreter with no built-in globals and libraries
- `MlFront_Manip.2.4.2.160`: Binary manipulation tools for MlFront
- `MlFront_Progress.2.4.2.160`: Progress reporting API and builtin backends
- `MlFront_ProgressPeriod.2.4.2.160`: Periodic progress reporting for headless and accessible environments
- `MlFront_ProgressZig.2.4.2.160`: Zig compatible progress reporting for TUIs
- `MlFront_Signify.2.4.2.160`: OpenBSD compatible signify for MlFront
- `MlFront_Thunk.2.4.2.160`: Describes and runs reproducible units of work called thunks
- `MlFront_Tools.2.4.2.160`: Console access for MlFront
- `MlFront_ZipFile.2.4.2.160`: Zip files for MlFront
- `UnifiedScript_Std.2.4.2.160`: Unified scripts
- `UnifiedScript_Top.2.4.2.160`: OCaml toplevel unified tests



---
* Source repo: git+https://gitlab.com/dkml/build-tools/MlFront.git
* Bug tracker: https://gitlab.com/dkml/build-tools/MlFront/-/issues

---
:camel: Pull-request generated by opam-publish v3.0.0