### PR TITLE
[new release] odep (0.2.2)

### DIFF
--- a/packages/odep/odep.0.2.2/opam
+++ b/packages/odep/odep.0.2.2/opam
@@ -1,0 +1,49 @@
+opam-version: "2.0"
+synopsis: "Dependency graphs for OCaml modules, libraries and packages"
+maintainer: ["Simmo Saan <simmo.saan@gmail.com>"]
+authors: ["Simmo Saan"]
+license: "MIT"
+homepage: "https://github.com/sim642/odep"
+bug-reports: "https://github.com/sim642/odep/issues"
+depends: [
+  "dune" {>= "3.0"}
+  "ocaml" {>= "4.08"}
+  "sexplib"
+  "ppx_sexp_conv" {>= "v0.13"}
+  "parsexp"
+  "opam-core" {>= "2.1.0"}
+  "opam-state" {>= "2.1.0" & (< "2.2.0~beta3" | >= "2.2.0")}
+  "opam-format"
+  "ocamlfind" {>= "1.8.1"}
+  "cmdliner" {>= "1.1.0"}
+  "bos"
+  "ppx_deriving"
+  "odoc" {with-doc}
+]
+conflicts: [
+  "result" {< "1.5"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/sim642/odep.git"
+url {
+  src:
+    "https://github.com/sim642/odep/releases/download/0.2.2/odep-0.2.2.tbz"
+  checksum: [
+    "sha256=85bce72c08ae4699dbeaf327ed9970daf2d54d55ad37fa88e823219d4c220333"
+    "sha512=7b8116ad0e0f9840787005f9daefadcbd493458fe2ab9434a814475b375d440fc2298732fed3bd81746273dc62c7f84e525f2696b5e77c173191ba2b246be948"
+  ]
+}
+x-commit-hash: "b95ef24b650e3734617ae30c9cb1c4069253e180"


### PR DESCRIPTION
Dependency graphs for OCaml modules, libraries and packages

- Project page: <a href="https://github.com/sim642/odep">https://github.com/sim642/odep</a>

##### CHANGES:

* Add `--with-modules` argument to dune dependencies.
* Fix opam 2.4 compatibility.
* Fix vertex name conflict when dune library and executable have same name (sim642/odep#9).
