### PR TITLE
async_ssl: v0.16.1-2 and v0.17.0-2 fix warnings-as-errors

### DIFF
--- a/packages/async_ssl/async_ssl.v0.16.1-2/opam
+++ b/packages/async_ssl/async_ssl.v0.16.1-2/opam
@@ -1,0 +1,47 @@
+opam-version: "2.0"
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
+homepage: "https://github.com/janestreet/async_ssl"
+bug-reports: "https://github.com/janestreet/async_ssl/issues"
+dev-repo: "git+https://github.com/janestreet/async_ssl.git"
+doc: "https://ocaml.janestreet.com/ocaml-core/latest/doc/async_ssl/index.html"
+license: "MIT"
+patches: [ "no-warnings-0161-2.patch" ]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "ocaml"             {>= "4.14.0"}
+  "async"             {>= "v0.16" & < "v0.17"}
+  "base"              {>= "v0.16" & < "v0.17"}
+  "core"              {>= "v0.16" & < "v0.17"}
+  "ppx_jane"          {>= "v0.16" & < "v0.17"}
+  "ppx_optcomp"       {>= "v0.16" & < "v0.17"}
+  "stdio"             {>= "v0.16" & < "v0.17"}
+  "conf-libssl"
+  "ctypes"            {>= "0.18.0"}
+  "ctypes-foreign" {>= "0.18.0"}
+  "dune"              {>= "2.0.0"}
+  "dune-configurator"
+]
+available: arch != "arm32" & arch != "x86_32"
+synopsis: "An Async-pipe-based interface with OpenSSL"
+description: "
+This library allows you to create an SSL client and server, with
+encrypted communication between both.
+"
+url {
+  src:
+    "https://github.com/janestreet/async_ssl/archive/refs/tags/v0.16.1.tar.gz"
+  checksum: [
+    "md5=7e404ed41467b7ac0ef985f5ac6eccd8"
+    "sha512=e4545e91d15d43f1a53ca8d05e8b7d39d11627671d0da2b2b02451b197387b396a310d51397decbd6448fc2bb13aa237b052685263dea4e2010f7884ad94371d"
+  ]
+}
+extra-source "no-warnings-0161-2.patch" {
+  src:
+    "https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/async_ssl/no-warnings-0161-2.patch"
+  checksum: [
+    "sha256=cbac0da5e278c247e30f19dce943e7346e03aa7f7095d8ee46cf489b49ed110e"
+  ]
+}

--- a/packages/async_ssl/async_ssl.v0.17.0-2/opam
+++ b/packages/async_ssl/async_ssl.v0.17.0-2/opam
@@ -1,0 +1,44 @@
+opam-version: "2.0"
+maintainer: "Jane Street developers"
+authors: ["Jane Street Group, LLC"]
+homepage: "https://github.com/janestreet/async_ssl"
+bug-reports: "https://github.com/janestreet/async_ssl/issues"
+dev-repo: "git+https://github.com/janestreet/async_ssl.git"
+doc: "https://ocaml.janestreet.com/ocaml-core/latest/doc/async_ssl/index.html"
+license: "MIT"
+patches: [ "no-warnings-017-2.patch" ]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "ocaml"             {>= "5.1.0"}
+  "async"             {>= "v0.17" & < "v0.18~"}
+  "base"              {>= "v0.17" & < "v0.18~"}
+  "core"              {>= "v0.17" & < "v0.18~"}
+  "ppx_jane"          {>= "v0.17" & < "v0.18~"}
+  "ppx_optcomp"       {>= "v0.17" & < "v0.18~"}
+  "stdio"             {>= "v0.17" & < "v0.18~"}
+  "conf-libssl"
+  "ctypes"            {>= "0.18.0"}
+  "ctypes-foreign" {>= "0.18.0"}
+  "dune"              {>= "3.11.0"}
+  "dune-configurator"
+]
+available: arch != "arm32" & arch != "x86_32"
+synopsis: "An Async-pipe-based interface with OpenSSL"
+description: "
+This library allows you to create an SSL client and server, with
+encrypted communication between both.
+"
+url {
+src: "https://github.com/janestreet/async_ssl/archive/refs/tags/v0.17.0.tar.gz"
+checksum: "sha256=d1f9ca883ce9154571b2812235171707b70cb8e65b24ed3aeaec1fbebc5be1ba"
+}
+extra-source "no-warnings-017-2.patch" {
+  src:
+    "https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/async_ssl/no-warnings-017-2.patch"
+  checksum: [
+    "sha256=074a08e80f67bc3c6749fef91fb79825f2c7bfca270f079b47e734be45af2a53"
+  ]
+}
+x-maintenance-intent: ["(latest)"]


### PR DESCRIPTION
Corresponding PR https://github.com/ocaml/opam-source-archives/pull/59

Short story
---
Adds two patches that restore the `-Wno-implicit-function-declaration` C flag suppression that was present in `no-incompatible-pointer-types-0160.patch` but dropped when the patch was rewritten for v0.16.1-1 and v0.17.0-1.

Long story
---
`async_ssl`'s `ffi_generated_stubs.c` references the deprecated OpenSSL `ENGINE_load_builtin_engines` and `ENGINE_register_all_complete` functions without including `<openssl/engine.h>`. On distros where OpenSSL is built with the `ENGINE` API stripped (or where the headers no longer expose those symbols at default warning levels), GCC reports them as implicit declarations, which is a hard error under modern GCC defaults (GCC 14+).

  | Revision   | Suppresses `-Wimplicit-function-declaration`? |
  |------------|------------------------------------------------|
  | v0.16.0-1  | Yes                                            |
  | v0.16.1-1  | No (regression)                                |
  | v0.17.0-1  | No (regression continued)                      |

Real world specimen:

opam-ci hits this on `centos-10-ocaml-5.4` (and others): https://opam.ci.ocaml.org/github/ocaml/opam-repository/commit/a9188c69fee7c73594bf9c9017588e99452b8f44/variant/distributions,centos-10-ocaml-5.4,awso-async.0.9.0

Continuing on this prior work https://github.com/ocaml/opam-repository/pull/26886