### PR TITLE
3 packages from ocurrent/ocaml-dockerfile at 8.4.0

### DIFF
--- a/packages/dockerfile-cmd/dockerfile-cmd.8.4.0/opam
+++ b/packages/dockerfile-cmd/dockerfile-cmd.8.4.0/opam
@@ -64,7 +64,7 @@ build: [
 dev-repo: "git+https://github.com/ocurrent/ocaml-dockerfile.git"
 url {
   src:
-    "https://github.com/ocurrent/ocaml-dockerfile/releases/download/v8.4.0/ocaml-dockerfile-8.4.0.tbz"
+    "https://github.com/ocurrent/ocaml-dockerfile/releases/download/8.4.0/ocaml-dockerfile-8.4.0.tbz"
   checksum: [
     "md5=955846375a80ed2cfd26749b92ea6dc4"
     "sha512=4be3497556761c570a6962ee2b5950bcc05f564d94a6a870ede6904f026e08f3ee2de7a9fa8dcd27a3a7c9acaa5e550cba4aef8bab7d617067fae739a43f9169"

--- a/packages/dockerfile-cmd/dockerfile-cmd.8.4.0/opam
+++ b/packages/dockerfile-cmd/dockerfile-cmd.8.4.0/opam
@@ -1,0 +1,73 @@
+opam-version: "2.0"
+synopsis: "Dockerfile eDSL -- generation support"
+description: """\
+This library provides a typed OCaml interface to generating Dockerfiles
+programmatically without having to resort to lots of shell scripting and
+awk/sed-style assembly.
+
+This sublibrary has support functions for generating arrays of Dockerfiles
+programmatically."""
+maintainer: [
+  "Anil Madhavapeddy <anil@recoil.org>"
+  "Antonin Décimo <antonin@tarides.com>"
+  "David Allsopp <david.allsopp@metastack.com>"
+  "Kate <kit.ty.kate@disroot.org>"
+  "Thomas Leonard <talex5@gmail.com>"
+  "Tim McGilchrist <timmcgil@gmail.com>"
+]
+authors: [
+  "Anil Madhavapeddy"
+  "Anton Kochkov"
+  "Antonin Décimo"
+  "David Allsopp"
+  "Ewan Mellor"
+  "Kate Deplaix"
+  "Louis Gesbert"
+  "Mark Elvers"
+  "Thomas Leonard"
+  "Tim McGilchrist"
+]
+license: "ISC"
+tags: ["org:mirage" "org:ocamllabs"]
+homepage: "https://github.com/ocurrent/ocaml-dockerfile"
+bug-reports: "https://github.com/ocurrent/ocaml-dockerfile/issues"
+depends: [
+  "dune" {>= "3.20"}
+  "astring"
+  "bos" {>= "0.2"}
+  "cmdliner"
+  "dockerfile-opam" {= version}
+  "fmt" {>= "0.8.7"}
+  "logs"
+  "ppx_sexp_conv" {>= "v0.9.0"}
+  "sexplib0"
+  "odoc" {with-doc}
+]
+conflicts: [
+  "result" {< "1.5"}
+  "rresult" {< "0.7.0"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/ocurrent/ocaml-dockerfile.git"
+url {
+  src:
+    "https://github.com/ocurrent/ocaml-dockerfile/releases/download/v8.4.0/ocaml-dockerfile-8.4.0.tbz"
+  checksum: [
+    "md5=955846375a80ed2cfd26749b92ea6dc4"
+    "sha512=4be3497556761c570a6962ee2b5950bcc05f564d94a6a870ede6904f026e08f3ee2de7a9fa8dcd27a3a7c9acaa5e550cba4aef8bab7d617067fae739a43f9169"
+  ]
+}
+x-maintenance-intent: ["(latest)"]

--- a/packages/dockerfile-opam/dockerfile-opam.8.4.0/opam
+++ b/packages/dockerfile-opam/dockerfile-opam.8.4.0/opam
@@ -62,7 +62,7 @@ build: [
 dev-repo: "git+https://github.com/ocurrent/ocaml-dockerfile.git"
 url {
   src:
-    "https://github.com/ocurrent/ocaml-dockerfile/releases/download/v8.4.0/ocaml-dockerfile-8.4.0.tbz"
+    "https://github.com/ocurrent/ocaml-dockerfile/releases/download/8.4.0/ocaml-dockerfile-8.4.0.tbz"
   checksum: [
     "md5=955846375a80ed2cfd26749b92ea6dc4"
     "sha512=4be3497556761c570a6962ee2b5950bcc05f564d94a6a870ede6904f026e08f3ee2de7a9fa8dcd27a3a7c9acaa5e550cba4aef8bab7d617067fae739a43f9169"

--- a/packages/dockerfile-opam/dockerfile-opam.8.4.0/opam
+++ b/packages/dockerfile-opam/dockerfile-opam.8.4.0/opam
@@ -1,0 +1,71 @@
+opam-version: "2.0"
+synopsis: "Dockerfile eDSL -- opam support"
+description: """\
+This library provides a typed OCaml interface to generating Dockerfiles
+programmatically without having to resort to lots of shell scripting and
+awk/sed-style assembly.
+
+The opam subpackage provides opam and Linux-specific distribution support
+for generating dockerfiles."""
+maintainer: [
+  "Anil Madhavapeddy <anil@recoil.org>"
+  "Antonin Décimo <antonin@tarides.com>"
+  "David Allsopp <david.allsopp@metastack.com>"
+  "Kate <kit.ty.kate@disroot.org>"
+  "Thomas Leonard <talex5@gmail.com>"
+  "Tim McGilchrist <timmcgil@gmail.com>"
+]
+authors: [
+  "Anil Madhavapeddy"
+  "Anton Kochkov"
+  "Antonin Décimo"
+  "David Allsopp"
+  "Ewan Mellor"
+  "Kate Deplaix"
+  "Louis Gesbert"
+  "Mark Elvers"
+  "Thomas Leonard"
+  "Tim McGilchrist"
+]
+license: "ISC"
+tags: ["org:mirage" "org:ocamllabs"]
+homepage: "https://github.com/ocurrent/ocaml-dockerfile"
+bug-reports: "https://github.com/ocurrent/ocaml-dockerfile/issues"
+depends: [
+  "dune" {>= "3.20"}
+  "dockerfile" {= version}
+  "fmt" {>= "0.8.7"}
+  "ocaml-version" {>= "3.6.4"}
+  "ppx_sexp_conv" {>= "v0.9.0"}
+  "sexplib0"
+  "alcotest" {>= "1.9.1" & with-test}
+  "odoc" {with-doc}
+]
+conflicts: [
+  "result" {< "1.5"}
+  "rresult" {< "0.7.0"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/ocurrent/ocaml-dockerfile.git"
+url {
+  src:
+    "https://github.com/ocurrent/ocaml-dockerfile/releases/download/v8.4.0/ocaml-dockerfile-8.4.0.tbz"
+  checksum: [
+    "md5=955846375a80ed2cfd26749b92ea6dc4"
+    "sha512=4be3497556761c570a6962ee2b5950bcc05f564d94a6a870ede6904f026e08f3ee2de7a9fa8dcd27a3a7c9acaa5e550cba4aef8bab7d617067fae739a43f9169"
+  ]
+}
+x-maintenance-intent: ["(latest)"]

--- a/packages/dockerfile/dockerfile.8.4.0/opam
+++ b/packages/dockerfile/dockerfile.8.4.0/opam
@@ -1,0 +1,67 @@
+opam-version: "2.0"
+synopsis: "Dockerfile eDSL in OCaml"
+description: """\
+This library provides a typed OCaml interface to generating Dockerfiles
+programmatically without having to resort to lots of shell scripting and
+awk/sed-style assembly."""
+maintainer: [
+  "Anil Madhavapeddy <anil@recoil.org>"
+  "Antonin Décimo <antonin@tarides.com>"
+  "David Allsopp <david.allsopp@metastack.com>"
+  "Kate <kit.ty.kate@disroot.org>"
+  "Thomas Leonard <talex5@gmail.com>"
+  "Tim McGilchrist <timmcgil@gmail.com>"
+]
+authors: [
+  "Anil Madhavapeddy"
+  "Anton Kochkov"
+  "Antonin Décimo"
+  "David Allsopp"
+  "Ewan Mellor"
+  "Kate Deplaix"
+  "Louis Gesbert"
+  "Mark Elvers"
+  "Thomas Leonard"
+  "Tim McGilchrist"
+]
+license: "ISC"
+tags: ["org:mirage" "org:ocamllabs"]
+homepage: "https://github.com/ocurrent/ocaml-dockerfile"
+bug-reports: "https://github.com/ocurrent/ocaml-dockerfile/issues"
+depends: [
+  "dune" {>= "3.20"}
+  "ocaml" {>= "4.08"}
+  "fmt" {>= "0.8.7"}
+  "ppx_sexp_conv" {>= "v0.9.0"}
+  "sexplib0"
+  "alcotest" {>= "1.9.1" & with-test}
+  "odoc" {with-doc}
+]
+conflicts: [
+  "result" {< "1.5"}
+  "rresult" {< "0.7.0"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/ocurrent/ocaml-dockerfile.git"
+url {
+  src:
+    "https://github.com/ocurrent/ocaml-dockerfile/releases/download/v8.4.0/ocaml-dockerfile-8.4.0.tbz"
+  checksum: [
+    "md5=955846375a80ed2cfd26749b92ea6dc4"
+    "sha512=4be3497556761c570a6962ee2b5950bcc05f564d94a6a870ede6904f026e08f3ee2de7a9fa8dcd27a3a7c9acaa5e550cba4aef8bab7d617067fae739a43f9169"
+  ]
+}
+x-maintenance-intent: ["(latest)"]

--- a/packages/dockerfile/dockerfile.8.4.0/opam
+++ b/packages/dockerfile/dockerfile.8.4.0/opam
@@ -58,7 +58,7 @@ build: [
 dev-repo: "git+https://github.com/ocurrent/ocaml-dockerfile.git"
 url {
   src:
-    "https://github.com/ocurrent/ocaml-dockerfile/releases/download/v8.4.0/ocaml-dockerfile-8.4.0.tbz"
+    "https://github.com/ocurrent/ocaml-dockerfile/releases/download/8.4.0/ocaml-dockerfile-8.4.0.tbz"
   checksum: [
     "md5=955846375a80ed2cfd26749b92ea6dc4"
     "sha512=4be3497556761c570a6962ee2b5950bcc05f564d94a6a870ede6904f026e08f3ee2de7a9fa8dcd27a3a7c9acaa5e550cba4aef8bab7d617067fae739a43f9169"


### PR DESCRIPTION
This pull-request concerns:
- `dockerfile.8.4.0`: Dockerfile eDSL in OCaml
- `dockerfile-cmd.8.4.0`: Dockerfile eDSL -- generation support
- `dockerfile-opam.8.4.0`: Dockerfile eDSL -- opam support



---
* Homepage: https://github.com/ocurrent/ocaml-dockerfile
* Source repo: git+https://github.com/ocurrent/ocaml-dockerfile.git
* Bug tracker: https://github.com/ocurrent/ocaml-dockerfile/issues

---
## What's Changed
* Add Distro.gcc_version by @mtelvers in https://github.com/ocurrent/ocaml-dockerfile/pull/267


**Full Changelog**: https://github.com/ocurrent/ocaml-dockerfile/compare/8.3.9...8.4.0


---
:camel: Pull-request generated by opam-publish v2.5.1