### PR TITLE
Add an ocaml.5.5 upper bound on lwt.5.10.0

### DIFF
--- a/packages/lwt/lwt.5.10.0/opam
+++ b/packages/lwt/lwt.5.10.0/opam
@@ -21,7 +21,7 @@ doc: "https://ocsigen.org/lwt"
 bug-reports: "https://github.com/ocsigen/lwt/issues"
 depends: [
   "dune" {>= "3.15"}
-  "ocaml" {>= "4.08"}
+  "ocaml" {>= "4.08" & < "5.5"}
   "cppo" {build & >= "1.1"}
   "ocamlfind" {dev & >= "1.7.3-1"}
   "odoc" {with-doc & >= "2.3"}


### PR DESCRIPTION
Spotted on #29916 and confirmed locally:
```
#=== ERROR while compiling lwt.5.10.0 =========================================#
# context              2.5.1 | linux/x86_64 | ocaml-base-compiler.5.5.0~beta1 | file:///home/opam/opam-repository
# path                 ~/.opam/5.5~beta1/.opam-switch/build/lwt.5.10.0
# command              ~/.opam/opam-init/hooks/sandbox.sh build dune build -p lwt -j 71 @install
# exit-code            1
# env-file             ~/.opam/log/lwt-7-d71a51.env
# output-file          ~/.opam/log/lwt-7-d71a51.out
### output ###
# File "src/unix/dune", line 90, characters 3-18:
# 90 |    unix_bytes_send
#         ^^^^^^^^^^^^^^^
# (cd _build/default/src/unix && /usr/bin/gcc -Wall -fdiagnostics-color=always -fPIC -pthread -g -I /home/opam/.opam/5.5~beta1/lib/ocaml -I /home/opam/.opam/5.5~beta1/lib/bytes -I /home/opam/.opam/5.5~beta1/lib/ocaml/threads -I /home/opam/.opam/5.5~beta1/lib/ocaml/unix -I /home/opam/.opam/5.5~beta1/lib/ocplib-endian -I /home/opam/.opam/5.5~beta1/lib/ocplib-endian/bigstring -I ../core -o unix_bytes_send.o -c unix_bytes_send.c)
# In file included from lwt_unix.h:14,
#                  from unix_bytes_send.c:17:
# /home/opam/.opam/5.5~beta1/lib/ocaml/caml/socketaddr.h:117:5: error: expected declaration specifiers or '...' before '(' token
#   117 |     (vaddr),                                                  \
#       |     ^
# /home/opam/.opam/5.5~beta1/lib/ocaml/caml/socketaddr.h:69:22: note: in expansion of macro 'caml_unix_get_sockaddr'
#    69 | #define get_sockaddr caml_unix_get_sockaddr
#       |                      ^~~~~~~~~~~~~~~~~~~~~~
# unix_recv_send_utils.h:48:13: note: in expansion of macro 'get_sockaddr'
#    48 | extern void get_sockaddr(value mladdr, union sock_addr_union *addr /*out*/,
#       |             ^~~~~~~~~~~~
# /home/opam/.opam/5.5~beta1/lib/ocaml/caml/socketaddr.h:118:5: error: expected declaration specifiers or '...' before '_Generic'
#   118 |     _Generic((addr),                                          \
#       |     ^~~~~~~~
# /home/opam/.opam/5.5~beta1/lib/ocaml/caml/socketaddr.h:69:22: note: in expansion of macro 'caml_unix_get_sockaddr'
#    69 | #define get_sockaddr caml_unix_get_sockaddr
#       |                      ^~~~~~~~~~~~~~~~~~~~~~
# unix_recv_send_utils.h:48:13: note: in expansion of macro 'get_sockaddr'
#    48 | extern void get_sockaddr(value mladdr, union sock_addr_union *addr /*out*/,
#       |             ^~~~~~~~~~~~
# /home/opam/.opam/5.5~beta1/lib/ocaml/caml/socketaddr.h:122:5: error: expected declaration specifiers or '...' before '(' token
#   122 |     (addr_len))
#       |     ^
# /home/opam/.opam/5.5~beta1/lib/ocaml/caml/socketaddr.h:69:22: note: in expansion of macro 'caml_unix_get_sockaddr'
#    69 | #define get_sockaddr caml_unix_get_sockaddr
#       |                      ^~~~~~~~~~~~~~~~~~~~~~
# unix_recv_send_utils.h:48:13: note: in expansion of macro 'get_sockaddr'
#    48 | extern void get_sockaddr(value mladdr, union sock_addr_union *addr /*out*/,
#       |             ^~~~~~~~~~~~

[...[
```