### PR TITLE
[new release] tar (4 packages) (3.5.0)

### DIFF
--- a/packages/tar-eio/tar-eio.3.5.0/opam
+++ b/packages/tar-eio/tar-eio.3.5.0/opam
@@ -1,0 +1,57 @@
+opam-version: "2.0"
+synopsis: "Decode and encode tar format files using Eio"
+description: """
+tar is a library to read and write tar files with an emphasis on
+streaming.  This library uses Eio to provide a portable tar library.
+"""
+maintainer: ["Reynir Björnsson <reynir@reynir.dk>" "dave@recoil.org"]
+authors: [
+  "Dave Scott"
+  "Thomas Gazagnaire"
+  "David Allsopp"
+  "Antonin Décimo"
+  "Reynir Björnsson"
+  "Hannes Mehnert"
+]
+license: "ISC"
+tags: ["org:xapi-project" "org:mirage"]
+homepage: "https://github.com/mirage/ocaml-tar"
+doc: "https://mirage.github.io/ocaml-tar/"
+bug-reports: "https://github.com/mirage/ocaml-tar/issues"
+depends: [
+  "dune" {>= "2.9"}
+  "ocaml" {>= "5.00.0"}
+  "eio" {>= "1.1"}
+  "tar" {= version}
+  "eio_main" {with-test}
+  "alcotest" {with-test}
+  "decompress" {with-test}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+dev-repo: "git+https://github.com/mirage/ocaml-tar.git"
+x-maintenance-intent: [ "(latest)" ]
+url {
+  src:
+    "https://github.com/mirage/ocaml-tar/releases/download/v3.5.0/tar-3.5.0.tbz"
+  checksum: [
+    "sha256=85a2a61d30eef81e4bf81e0b429d213ceb5dd6eaedcd60c979e1cbb91149f90c"
+    "sha512=07949e3ed9d95744e8e9e1744863aa3b791cb0ac24bcee8b9cdb0b942eb56fe2a3dfc933f6e94ebc8c0274ee77cf16377e63150231985382a460b20469ef2c01"
+  ]
+}
+x-commit-hash: "9918230709cd4f3c96551190b17c0549ff366e53"

--- a/packages/tar-mirage/tar-mirage.3.5.0/opam
+++ b/packages/tar-mirage/tar-mirage.3.5.0/opam
@@ -1,0 +1,68 @@
+opam-version: "2.0"
+synopsis: "Read and write tar format files via MirageOS interfaces"
+description: """
+tar is a library to read and write tar files with an emphasis on
+streaming.  This library is functorised over external OS dependencies
+to facilitate embedding within MirageOS.
+"""
+maintainer: ["Reynir Björnsson <reynir@reynir.dk>" "dave@recoil.org"]
+authors: [
+  "Dave Scott"
+  "Thomas Gazagnaire"
+  "David Allsopp"
+  "Antonin Décimo"
+  "Reynir Björnsson"
+  "Hannes Mehnert"
+]
+license: "ISC"
+tags: ["org:xapi-project" "org:mirage"]
+homepage: "https://github.com/mirage/ocaml-tar"
+doc: "https://mirage.github.io/ocaml-tar/"
+bug-reports: "https://github.com/mirage/ocaml-tar/issues"
+depends: [
+  "dune" {>= "2.9"}
+  "ocaml" {>= "4.08.0"}
+  "cstruct" {>= "6.0.0"}
+  "lwt" {>= "5.6.0"}
+  "mirage-block" {>= "2.0.0"}
+  "mirage-ptime" {>= "5.0.0"}
+  "mirage-kv" {>= "6.0.0"}
+  "optint"
+  "ptime"
+  "tar" {= version}
+  "mirage-block-unix" {with-test & >= "2.13.0"}
+  "alcotest" {>= "1.7.0" & with-test}
+  "alcotest-lwt" {>= "1.7.0" & with-test}
+  "tar-unix" {with-test & = version}
+  "odoc" {with-doc}
+]
+conflicts: [
+  "result" {< "1.5"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+dev-repo: "git+https://github.com/mirage/ocaml-tar.git"
+x-maintenance-intent: [ "(latest)" ]
+url {
+  src:
+    "https://github.com/mirage/ocaml-tar/releases/download/v3.5.0/tar-3.5.0.tbz"
+  checksum: [
+    "sha256=85a2a61d30eef81e4bf81e0b429d213ceb5dd6eaedcd60c979e1cbb91149f90c"
+    "sha512=07949e3ed9d95744e8e9e1744863aa3b791cb0ac24bcee8b9cdb0b942eb56fe2a3dfc933f6e94ebc8c0274ee77cf16377e63150231985382a460b20469ef2c01"
+  ]
+}
+x-commit-hash: "9918230709cd4f3c96551190b17c0549ff366e53"

--- a/packages/tar-unix/tar-unix.3.5.0/opam
+++ b/packages/tar-unix/tar-unix.3.5.0/opam
@@ -23,8 +23,8 @@ depends: [
   "ocaml" {>= "4.08.0"}
   "lwt" {>= "5.7.0"}
   "tar" {= version}
-  "fpath"
-  "logs"
+  "fpath" {>= "0.7.3"}
+  "logs" {>= "0.8.0"}
   "odoc" {with-doc}
 ]
 build: [

--- a/packages/tar-unix/tar-unix.3.5.0/opam
+++ b/packages/tar-unix/tar-unix.3.5.0/opam
@@ -1,0 +1,56 @@
+opam-version: "2.0"
+synopsis: "Decode and encode tar format files from Unix"
+description: """
+tar is a library to read and write tar files with an emphasis on
+streaming.  This library provides a Unix or Windows compatible interface.
+"""
+maintainer: ["Reynir Björnsson <reynir@reynir.dk>" "dave@recoil.org"]
+authors: [
+  "Dave Scott"
+  "Thomas Gazagnaire"
+  "David Allsopp"
+  "Antonin Décimo"
+  "Reynir Björnsson"
+  "Hannes Mehnert"
+]
+license: "ISC"
+tags: ["org:xapi-project" "org:mirage"]
+homepage: "https://github.com/mirage/ocaml-tar"
+doc: "https://mirage.github.io/ocaml-tar/"
+bug-reports: "https://github.com/mirage/ocaml-tar/issues"
+depends: [
+  "dune" {>= "2.9"}
+  "ocaml" {>= "4.08.0"}
+  "lwt" {>= "5.7.0"}
+  "tar" {= version}
+  "fpath"
+  "logs"
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+dev-repo: "git+https://github.com/mirage/ocaml-tar.git"
+x-maintenance-intent: [ "(latest)" ]
+url {
+  src:
+    "https://github.com/mirage/ocaml-tar/releases/download/v3.5.0/tar-3.5.0.tbz"
+  checksum: [
+    "sha256=85a2a61d30eef81e4bf81e0b429d213ceb5dd6eaedcd60c979e1cbb91149f90c"
+    "sha512=07949e3ed9d95744e8e9e1744863aa3b791cb0ac24bcee8b9cdb0b942eb56fe2a3dfc933f6e94ebc8c0274ee77cf16377e63150231985382a460b20469ef2c01"
+  ]
+}
+x-commit-hash: "9918230709cd4f3c96551190b17c0549ff366e53"

--- a/packages/tar/tar.3.5.0/opam
+++ b/packages/tar/tar.3.5.0/opam
@@ -1,0 +1,55 @@
+opam-version: "2.0"
+synopsis: "Decode and encode tar format files in pure OCaml"
+description: """
+tar is a library to read and write tar files with an emphasis on
+streaming.
+
+This is pure OCaml code, no C bindings.
+"""
+maintainer: ["Reynir Björnsson <reynir@reynir.dk>" "dave@recoil.org"]
+authors: [
+  "Dave Scott"
+  "Thomas Gazagnaire"
+  "David Allsopp"
+  "Antonin Décimo"
+  "Reynir Björnsson"
+  "Hannes Mehnert"
+]
+license: "ISC"
+tags: ["org:xapi-project" "org:mirage"]
+homepage: "https://github.com/mirage/ocaml-tar"
+doc: "https://mirage.github.io/ocaml-tar/"
+bug-reports: "https://github.com/mirage/ocaml-tar/issues"
+depends: [
+  "dune" {>= "2.9"}
+  "ocaml" {>= "4.08.0"}
+  "decompress" {>= "1.5.1"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+dev-repo: "git+https://github.com/mirage/ocaml-tar.git"
+x-maintenance-intent: [ "(latest)" ]
+url {
+  src:
+    "https://github.com/mirage/ocaml-tar/releases/download/v3.5.0/tar-3.5.0.tbz"
+  checksum: [
+    "sha256=85a2a61d30eef81e4bf81e0b429d213ceb5dd6eaedcd60c979e1cbb91149f90c"
+    "sha512=07949e3ed9d95744e8e9e1744863aa3b791cb0ac24bcee8b9cdb0b942eb56fe2a3dfc933f6e94ebc8c0274ee77cf16377e63150231985382a460b20469ef2c01"
+  ]
+}
+x-commit-hash: "9918230709cd4f3c96551190b17c0549ff366e53"


### PR DESCRIPTION
CHANGES:

- Fix security issue in unix, lwt-unix, eio
- Fix integer overflows originating from Int64.to_int (on 32 bit platforms) faf7bdf43356a81a0cf8f786e1c199c55512acf7