### PR TITLE
Windows CI tweaks + conf-bzip2.1 fix

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -61,11 +61,24 @@ jobs:
       - name: Install packages
         run: |
           $failed = $false
+          function Skip-Until {
+            param(
+              [Parameter(Mandatory, Position=0)][string]$Pattern,
+              [Parameter(ValueFromPipeline)]$Line
+            )
+            begin { $found = $false }
+            process {
+              if ($found) { $Line }
+              elseif ($Line -match $Pattern) { $found = $true }
+            }
+          }
           Foreach ($pkg in '${{ matrix.packages }}' -split ' ') {
             Write-Host "::group::Testing `e[1;34m$pkg`e[0m"
             opam install --color=always --confirm-level=unsafe-yes "$pkg"
+            $install_exit_code = $LASTEXITCODE
+            opam config list $pkg.Split('.')[0] | Skip-Until ':opamfile'
             Write-Host "::endgroup::"
-            switch ($LASTEXITCODE) {
+            switch ($install_exit_code) {
               0 { Write-Host "`e[1;32m$pkg installed successfully`e[0m."; Break }
               5 { Write-Host "$pkg is not installable. `e[1;33mSkip`e[0m."; Break } # TODO: Remove when https://github.com/ocaml/opam/issues/6017 is fixed
               20 { Write-Host "$pkg is not installable. `e[1;33mSkip`e[0m."; Break }

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -74,7 +74,7 @@ jobs:
           }
           Foreach ($pkg in '${{ matrix.packages }}' -split ' ') {
             Write-Host "::group::Testing `e[1;34m$pkg`e[0m"
-            opam install --color=always --confirm-level=unsafe-yes "$pkg"
+            opam install -v --color=always --confirm-level=unsafe-yes "$pkg"
             $install_exit_code = $LASTEXITCODE
             opam config list $pkg.Split('.')[0] | Skip-Until ':opamfile'
             Write-Host "::endgroup::"

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -58,6 +58,11 @@ jobs:
           opam-pin: false
           windows-environment: ${{ matrix.windows_environment }}
 
+      - name: Initial state
+        run: |
+          Write-Host "# Switch invariant: `e[34m$(opam switch invariant)`e[0m"
+          opam list
+
       - name: Install packages
         run: |
           $failed = $false

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -95,4 +95,3 @@ jobs:
           if ($failed) {
             throw "One or more packages failed to build"
           }
-          Exit

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -60,11 +60,13 @@ jobs:
 
       - name: Initial state
         run: |
+          # commands
           Write-Host "# Switch invariant: `e[34m$(opam switch invariant)`e[0m"
           opam list
 
       - name: Install packages
         run: |
+          # package installations
           $failed = $false
           function Skip-Until {
             param(

--- a/packages/conf-bzip2/conf-bzip2.1/opam
+++ b/packages/conf-bzip2/conf-bzip2.1/opam
@@ -6,30 +6,20 @@ authors:      ["Julian Seward"]
 license:      "bzip2-1.0.6"
 
 build: [
-    "pkgconf"	    { (os = "win32" & os-distribution != "cygwinports")
-		      | os-distribution = "netbsd" }
-    "true"	    {os-distribution = "freebsd"
-		    # https://cgit.freebsd.org/ports/tree/archivers/bzip2/pkg-plist
-		    # missing libdata/pkgconfig/bzip2.pc
-		     | (os-distribution = "ubuntu" & os-version < 25)
-		    # https://packages.ubuntu.com/noble/libbz2-dev
-		    # missing /usr/share/pkgconfig/bzip2.pc
-		     | (os-distribution = "debian" & os-version < 13)	    
-		    # https://packages.debian.org/bookworm/amd64/libbz2-dev/filelist
-		    # missing /usr/share/pkgconfig/bzip2.pc
-		    }
-    "pkg-config"    { !((os = "win32" & os-distribution != "cygwinports")
-			 | os-distribution = "freebsd"
-			 | (os-distribution = "ubuntu" & os-version < 25)
-			 | os-distribution = "netbsd") }
-    "--personality=i686-w64-mingw32"
-		    {os = "win32" & os-distribution != "cygwinports"
-				  & host-arch-x86_32:installed}
-    "--personality=x86_64-w64-mingw32"
-		    {os = "win32" & os-distribution != "cygwinports"
-				  & host-arch-x86_64:installed}
+  "pkgconf" { (os = "win32" & os-distribution != "cygwinports") | os-distribution = "netbsd" }
+  "pkg-config" { !((os = "win32" & os-distribution != "cygwinports") | os-distribution = "netbsd") }
+    "--personality=i686-w64-mingw32" {os = "win32" & os-distribution = "cygwin" & host-arch-x86_32:installed}
+    "--personality=x86_64-w64-mingw32" {os = "win32" & os-distribution = "cygwin" & host-arch-x86_64:installed}
     "bzip2"
-]
+] {os-distribution != "freebsd"
+     # https://cgit.freebsd.org/ports/tree/archivers/bzip2/pkg-plist
+     # missing libdata/pkgconfig/bzip2.pc
+   & !(os-distribution = "ubuntu" & os-version < 25)
+     # https://packages.ubuntu.com/noble/libbz2-dev
+     # missing /usr/share/pkgconfig/bzip2.pc
+   & !(os-distribution = "debian" & os-version < 13)}
+     # https://packages.debian.org/bookworm/amd64/libbz2-dev/filelist
+     # missing /usr/share/pkgconfig/bzip2.pc
 
 depends: [
   "conf-pkg-config"	    {build}

--- a/packages/conf-bzip2/conf-bzip2.1/opam
+++ b/packages/conf-bzip2/conf-bzip2.1/opam
@@ -8,8 +8,6 @@ license:      "bzip2-1.0.6"
 build: [
   "pkgconf" { (os = "win32" & os-distribution != "cygwinports") | os-distribution = "netbsd" }
   "pkg-config" { !((os = "win32" & os-distribution != "cygwinports") | os-distribution = "netbsd") }
-    "--personality=i686-w64-mingw32" {os = "win32" & os-distribution = "cygwin" & host-arch-x86_32:installed}
-    "--personality=x86_64-w64-mingw32" {os = "win32" & os-distribution = "cygwin" & host-arch-x86_64:installed}
     "bzip2"
 ] {os-distribution != "freebsd"
      # https://cgit.freebsd.org/ports/tree/archivers/bzip2/pkg-plist
@@ -17,9 +15,12 @@ build: [
    & !(os-distribution = "ubuntu" & os-version < 25)
      # https://packages.ubuntu.com/noble/libbz2-dev
      # missing /usr/share/pkgconfig/bzip2.pc
-   & !(os-distribution = "debian" & os-version < 13)}
+   & !(os-distribution = "debian" & os-version < 13)
      # https://packages.debian.org/bookworm/amd64/libbz2-dev/filelist
      # missing /usr/share/pkgconfig/bzip2.pc
+   & !(os = "win32" & os-distribution = "cygwin")}
+     # https://cygwin.com/cgi-bin2/package-cat.cgi?file=noarch%2Fmingw64-x86_64-bzip2%2Fmingw64-x86_64-bzip2-1.0.6-4
+     # no bzip2.pc file in cygwin package
 
 depends: [
   "conf-pkg-config"	    {build}


### PR DESCRIPTION
I've been doing a fair bit of tweaking on these packages recently, and accrued a few possibly useful tweaks to the Windows CI workflow, which are here for consideration. In order for them to have something to test, I've included a refactor of conf-bzip.1 to eliminate the use of `true` in the same way as in https://github.com/ocaml/opam-repository/pull/29795/changes/22a81ff0978a7028c17e101b2d2ab4cdbe2891a9. The package is also updated not to fail on Cygwin.

Given the number of mistakes I made while testing it, conf-bzip.1 is worth staring carefully at! The idea, extracted from the existing package, is that:
- FreeBSD, Ubuntu (before 25.04), Debian (before 13) and Cygwin should not attempt to detect the package using pkg-config, because these platforms don't configure pkg-config correctly for the bzip2 package
- NetBSD and MSYS2 should call `pkgconf`
- Everything else should call `pkg-config`

That should be correctly expressed! The CI changes are:
- Display any variables the package exported in its .config file. No demo in this PR, but for example, that adds lines like:
```
ocaml-env-msvc64:package   Visual Studio Community 2026 (18.5.11723.231)
ocaml-env-msvc64:script    "C:\Program Files\Microsoft Visual Studio\18\Community\VC\Auxiliary\Build\vcvarsall.bat" x64
ocaml-env-msvc64:ml        ml64
```
which is useful
- Likewise, it's useful to have confirmation of exactly what was installed by setup-ocaml, and I've added a stage which displays the switch invariant and installed packages
- opam-repo-ci doesn't, but it's handy when debugging to be able to see which commands were run (especially when debugging filters like the one's in conf-bzip2.1 and so forth), and adding `-v` to the `opam install` gives some potentially useful extra information when scratching one's head figuring out what happened in CI...
- A couple of minor cosmetic tweaks (weird "Run" folds suppressed by adding comments at the start of the PowerShell blocks and a redundant `Exit` removed)