### PR TITLE
[new release] out-channel-redirect (0.2)

### DIFF
--- a/packages/out-channel-redirect/out-channel-redirect.0.2/opam
+++ b/packages/out-channel-redirect/out-channel-redirect.0.2/opam
@@ -29,7 +29,6 @@ build: [
     "-j"
     jobs
     "@install"
-    "@runtest" {with-test}
     "@doc" {with-doc}
   ]
 ]

--- a/packages/out-channel-redirect/out-channel-redirect.0.2/opam
+++ b/packages/out-channel-redirect/out-channel-redirect.0.2/opam
@@ -1,0 +1,45 @@
+opam-version: "2.0"
+synopsis: "Redirect and capture output written to out_channels"
+description: """
+An OCaml library for redirecting and capturing output written to out_channels, with support
+for native, JavaScript (js_of_ocaml), and WebAssembly (wasm_of_ocaml) targets."""
+maintainer: ["hugo.heuzard@gmail.com"]
+authors: ["Hugo Heuzard"]
+license: "MIT"
+homepage: "https://github.com/hhugo/out-channel-redirect"
+doc: "https://ocaml.org/p/out-channel-redirect"
+bug-reports: "https://github.com/hhugo/out-channel-redirect/issues"
+depends: [
+  "dune" {>= "3.17"}
+  "ocaml" {>= "4.11"}
+  "ocamlformat" {= "0.28.1" & with-dev-setup}
+  "js_of_ocaml" {with-test}
+  "odoc" {with-doc}
+]
+depopts: [
+  "wasm_of_ocaml-compiler" {with-test}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/hhugo/out-channel-redirect.git"
+url {
+  src:
+    "https://github.com/hhugo/out-channel-redirect/releases/download/0.2/out-channel-redirect-0.2.tbz"
+  checksum: [
+    "sha256=ad427e8dd36fe18347cc4a574af17777e0650f5585345fab582ceefb16ee219e"
+    "sha512=3e186e5f9b40979f4909d772eb6475ed587f997ad392c85b62c8c1f81a89cd20d44624832b82939ca2833a560c3244123a7d33a66581c94243ff8eef69a96640"
+  ]
+}
+x-commit-hash: "37dcaa8ebf5cddc23288afb30c27cc2035790d02"


### PR DESCRIPTION
Redirect and capture output written to out_channels

- Project page: <a href="https://github.com/hhugo/out-channel-redirect">https://github.com/hhugo/out-channel-redirect</a>
- Documentation: <a href="https://ocaml.org/p/out-channel-redirect">https://ocaml.org/p/out-channel-redirect</a>

##### CHANGES:

- Add `capture_channels` and `capture_channels_interleaved` for capturing
  a list of channels (separately or merged into one string)
- Add `capture_outputs` and `capture_outputs_interleaved` for stdout and
  stderr (separately or merged)
- `capture` is now an alias for `capture_outputs_interleaved`
- Raise OCaml lower bound to 4.11
