### PR TITLE
Relax caqti-lwt Lwt upper bound

### DIFF
--- a/packages/caqti-lwt/caqti-lwt.2.3.0/opam
+++ b/packages/caqti-lwt/caqti-lwt.2.3.0/opam
@@ -12,7 +12,7 @@ depends: [
   "ipaddr"
   "logs"
   "mtime" {>= "2.0.0"}
-  "lwt" {>= "5.3.0" & < "6~"}
+  "lwt" {>= "5.3.0"}
   "ocaml"
   "alcotest" {with-test & >= "1.5.0"}
   "alcotest-lwt" {with-test & >= "1.5.0"}


### PR DESCRIPTION
Relaxes the `lwt` constraint on `caqti-lwt.2.3.0` by removing the `< 6~` upper bound.

This is enough for packages such as Dream that need the Caqti Lwt support package to be installable with Lwt 6 / OCaml 5.5. No source release is needed for this metadata-only change.

Validation:
- `opam lint packages/caqti-lwt/caqti-lwt.2.3.0/opam`
- `git diff --check`