### PR TITLE
Package visitors.20260520

### DIFF
--- a/packages/visitors/visitors.20260520/opam
+++ b/packages/visitors/visitors.20260520/opam
@@ -14,7 +14,6 @@ depends: [
   "ocaml" {>= "4.14.2"}
   "ppxlib" {>= "0.37.0"}
   "ppx_deriving" {>= "5.0"}
-  "result"
   "dune" {>= "2.0"}
 ]
 synopsis: "An OCaml syntax extension for generating visitor classes"

--- a/packages/visitors/visitors.20260520/opam
+++ b/packages/visitors/visitors.20260520/opam
@@ -14,6 +14,7 @@ depends: [
   "ocaml" {>= "4.14.2"}
   "ppxlib" {>= "0.37.0"}
   "ppx_deriving" {>= "5.0"}
+  "result"
   "dune" {>= "2.0"}
 ]
 synopsis: "An OCaml syntax extension for generating visitor classes"

--- a/packages/visitors/visitors.20260520/opam
+++ b/packages/visitors/visitors.20260520/opam
@@ -1,0 +1,33 @@
+opam-version: "2.0"
+maintainer: "francois.pottier@inria.fr"
+authors: [
+  "François Pottier <francois.pottier@inria.fr>"
+]
+homepage: "https://gitlab.inria.fr/fpottier/visitors"
+dev-repo: "git+https://gitlab.inria.fr/fpottier/visitors.git"
+bug-reports: "francois.pottier@inria.fr"
+license: "LGPL-2.1-only WITH OCaml-LGPL-linking-exception"
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "ocaml" {>= "4.14.2"}
+  "ppxlib" {>= "0.37.0"}
+  "ppx_deriving" {>= "5.0"}
+  "result"
+  "dune" {>= "2.0"}
+]
+synopsis: "An OCaml syntax extension for generating visitor classes"
+description: """
+Annotating an algebraic data type definition with [@@deriving visitors { ... }]
+causes visitor classes to be automatically generated. A visitor is an object
+that knows how to traverse and transform a data structure."""
+x-maintenance-intent: ["(latest)"]
+url {
+  src:
+    "https://gitlab.inria.fr/fpottier/visitors/-/archive/20260520/archive.tar.gz"
+  checksum: [
+    "md5=d0adee657412e542b07b3b8f6eb6409c"
+    "sha512=a8a008f18ef2c7cf77d9e7978bdfde322d3d62a52ce70af2fa0169c36f979a515b6edacf8af2b718d0f49bb3f0c52155366ff450e41fe6b71b8ccc1439dfc812"
+  ]
+}


### PR DESCRIPTION
### `visitors.20260520`
An OCaml syntax extension for generating visitor classes
Annotating an algebraic data type definition with [@@deriving visitors { ... }]
causes visitor classes to be automatically generated. A visitor is an object
that knows how to traverse and transform a data structure.



---
* Homepage: https://gitlab.inria.fr/fpottier/visitors
* Source repo: git+https://gitlab.inria.fr/fpottier/visitors.git
* Bug tracker: francois.pottier@inria.fr

---
:camel: Pull-request generated by opam-publish v2.3.0