### PR TITLE
[new release] lrgrep (0.9)

### DIFF
--- a/packages/lrgrep/lrgrep.0.9/opam
+++ b/packages/lrgrep/lrgrep.0.9/opam
@@ -1,0 +1,28 @@
+opam-version: "2.0"
+maintainer: "Frederic Bour <frederic.bour@lakaban.net>"
+authors: "Frederic Bour <frederic.bour@lakaban.net>"
+homepage: "https://github.com/let-def/lrgrep"
+bug-reports: "https://github.com/let-def/lrgrep"
+license: "ISC"
+dev-repo: "git+https://github.com/let-def/lrgrep.git"
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+depends: [
+  "ocaml" {>= "4.13.0"}
+  "dune" {>= "2.0.0"}
+  "menhir" {>= "20260209"}
+  "cmon" {>= "0.2"}
+]
+synopsis: "Detailed error messages for Menhir-generated parsers"
+url {
+  src:
+    "https://github.com/let-def/lrgrep/releases/download/v0.9/lrgrep-0.9.tbz"
+  checksum: [
+    "sha256=e53de12e4c5cbe6bca00643593266b4f9fa2e3f6a138195eeff7a4329f5c1c75"
+    "sha512=7fd7c4d11506fea7cc11c9bbf5aea9142d905643553c0c90e1bb16b794106b0c14a266acf89ae91b6929008dc0ba6515f788642873e2e4ba6c3d49bd45d25127"
+  ]
+}
+x-commit-hash: "b0f81602a317390d4c4d66e6419aae566e2e1c59"


### PR DESCRIPTION
Detailed error messages for Menhir-generated parsers

- Project page: <a href="https://github.com/let-def/lrgrep">https://github.com/let-def/lrgrep</a>

##### CHANGES:

First publicly announced release.

New features:
- enumeration and coverage are now precise (and reasonably fast)
- reports can be provided in a low-level JSON format, to be post-processed by jq;
  the format is not stable yet
- "Getting started" guide
- `lrgrep.top` provides a functor to customize lexical syntax
- application to OCaml with exhaustive coverage (builtin and https://github.com/let-def/lrgrep-ocaml)
- prototype on OxCaml

Still pending:
- prototype on latest OxCaml
- sample applications to (Mini-)Elm and Catala have not been merged yet
- guards for detecting "unreachable actions" are not yet supported
