### PR TITLE
Raise the ocaml lower bound for dune-configurator.3.23.0 to 4.14 too

### DIFF
--- a/packages/dune-configurator/dune-configurator.3.23.0/opam
+++ b/packages/dune-configurator/dune-configurator.3.23.0/opam
@@ -18,7 +18,7 @@ doc: "https://dune.readthedocs.io/"
 bug-reports: "https://github.com/ocaml/dune/issues"
 depends: [
   "dune" {>= "3.23"}
-  "ocaml" {>= "4.08.0"}
+  "ocaml" {>= "4.14.0"}
   "base-unix"
   "csexp" {>= "1.5.0"}
   "odoc" {with-doc}


### PR DESCRIPTION
Spotted on #29923:

The `dune.3.23.1` release in #29903 put an ocaml lower bound of 4.14 for `dune-configurator.3.23.1`.
However `dune-configurator.3.23.0` still has an `ocaml.4.08` lower bound, causing it not to build on, e.g., `4.11`:
https://opam.ci.ocaml.org/github/ocaml/opam-repository/commit/d5e0b8893f59724e3d70feb1ebbc1a6d041da68c/variant/compilers,4.11,lwt.5.10.0
```
#=== ERROR while compiling dune-configurator.3.23.0 ===========================#
# context              2.5.1 | linux/x86_64 | ocaml-base-compiler.4.11.2 | file:///home/opam/opam-repository
# path                 ~/.opam/4.11/.opam-switch/build/dune-configurator.3.23.0
# command              ~/.opam/opam-init/hooks/sandbox.sh build dune build -p dune-configurator -j 71 @install
# exit-code            1
# env-file             ~/.opam/log/dune-configurator-7-f15793.env
# output-file          ~/.opam/log/dune-configurator-7-f15793.out
### output ###
# (cd _build/default && /home/opam/.opam/4.11/bin/ocamlc.opt -w @1..3@5..28@31..39@43@46..47@49..57@61..62@67@69-40 -strict-sequence -strict-formats -safe-string -g -bin-annot -I otherlibs/configurator/src/.configurator.objs/byte -I otherlibs/configurator/src/.configurator.objs/public_cmi -I /home/opam/.opam/4.11/lib/csexp -intf-suffix .ml -no-alias-deps -open Configurator__ -o otherlibs/configurator/src/.configurator.objs/byte/configurator__V1.cmo -c -impl otherlibs/configurator/src/v1.ml)
# File "otherlibs/configurator/src/v1.ml", line 100, characters 18-34:
# 100 |       let fn = if String.ends_with ~suffix:exe prog then prog else prog ^ exe in
#                         ^^^^^^^^^^^^^^^^
# Error: Unbound value String.ends_with
# (cd _build/default && /home/opam/.opam/4.11/bin/ocamlopt.opt -w @1..3@5..28@31..39@43@46..47@49..57@61..62@67@69-40 -strict-sequence -strict-formats -safe-string -g -I otherlibs/configurator/src/.configurator.objs/byte -I otherlibs/configurator/src/.configurator.objs/native -I otherlibs/configurator/src/.configurator.objs/public_cmi -I /home/opam/.opam/4.11/lib/csexp -intf-suffix .ml -no-alias-deps -open Configurator__ -o otherlibs/configurator/src/.configurator.objs/native/configurator__V1.cmx -c -impl otherlibs/configurator/src/v1.ml)
# File "otherlibs/configurator/src/v1.ml", line 100, characters 18-34:
# 100 |       let fn = if String.ends_with ~suffix:exe prog then prog else prog ^ exe in
#                         ^^^^^^^^^^^^^^^^
# Error: Unbound value String.ends_with
```

This PR thus sets the same `ocaml.4.14` bound in `dune-configurator.3.23.0` as in `dune-configurator.3.23.1`, following the recommendation in https://github.com/ocaml/dune/issues/14548