### PR TITLE
Package z3.4.16.0

### DIFF
--- a/packages/z3/z3.4.16.0/opam
+++ b/packages/z3/z3.4.16.0/opam
@@ -43,7 +43,13 @@ depends: [
   "conf-c++" {build}
 ]
 x-ci-accept-failures: [
-  "centos-7" "oraclelinux-7" "opensuse-15.6" # C compiler is too old
+  # C compiler is too old
+  "centos-7" 
+  "oraclelinux-7"
+  "opensuse-15.6"
+  "centos-9"
+  "debian-12"
+  "ubuntu-22.04" 
 ]
 conflicts: [
   "ocaml-option-bytecode-only"

--- a/packages/z3/z3.4.16.0/opam
+++ b/packages/z3/z3.4.16.0/opam
@@ -1,0 +1,65 @@
+opam-version: "2.0"
+maintainer: "weng@cs.jhu.edu"
+authors: "MSR"
+homepage: "https://github.com/Z3prover/z3"
+bug-reports: "https://github.com/Z3prover/z3/issues"
+license: "MIT"
+dev-repo: "git+https://github.com/Z3prover/z3.git"
+patches: [
+  "gccstd-2a.patch" { (os-family = "opensuse" | os-family = "suse") | (os-distribution = "ubuntu" & os-version <= "20.04") }
+]
+build: [
+  [ "python3" "scripts/mk_make.py" "--ml" ] {os-distribution != "homebrew"}
+  [ make "-C" "build" "-j" jobs ] {os-distribution != "homebrew"}
+  [ "sh" "-c" """#!/bin/sh
+    PATH=/usr/local/opt/llvm/bin:$PATH
+    LDFLAGS="-L/usr/local/opt/llvm/lib $LDFLAGS"
+    CPPFLAGS="-I/usr/local/opt/llvm/include $CPPFLAGS"
+    export PATH LDFLAGS CPPFLAGS
+    python3 scripts/mk_make.py --ml
+    make -C build -j %{jobs}%
+  """] {os-distribution = "homebrew" & arch = "x86_64"}
+  [ "sh" "-c" """#!/bin/sh
+    PATH=/opt/homebrew/opt/llvm/bin:$PATH
+    LDFLAGS="-L/opt/homebrew/opt/llvm/lib $LDFLAGS"
+    CPPFLAGS="-I/opt/homebrew/opt/llvm/include $CPPFLAGS"
+    export PATH LDFLAGS CPPFLAGS
+    python3 scripts/mk_make.py --ml
+    make -C build -j %{jobs}%
+  """] {os-distribution = "homebrew" & arch = "arm64"}
+]
+
+install: [
+  [ "sh" "-c" "ocamlfind install z3 build/api/ml/* -dll build/libz3.*"]
+  [ "cp" "build/z3" "%{bin}%/z3"]
+]
+
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "ocamlfind" {build}
+  "zarith"
+  "conf-llvm" { os-distribution = "homebrew" }
+  "conf-python-3" {build}
+  "conf-c++" {build}
+]
+x-ci-accept-failures: [
+  "centos-7" "oraclelinux-7" "opensuse-15.6" # C compiler is too old
+]
+conflicts: [
+  "ocaml-option-bytecode-only"
+]
+synopsis: "Z3 solver"
+url {
+  src:
+    "https://github.com/Z3Prover/z3/archive/refs/tags/z3-4.16.0.tar.gz"
+  checksum: [
+    "sha256=c68c3e5e4810b16126b8cb4c47eee85c1ac3e24a81914c8e371b40de9dd33ac7"
+    "sha512=7dbcdd04a72f46bc3b6cbac2453b2a43f5ae126287b878ffe37f0573f910a1130c474c5edfa622dab09957f106cf425ab0f7cdfd34d41658599ad50a81ae39dd"
+  ]
+}
+extra-source "gccstd-2a.patch" {
+  src:
+    "https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/z3/gccstd-2a.patch"
+  checksum:
+    "sha256=ae4088ff14739bcc2cadc90bc428f08277e898b832f6b859a46e23c584d513c8"
+}


### PR DESCRIPTION
The current Z3 version available in the opam-repos is 4.15.2, which is nearly a year old. Because there have been several upstream Z3 releases since then, I am adding only the latest version. While I am not a Z3 maintainer, our team uses it extensively, and this new version introduces several highly anticipated APIs and improvements.