### PR TITLE
release pa_ppx suite of packages for camlp5 8.05.01

### DIFF
--- a/packages/pa_ppx/pa_ppx.8.05.01/opam
+++ b/packages/pa_ppx/pa_ppx.8.05.01/opam
@@ -65,7 +65,7 @@ conflicts: [
   "ocaml-option-bytecode-only"
   "pa_ppx_hashcons" { < "8.05.01" }
   "pa_ppx_migrate" { < "8.05.01" }
-  "pa_ppx_migrate_ocaml_parsetree" { < "8.05.01" }
+  "pa_ppx_migrate_ocaml_parsetree" { < "5.4.0" }
   "pa_ppx_q_ast" { < "8.05.01" }
   "pa_ppx_quotation2extension" { < "8.05.01" }
   "pa_ppx_regexp" { < "8.05.01" }

--- a/packages/pa_ppx_fmtformat/pa_ppx_fmtformat.8.05.01/opam
+++ b/packages/pa_ppx_fmtformat/pa_ppx_fmtformat.8.05.01/opam
@@ -1,0 +1,41 @@
+
+synopsis: "A Camlp5 PPX Rewriter for interpolation into strings (based on fmt) "
+description:
+"""
+This is a PPX Rewriter to provide string interpolation, based on
+the Fmt package.
+"""
+opam-version: "2.0"
+x-maintenance-intent: [ "(latest)" ]
+maintainer: "Chet Murthy <chetsky@gmail.com>"
+authors: ["Chet Murthy"]
+homepage: "https://github.com/camlp5/pa_ppx_fmtformat"
+license: "BSD-3-Clause"
+bug-reports: "https://github.com/camlp5/pa_ppx_fmtformat/issues"
+dev-repo: "git+https://github.com/camlp5/pa_ppx_fmtformat.git"
+doc: "https://github.com/camlp5/pa_ppx_fmtformat/doc"
+
+depends: [
+  "ocaml"       { >= "4.10.0" }
+  "camlp5-buildscripts" { >= "0.02" }
+  "camlp5"      { >= "8.05.01" }
+  "pcre2" { >= "8.0.3" }
+  "pa_ppx"      { >= "8.05.01" }
+  "not-ocamlfind" { >= "0.13" }
+  "ounit" { >= "2.2.7" }
+  "fmt"
+  "mdx" { >= "2.3.0" & with-test}
+  "pp-binary-ints" {with-test}
+  "pa_ppx_regexp" { >= "8.05.01" }
+]
+build: [
+  [make "DEBUG=-g" "sys"]
+  [make "test"] {with-test}
+]
+install: [make "install"]
+url {
+  src: "https://github.com/camlp5/pa_ppx_fmtformat/archive/refs/tags/8.05.01.tar.gz"
+  checksum: [
+    "sha512=5e646060a0a8e90857b38e5a445b3a2e0e135495b279c38341f696292aaa6589d67d35c1ef40f3adeb62d242a5197fd458b2dd892c4eedc8ae25128d7cf31b14"
+  ]
+}

--- a/packages/pa_ppx_hashcons/pa_ppx_hashcons.8.05.01/opam
+++ b/packages/pa_ppx_hashcons/pa_ppx_hashcons.8.05.01/opam
@@ -1,0 +1,43 @@
+
+synopsis: "A PPX Rewriter for Hashconsing"
+description:
+"""
+This is a PPX Rewriter for generating hashconsing implementations
+of ASTs, mechanizing the ideas and code of Jean-Christophe Filliatre
+and Sylvain Conchon.
+
+"""
+opam-version: "2.0"
+x-maintenance-intent: [ "(latest)" ]
+maintainer: "Chet Murthy <chetsky@gmail.com>"
+authors: ["Chet Murthy"]
+homepage: "https://github.com/camlp5/pa_ppx_hashcons"
+license: "BSD-3-Clause"
+bug-reports: "https://github.com/camlp5/pa_ppx_hashcons/issues"
+dev-repo: "git+https://github.com/camlp5/pa_ppx_hashcons.git"
+doc: "https://github.com/camlp5/pa_ppx_hashcons/doc"
+
+depends: [
+  "ocaml"       { >= "4.11.0" }
+  "cppo" { >= "1.6.9" }
+  "camlp5-buildscripts" { >= "0.02" }
+  "camlp5"      { >= "8.05.01" }
+  "pa_ppx"      { >= "8.05.01" }
+  "pa_ppx_migrate"      { with-test & >= "8.05.01" }
+  "not-ocamlfind" { >= "0.10" }
+  "ounit" { >= "2.2.7" & with-test}
+  "bos" { >= "0.2.0" }
+  "fmt"
+  "hashcons"
+]
+build: [
+  [make "DEBUG=-g" "sys"]
+  [make "test"] {with-test}
+]
+install: [make "install"]
+url {
+  src: "https://github.com/camlp5/pa_ppx_hashcons/archive/refs/tags/8.05.01.tar.gz"
+  checksum: [
+    "sha512=05a9dc1350d7a5d47b717797c1cdc3bb7981dc45cf16b474626a3b8e10bd248d87fce9db347a07683eaf3b2f313800be87f267f1336ce69144c71289c65b7e58"
+  ]
+}

--- a/packages/pa_ppx_migrate/pa_ppx_migrate.8.05.01/opam
+++ b/packages/pa_ppx_migrate/pa_ppx_migrate.8.05.01/opam
@@ -1,0 +1,47 @@
+
+synopsis: "A PPX Rewriter for Migrating AST types (written using Camlp5)"
+description:
+"""
+This is a PPX Rewriter for generating "migrations" like those written
+by-hand (with some automated support) in "ocaml-migrate-parsetree".
+The goal here is that the input to the automated tool is the minimum
+possible, with no need for human massaging of output from the tool.
+
+There are two examples: a small one (in a unit-test) and a full set of
+migrations from Ocaml's AST 4.02 all the way up to 5.2.0, with all the
+intermediate ASTs, and migrations forward as well as backward.
+
+"""
+opam-version: "2.0"
+x-maintenance-intent: [ "(latest)" ]
+maintainer: "Chet Murthy <chetsky@gmail.com>"
+authors: ["Chet Murthy"]
+homepage: "https://github.com/camlp5/pa_ppx_migrate"
+license: "BSD-3-Clause"
+bug-reports: "https://github.com/camlp5/pa_ppx_migrate/issues"
+dev-repo: "git+https://github.com/camlp5/pa_ppx_migrate.git"
+doc: "https://github.com/camlp5/pa_ppx_migrate/doc"
+x-ci-accept-failures: [ "opensuse-tumbleweed" ]
+
+depends: [
+  "ocaml"       { >= "4.10.0" }
+  "cppo" { >= "1.6.9" }
+  "camlp5-buildscripts" { >= "0.02" }
+  "camlp5"      { >= "8.05.01" }
+  "pa_ppx"      { >= "8.05.01" }
+  "not-ocamlfind" { >= "0.10" }
+  "ounit" { >= "2.2.7" & with-test}
+  "fmt"
+  "bos" { >= "0.2.0" }
+]
+build: [
+  [make "-j%{jobs}%" "DEBUG=-g" "sys"]
+  [make "test"] {with-test}
+]
+install: [make "install"]
+url {
+  src: "https://github.com/camlp5/pa_ppx_migrate/archive/refs/tags/8.05.01.tar.gz"
+  checksum: [
+    "sha512=78e117c65a1ca43f160acf0254f18d76ea09bf829d0f097b794c708ff71ddffbfda0a4caa22cc880d15e890b57b8c929e3b01366d2f289034f6a5fff0e13550b"
+  ]
+}

--- a/packages/pa_ppx_migrate_ocaml_parsetree/pa_ppx_migrate_ocaml_parsetree.5.4.0/opam
+++ b/packages/pa_ppx_migrate_ocaml_parsetree/pa_ppx_migrate_ocaml_parsetree.5.4.0/opam
@@ -1,0 +1,41 @@
+
+synopsis: "Migrations from one version of the OCaml AST to another"
+description:
+"""
+This package provides migrations from one version of the OCaml AST to another,
+using Camlp5-based pa_ppx_migrate to do the actual heavy lifting.
+
+"""
+opam-version: "2.0"
+x-maintenance-intent: [ "(latest)" ]
+maintainer: "Chet Murthy <chetsky@gmail.com>"
+authors: ["Chet Murthy"]
+homepage: "https://github.com/camlp5/pa_ppx_migrate_ocaml_parsetree"
+license: "BSD-3-Clause"
+bug-reports: "https://github.com/camlp5/pa_ppx_migrate_ocaml_parsetree/issues"
+dev-repo: "git+https://github.com/camlp5/pa_ppx_migrate_ocaml_parsetree.git"
+doc: "https://github.com/camlp5/pa_ppx_migrate_ocaml_parsetree/doc"
+
+depends: [
+  "ocaml"       { >= "4.10.0" }
+  "conf-perl"
+  "cppo" { >= "1.6.9" }
+  "camlp5-buildscripts" { >= "0.02" }
+  "camlp5"      { >= "8.05.01" }
+  "pa_ppx_migrate"      { >= "8.05.01" }
+  "not-ocamlfind" { >= "0.10" }
+  "ounit" { >= "2.2.7" & with-test}
+  "fmt"
+  "bos" { >= "0.2.0" }
+]
+build: [
+  [make "-j%{jobs}%" "DEBUG=-g" "sys"]
+  [make "test"] {with-test}
+]
+install: [make "install"]
+url {
+  src: "https://github.com/camlp5/pa_ppx_migrate_ocaml_parsetree/archive/refs/tags/5.4.0.tar.gz"
+  checksum: [
+    "sha512=04d21f63282500e1fc9e58b7d88bf8a8bac5f74ef341d3568c28acf49191f4a0ef3ddce62797d2ec5a9a41e1f0eb11225823af2d6cd954212c142e7557b54757"
+  ]
+}

--- a/packages/pa_ppx_q_ast/pa_ppx_q_ast.8.05.01/opam
+++ b/packages/pa_ppx_q_ast/pa_ppx_q_ast.8.05.01/opam
@@ -1,0 +1,52 @@
+
+synopsis: "A PPX Rewriter for automating generation of data-conversion code for use with Camlp5's Q_ast"
+description:
+"""
+This is a PPX Rewriter for generating data-conversion code that is otherwise
+hand-written, when using Camlp5's Q_ast.
+
+"""
+opam-version: "2.0"
+x-maintenance-intent: [ "(latest)" ]
+maintainer: "Chet Murthy <chetsky@gmail.com>"
+authors: ["Chet Murthy"]
+homepage: "https://github.com/camlp5/pa_ppx_q_ast"
+license: "BSD-3-Clause"
+bug-reports: "https://github.com/camlp5/pa_ppx_q_ast/issues"
+dev-repo: "git+https://github.com/camlp5/pa_ppx_q_ast.git"
+doc: "https://github.com/camlp5/pa_ppx_q_ast/doc"
+
+depends: [
+  "ocaml"       { >= "4.11.0" }
+  "conf-diffutils" { >= "1.2" & with-test }
+  "conf-perl"
+  "cppo" { >= "1.6.9" }
+  "camlp5-buildscripts" { >= "0.01" }
+  "camlp5"      { >= "8.05.01" }
+  "pa_ppx"      { >= "8.05.01" }
+  "pa_ppx_migrate"      { with-test & >= "8.05.01" }
+  "pa_ppx_hashcons"      { >= "8.05.01" }
+  "pa_ppx_unique"      { >= "8.05.01" }
+  "pa_ppx_regexp"      { >= "8.05.01" }
+  "not-ocamlfind" { >= "0.01" }
+  "pcre2"
+  "ounit" { >= "2.2.7" & with-test}
+  "bos" { >= "0.2.0" }
+  "menhir" { >= "20220210" }
+  "mdx" { >= "2.3.0" & with-test}
+]
+conflicts: [
+   "pa_ppx_parsetree" { <= "0.02" }
+]
+x-ci-accept-failures: [ "opensuse-tumbleweed" ]
+build: [
+  [make "DEBUG=-g" "sys"]
+  [make "test"] {with-test}
+]
+install: [make "install"]
+url {
+  src: "https://github.com/camlp5/pa_ppx_q_ast/archive/refs/tags/8.05.01.tar.gz"
+  checksum: [
+    "sha512=ff35cb571a7bbaa99d143cc7dc906b0fd16eed8dca0740faddfe31a379b69b9cc0b660b38fc041371fafb0ab91d625b1ded89017a7c719877c1f887ec95ba6e5"
+  ]
+}

--- a/packages/pa_ppx_quotation2extension/pa_ppx_quotation2extension.8.05.01/opam
+++ b/packages/pa_ppx_quotation2extension/pa_ppx_quotation2extension.8.05.01/opam
@@ -1,0 +1,39 @@
+
+synopsis: "A Camlp5 PPX Rewriter for treating PPX extensions as Camlp5 quotations  "
+description:
+"""
+This is a PPX Rewriter that processes PPX extensions with string payloads as
+Camlp5 quotations.
+"""
+opam-version: "2.0"
+x-maintenance-intent: [ "(latest)" ]
+maintainer: "Chet Murthy <chetsky@gmail.com>"
+authors: ["Chet Murthy"]
+homepage: "https://github.com/camlp5/pa_ppx_quotation2extension"
+license: "BSD-3-Clause"
+bug-reports: "https://github.com/camlp5/pa_ppx_quotation2extension/issues"
+dev-repo: "git+https://github.com/camlp5/pa_ppx_quotation2extension.git"
+doc: "https://github.com/camlp5/pa_ppx_quotation2extension/doc"
+
+depends: [
+  "ocaml"       { >= "4.10.0" }
+  "camlp5-buildscripts" { >= "0.02" }
+  "camlp5"      { >= "8.05.01" }
+  "pa_ppx"      { >= "8.05.01" }
+  "pa_ppx_regexp" { >= "8.05.01" }
+  "not-ocamlfind" { >= "0.10" }
+  "ounit" { >= "2.2.7" & with-test}
+  "fmt"
+  "mdx" { >= "2.3.0" & with-test}
+]
+build: [
+  [make "DEBUG=-g" "sys"]
+  [make "test"] {with-test}
+]
+install: [make "install"]
+url {
+  src: "https://github.com/camlp5/pa_ppx_quotation2extension/archive/refs/tags/8.05.01.tar.gz"
+  checksum: [
+    "sha512=7021b406550be766299913d4a3840c92fd6c980a8d3b17836c019de2996e1b7db6fe29198af1b8c92eb0b09fb269aac602ddac8a8e03ae0cdf7962930e72e7ed"
+  ]
+}

--- a/packages/pa_ppx_regexp/pa_ppx_regexp.8.05.01/opam
+++ b/packages/pa_ppx_regexp/pa_ppx_regexp.8.05.01/opam
@@ -1,0 +1,42 @@
+
+synopsis: "A Camlp5 PPX Rewriter for Perl Regexp Workalikes "
+description:
+"""
+This is a PPX Rewriter for some workalikes to perl regexp operations,
+based on Camlp5 (so it's compatible with all the other Camlp5-based PPX rewriters).
+"""
+opam-version: "2.0"
+x-maintenance-intent: [ "(latest)" ]
+maintainer: "Chet Murthy <chetsky@gmail.com>"
+authors: ["Chet Murthy"]
+homepage: "https://github.com/camlp5/pa_ppx_regexp"
+license: "BSD-3-Clause"
+bug-reports: "https://github.com/camlp5/pa_ppx_regexp/issues"
+dev-repo: "git+https://github.com/camlp5/pa_ppx_regexp.git"
+doc: "https://github.com/camlp5/pa_ppx_regexp/doc"
+
+depends: [
+  "ocaml"       { >= "4.11.0" }
+  "camlp5-buildscripts" { >= "0.02" }
+  "camlp5"      { >= "8.05.01" }
+  "pa_ppx"      { >= "8.05.01" }
+  "pa_ppx_migrate"      { >= "8.05.01" }
+  "pa_ppx_static" { >= "8.05.01" }
+  "not-ocamlfind" { >= "0.10" }
+  "ounit" { >= "2.2.7" }
+  "mdx" {>= "2.3.0" & with-test}
+  "fmt"
+  "pcre2" { >= "8.0.4" }
+  "re" { >= "1.12.0" }
+]
+build: [
+  [make "DEBUG=-g" "sys"]
+  [make "test"] {with-test}
+]
+install: [make "install"]
+url {
+  src: "https://github.com/camlp5/pa_ppx_regexp/archive/refs/tags/8.05.01.tar.gz"
+  checksum: [
+    "sha512=1effe9f3a55df3a1058655d58acc6643150f9943ff60ac19344e5fc00b03da2287621bf43c96a6c97e6da616859530e91863c710af171b6eee6454f1ce8a32fd"
+  ]
+}

--- a/packages/pa_ppx_static/pa_ppx_static.8.05.01/opam
+++ b/packages/pa_ppx_static/pa_ppx_static.8.05.01/opam
@@ -1,0 +1,41 @@
+
+synopsis: "A Camlp5 PPX Rewriter for static blocks "
+description:
+"""
+This is a PPX Rewriter to provide `static' blocks
+for OCaml, so you can write code that computes some
+expensive expression and mark it as static, so it'll
+be computed only once.  Like regexps.
+"""
+opam-version: "2.0"
+x-maintenance-intent: [ "(latest)" ]
+maintainer: "Chet Murthy <chetsky@gmail.com>"
+authors: ["Chet Murthy"]
+homepage: "https://github.com/camlp5/pa_ppx_static"
+license: "BSD-3-Clause"
+bug-reports: "https://github.com/camlp5/pa_ppx_static/issues"
+dev-repo: "git+https://github.com/camlp5/pa_ppx_static.git"
+doc: "https://github.com/camlp5/pa_ppx_static/doc"
+
+depends: [
+  "ocaml"       { >= "4.10.0" }
+  "camlp5-buildscripts" { >= "0.02" }
+  "camlp5"      { >= "8.05.01" }
+  "pcre2" { with-test }
+  "pa_ppx"      { >= "8.05.01" }
+  "not-ocamlfind" { >= "0.10" }
+  "ounit" { >= "2.2.7" }
+  "fmt"
+  "mdx" { >= "2.3.0" & with-test}
+]
+build: [
+  [make "DEBUG=-g" "sys"]
+  [make "test"] {with-test}
+]
+install: [make "install"]
+url {
+  src: "https://github.com/camlp5/pa_ppx_static/archive/refs/tags/8.05.01.tar.gz"
+  checksum: [
+    "sha512=fce3a038523632b659d02397dc157ebf1baabec13761b526ddbcc46b3a2ae1c6b5ab851ff87e39e9e955f75e4c63ce4d85a702ca19c5676e825bf1ea78bd8e17"
+  ]
+}

--- a/packages/pa_ppx_unique/pa_ppx_unique.8.05.01/opam
+++ b/packages/pa_ppx_unique/pa_ppx_unique.8.05.01/opam
@@ -1,0 +1,40 @@
+
+synopsis: "A PPX Rewriter for Uniqifying ASTs"
+description:
+"""
+This is a PPX Rewriter for uniqifying ASTs: inserting unique IDs
+systematically throughout an AST.
+"""
+opam-version: "2.0"
+x-maintenance-intent: [ "(latest)" ]
+maintainer: "Chet Murthy <chetsky@gmail.com>"
+authors: ["Chet Murthy"]
+homepage: "https://github.com/camlp5/pa_ppx_unique"
+license: "BSD-3-Clause"
+bug-reports: "https://github.com/camlp5/pa_ppx_unique/issues"
+dev-repo: "git+https://github.com/camlp5/pa_ppx_unique.git"
+doc: "https://github.com/camlp5/pa_ppx_unique/doc"
+
+depends: [
+  "ocaml"       { >= "4.11.0" }
+  "cppo" { >= "1.6.9" }
+  "camlp5-buildscripts" { >= "0.02" }
+  "camlp5"      { >= "8.05.01" }
+  "pa_ppx"      { >= "8.05.01" }
+  "pa_ppx_migrate"      { with-test & >= "8.05.01" }
+  "not-ocamlfind" { >= "0.10" }
+  "ounit" { >= "2.2.7" & with-test}
+  "bos" { >= "0.2.0" }
+  "fmt"
+]
+build: [
+  [make "DEBUG=-g" "sys"]
+  [make "test"] {with-test}
+]
+install: [make "install"]
+url {
+  src: "https://github.com/camlp5/pa_ppx_unique/archive/refs/tags/8.05.01.tar.gz"
+  checksum: [
+    "sha512=32558066895511ea4bf0e060598c67114c8c97f3019645dc84af0efd0c41c4f558cedf2c5f21dfee6584e7c3303c7317115c7bdfd80d89281e1ddeed87d000a6"
+  ]
+}


### PR DESCRIPTION
a "conflicts" was wrong for pa_ppx_migrate_ocaml_parsetree: fixed.

These packages have existed for long enough that I'm syncing their version-numbers with camlp5 -- it'll make it easier to manage them with camlp5 upgrades (though they should rarely need to be upgraded as camlp5 evolves).