### PR TITLE
add upperbound on ppxlib.0.37.0

### DIFF
--- a/packages/rdf_ppx/rdf_ppx.0.13.0/opam
+++ b/packages/rdf_ppx/rdf_ppx.0.13.0/opam
@@ -9,7 +9,7 @@ bug-reports: "https://framagit.org/zoggy/ocaml-rdf/issues"
 depends: [
   "dune" {>= "2.9"}
   "rdf" {= version}
-  "ppxlib" {>= "0.23.0"}
+  "ppxlib" {>= "0.23.0" & < "0.37.0"}
   "odoc" {with-doc}
 ]
 build: [

--- a/packages/rdf_ppx/rdf_ppx.0.14.0/opam
+++ b/packages/rdf_ppx/rdf_ppx.0.14.0/opam
@@ -9,7 +9,7 @@ bug-reports: "https://framagit.org/zoggy/ocaml-rdf/issues"
 depends: [
   "dune" {>= "2.9"}
   "rdf" {= version}
-  "ppxlib" {>= "0.23.0"}
+  "ppxlib" {>= "0.23.0" & < "0.37.0"}
   "odoc" {with-doc}
 ]
 build: [

--- a/packages/rdf_ppx/rdf_ppx.0.15.0/opam
+++ b/packages/rdf_ppx/rdf_ppx.0.15.0/opam
@@ -9,7 +9,7 @@ bug-reports: "https://framagit.org/zoggy/ocaml-rdf/issues"
 depends: [
   "dune" {>= "2.9"}
   "rdf" {= version}
-  "ppxlib" {>= "0.23.0"}
+  "ppxlib" {>= "0.23.0" & < "0.37.0"}
   "odoc" {with-doc}
 ]
 build: [

--- a/packages/rdf_ppx/rdf_ppx.1.0.0/opam
+++ b/packages/rdf_ppx/rdf_ppx.1.0.0/opam
@@ -9,7 +9,7 @@ bug-reports: "https://framagit.org/zoggy/ocaml-rdf/issues"
 depends: [
   "dune" {>= "2.9"}
   "rdf" {= version}
-  "ppxlib" {>= "0.32.0"}
+  "ppxlib" {>= "0.32.0" & < "0.37.0"}
   "odoc" {with-doc}
 ]
 build: [

--- a/packages/rdf_ppx/rdf_ppx.1.1.0/opam
+++ b/packages/rdf_ppx/rdf_ppx.1.1.0/opam
@@ -9,7 +9,7 @@ bug-reports: "https://framagit.org/zoggy/ocaml-rdf/issues"
 depends: [
   "dune" {>= "3.19"}
   "rdf" {= version}
-  "ppxlib" {>= "0.32.0"}
+  "ppxlib" {>= "0.32.0" & < "0.37.0"}
   "odoc" {with-doc}
 ]
 build: [


### PR DESCRIPTION
Breaking changes in ppxlib affecting this package otherwise, e.g. with

```
### output ###
(cd _build/default && /home/sf/.opam/5.4.1/bin/ocamlc.opt -g -w -40 -bin-annot -w -6-7-9-10-27-32-33-34-35-36-50-52 -no-strict-sequence -g -bin-annot -bin-annot-occurrences [...]
# File "ppx/ppx_rdf.ml", line 107, characters 32-94:
# 107 |       Exp.apply ~loc (Exp.ident (mknoloc (longident_of_string "Rdf.Sparql.query_from_string")))
#                                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
# Error: This expression has type Longident.t Location.loc
#        but an expression was expected of type
#          Ppxlib_ast__Ast_helper_lite.lid = Astlib.Longident.t Location.loc
#        Type Longident.t is not compatible with type Astlib.Longident.t
                                  

```

Turned up in https://github.com/ocaml/dune/pull/14538 (https://github.com/ocaml/dune/actions/runs/26299262571/job/77419913002?pr=14538)