### PR TITLE
[new release] awso (6 packages) (0.9.0)

### DIFF
--- a/packages/awso-async/awso-async.0.9.0/opam
+++ b/packages/awso-async/awso-async.0.9.0/opam
@@ -1,0 +1,52 @@
+opam-version: "2.0"
+synopsis:
+  "AWS client for Async (400+ services, auto-generated from botocore)"
+description:
+  "AWS service bindings backed by Jane Street's Async I/O library. Generated from botocore for ~400 services. Use this if your codebase is already Async-flavored."
+maintainer: ["Michael Bacarella <m@bacarella.com>"]
+authors: [
+  "Ashish Agarwal <ashish@solvuu.com>"
+  "Solvuu Inc."
+  "Michael Bacarella <m@bacarella.com>"
+]
+license: "MIT"
+homepage: "https://github.com/mbacarella/ocaml-awso"
+doc: "https://mbacarella.github.io/ocaml-awso/"
+bug-reports: "https://github.com/mbacarella/ocaml-awso/issues"
+depends: [
+  "dune" {>= "3.6"}
+  "ocaml" {>= "5.3.0"}
+  "awso"
+  "cohttp-async"
+  "core_unix" {>= "v0.16.0"}
+  "ppx_jane" {>= "v0.16.0"}
+  "ppx_yojson_conv"
+  "async" {>= "v0.16.0"}
+  "async_ssl" {>= "v0.16.1-1" & != "v0.17.0"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/mbacarella/ocaml-awso.git"
+available: [ os != "win32" ]
+url {
+  src:
+    "https://github.com/mbacarella/ocaml-awso/releases/download/0.9.0/awso-0.9.0.tbz"
+  checksum: [
+    "sha256=47224890900b1f5d2bd717000a02fa8918f92eafa99f702f7d59a1b053ff8e95"
+    "sha512=e187288f7c8fccb221f5417671732c8c8de95cdbacba1514db592b5700df2293468bde07956539bd44f3d460f6c75d38bd66ca161d0eae68a8b1b4e081882367"
+  ]
+}
+x-commit-hash: "988cdf43a574cc0b4c1375e37e56c43e6ea12d16"

--- a/packages/awso-cli/awso-cli.0.9.0/opam
+++ b/packages/awso-cli/awso-cli.0.9.0/opam
@@ -1,0 +1,47 @@
+opam-version: "2.0"
+synopsis: "A pure OCaml aws-cli covering 400+ services"
+description:
+  "For fun, an umbrella command-line binary that exposes every awso-async service as a subcommand, similar in spirit to the Python aws-cli. Ships as bytecode because linking ~400 native service libraries exceeds ARM64 executable sizes. Fast enough for interactive use."
+maintainer: ["Michael Bacarella <m@bacarella.com>"]
+authors: [
+  "Ashish Agarwal <ashish@solvuu.com>"
+  "Solvuu Inc."
+  "Michael Bacarella <m@bacarella.com>"
+]
+license: "MIT"
+homepage: "https://github.com/mbacarella/ocaml-awso"
+doc: "https://mbacarella.github.io/ocaml-awso/"
+bug-reports: "https://github.com/mbacarella/ocaml-awso/issues"
+depends: [
+  "dune" {>= "3.6"}
+  "ocaml" {>= "5.3.0"}
+  "awso-async"
+  "core_unix" {>= "v0.16.0"}
+  "ppx_jane" {>= "v0.16.0"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/mbacarella/ocaml-awso.git"
+available: [ os != "win32" ]
+url {
+  src:
+    "https://github.com/mbacarella/ocaml-awso/releases/download/0.9.0/awso-0.9.0.tbz"
+  checksum: [
+    "sha256=47224890900b1f5d2bd717000a02fa8918f92eafa99f702f7d59a1b053ff8e95"
+    "sha512=e187288f7c8fccb221f5417671732c8c8de95cdbacba1514db592b5700df2293468bde07956539bd44f3d460f6c75d38bd66ca161d0eae68a8b1b4e081882367"
+  ]
+}
+x-commit-hash: "988cdf43a574cc0b4c1375e37e56c43e6ea12d16"

--- a/packages/awso-common/awso-common.0.9.0/opam
+++ b/packages/awso-common/awso-common.0.9.0/opam
@@ -1,0 +1,45 @@
+opam-version: "2.0"
+synopsis: "AWSO common library"
+description:
+  "Small compatibility shim providing Jane Street Core-like helpers (Result, Option, List combinators) without dragging Core itself into non-Async/Lwt builds. Used by awso and the codegen."
+maintainer: ["Michael Bacarella <m@bacarella.com>"]
+authors: [
+  "Ashish Agarwal <ashish@solvuu.com>"
+  "Solvuu Inc."
+  "Michael Bacarella <m@bacarella.com>"
+]
+license: "MIT"
+homepage: "https://github.com/mbacarella/ocaml-awso"
+doc: "https://mbacarella.github.io/ocaml-awso/"
+bug-reports: "https://github.com/mbacarella/ocaml-awso/issues"
+depends: [
+  "dune" {>= "3.6"}
+  "ocaml" {>= "5.3.0"}
+  "ppx_expect"
+  "yojson" {>= "2.0.0"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/mbacarella/ocaml-awso.git"
+url {
+  src:
+    "https://github.com/mbacarella/ocaml-awso/releases/download/0.9.0/awso-0.9.0.tbz"
+  checksum: [
+    "sha256=47224890900b1f5d2bd717000a02fa8918f92eafa99f702f7d59a1b053ff8e95"
+    "sha512=e187288f7c8fccb221f5417671732c8c8de95cdbacba1514db592b5700df2293468bde07956539bd44f3d460f6c75d38bd66ca161d0eae68a8b1b4e081882367"
+  ]
+}
+x-commit-hash: "988cdf43a574cc0b4c1375e37e56c43e6ea12d16"

--- a/packages/awso-lwt/awso-lwt.0.9.0/opam
+++ b/packages/awso-lwt/awso-lwt.0.9.0/opam
@@ -1,0 +1,47 @@
+opam-version: "2.0"
+synopsis: "AWS client for Lwt (400+ services, auto-generated from botocore)"
+description:
+  "AWS service bindings backed by the Lwt I/O library. Generated from botocore for ~400 services. Use this if your codebase is Lwt-flavored."
+maintainer: ["Michael Bacarella <m@bacarella.com>"]
+authors: [
+  "Ashish Agarwal <ashish@solvuu.com>"
+  "Solvuu Inc."
+  "Michael Bacarella <m@bacarella.com>"
+]
+license: "MIT"
+homepage: "https://github.com/mbacarella/ocaml-awso"
+doc: "https://mbacarella.github.io/ocaml-awso/"
+bug-reports: "https://github.com/mbacarella/ocaml-awso/issues"
+depends: [
+  "dune" {>= "3.6"}
+  "ocaml" {>= "5.3.0"}
+  "awso"
+  "lwt"
+  "lwt_ppx"
+  "cohttp-lwt-unix"
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/mbacarella/ocaml-awso.git"
+url {
+  src:
+    "https://github.com/mbacarella/ocaml-awso/releases/download/0.9.0/awso-0.9.0.tbz"
+  checksum: [
+    "sha256=47224890900b1f5d2bd717000a02fa8918f92eafa99f702f7d59a1b053ff8e95"
+    "sha512=e187288f7c8fccb221f5417671732c8c8de95cdbacba1514db592b5700df2293468bde07956539bd44f3d460f6c75d38bd66ca161d0eae68a8b1b4e081882367"
+  ]
+}
+x-commit-hash: "988cdf43a574cc0b4c1375e37e56c43e6ea12d16"

--- a/packages/awso-sync/awso-sync.0.9.0/opam
+++ b/packages/awso-sync/awso-sync.0.9.0/opam
@@ -1,0 +1,47 @@
+opam-version: "2.0"
+synopsis:
+  "Synchronous (blocking) AWS client (400+ services, auto-generated from botocore)"
+description:
+  "AWS service bindings with a synchronous (blocking) I/O backend implemented over libcurl. Generated from botocore for ~400 services. Useful for scripts, CLIs, and any context where pulling in a concurrent scheduler is overkill."
+maintainer: ["Michael Bacarella <m@bacarella.com>"]
+authors: [
+  "Ashish Agarwal <ashish@solvuu.com>"
+  "Solvuu Inc."
+  "Michael Bacarella <m@bacarella.com>"
+]
+license: "MIT"
+homepage: "https://github.com/mbacarella/ocaml-awso"
+doc: "https://mbacarella.github.io/ocaml-awso/"
+bug-reports: "https://github.com/mbacarella/ocaml-awso/issues"
+depends: [
+  "dune" {>= "3.6"}
+  "ocaml" {>= "5.3.0"}
+  "awso"
+  "ocurl"
+  "ppx_expect"
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/mbacarella/ocaml-awso.git"
+url {
+  src:
+    "https://github.com/mbacarella/ocaml-awso/releases/download/0.9.0/awso-0.9.0.tbz"
+  checksum: [
+    "sha256=47224890900b1f5d2bd717000a02fa8918f92eafa99f702f7d59a1b053ff8e95"
+    "sha512=e187288f7c8fccb221f5417671732c8c8de95cdbacba1514db592b5700df2293468bde07956539bd44f3d460f6c75d38bd66ca161d0eae68a8b1b4e081882367"
+  ]
+}
+x-commit-hash: "988cdf43a574cc0b4c1375e37e56c43e6ea12d16"

--- a/packages/awso/awso.0.9.0/opam
+++ b/packages/awso/awso.0.9.0/opam
@@ -1,0 +1,53 @@
+opam-version: "2.0"
+synopsis:
+  "AWS API base library (400+ services, auto-generated from botocore)"
+description:
+  "Logic-only runtime for the awso family of packages: request signing (SigV4), HTTP plumbing, credential discovery, region/endpoint tables, and shared types. I/O bindings live in sibling packages (awso-async, awso-lwt, awso-sync)."
+maintainer: ["Michael Bacarella <m@bacarella.com>"]
+authors: [
+  "Ashish Agarwal <ashish@solvuu.com>"
+  "Solvuu Inc."
+  "Michael Bacarella <m@bacarella.com>"
+]
+license: "MIT"
+homepage: "https://github.com/mbacarella/ocaml-awso"
+doc: "https://mbacarella.github.io/ocaml-awso/"
+bug-reports: "https://github.com/mbacarella/ocaml-awso/issues"
+depends: [
+  "dune" {>= "3.6"}
+  "ocaml" {>= "5.3.0"}
+  "awso-common"
+  "cohttp" {>= "0.21.0"}
+  "cryptokit"
+  "ppx_expect"
+  "ppx_yojson_conv"
+  "re" {>= "1.7.2"}
+  "xmlm"
+  "yojson" {>= "2.0.0"}
+  "zarith"
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/mbacarella/ocaml-awso.git"
+url {
+  src:
+    "https://github.com/mbacarella/ocaml-awso/releases/download/0.9.0/awso-0.9.0.tbz"
+  checksum: [
+    "sha256=47224890900b1f5d2bd717000a02fa8918f92eafa99f702f7d59a1b053ff8e95"
+    "sha512=e187288f7c8fccb221f5417671732c8c8de95cdbacba1514db592b5700df2293468bde07956539bd44f3d460f6c75d38bd66ca161d0eae68a8b1b4e081882367"
+  ]
+}
+x-commit-hash: "988cdf43a574cc0b4c1375e37e56c43e6ea12d16"


### PR DESCRIPTION
AWS API base library (400+ services, auto-generated from botocore)

- Project page: <a href="https://github.com/mbacarella/ocaml-awso">https://github.com/mbacarella/ocaml-awso</a>
- Documentation: <a href="https://mbacarella.github.io/ocaml-awso/">https://mbacarella.github.io/ocaml-awso/</a>

##### CHANGES:

Initial opam release, forked from [solvuu/awsm](https://github.com/solvuu/awsm), which was itself never released to opam.

### Architectural changes since the fork

- Replaced the lightweight higher kinded polymorphism with a functorized approach. (End users don't need to instantiate the functors, it's already done in the library)
- Restructured `aws/` into `aws/<service>/{async,lwt,sync}/`, each backend ships only what it needs.
- Eliminated the `Transport` variant from API responses; only AWS-side errors stay in `Result`, transport errors raise, similar to the convention Async follows.
- As advised by opam-repository crew, consolidated the per-service opam packages into sub-libraries under each backend. `opam install awso-async` pulls in every service binding under `awso-async.<svc>`. Same for `-lwt` and `-sync`.
- Pre-generate the `aws/` tree and commit it. opam install no longer runs the codegen, which means end users require ~25 less packages in their dependency cone.

### New stuff

- `awso-sync`: synchronous (blocking) backend implemented over libcurl. For scripts and CLIs where pulling in an async scheduler is overkill
- `awso-cli`: for fun, an everything including the kitchen sink binary that exposes every awso-async service as a composable subcommand, similar in spirit to the python aws-cli. Ships as bytecode because linking ~400 native service libraries exceeds ARM64 executable assembly size limits
- `dogfood/` tools used by maintainers to develop awso

### Compatibility & dep hygiene

- minimum OCaml is 4.14
- now on dune 3.6
- removed Jane Street `Core` from the non-Async runtimes; non-async builds now use a very small `Jane_compat` shim under `lib/common/`
- replaced ad-hoc JSON with `Yojson.Safe.t` everywhere

### Code generation changes

- Freshened to [botocore 1.43.9](https://github.com/boto/botocore/releases/tag/1.43.9)
- Huge precomputed `endpoints.json` match table replaced with a memoised lookup
- Output shapes treat `required` as advisory. AWS itself routinely omits fields it marks required (`AccessDeniedException` with no `Message`, `GeocodeResponse` with no `PricingBucket`), so deserializers don't blow up when the service lies about its own spec. Input shapes still respect `required`. shim for newer services whose hostname doesn't follow `endpointPrefix` conventions (geo-places, geo-maps, geo-routes, iot-data, sso). snake-case and endpoint name/wire name fixes
- Escape odoc special characters in generated doc comments
- 22 retired AWS services that were dropped from botocore

See [TODO.md](./TODO.md) for things known to still be rough
