### PR TITLE
ocaml-solo5: relax constraints to allow 5.4.1 compiler variants

### DIFF
--- a/packages/ocaml-solo5/ocaml-solo5.1.2.1/opam
+++ b/packages/ocaml-solo5/ocaml-solo5.1.2.1/opam
@@ -31,7 +31,7 @@ depends: [
   "opatch" {build} # to patch the compiler sources
   "ocamlfind" {build}
   "ocaml-src" {build}
-  "ocaml" {= "5.4.1"}
+  "ocaml" {>= "5.4.1" & < "5.4.2~~"}
   "solo5" {>= "0.9.1"}
 ]
 conflicts: [

--- a/packages/ocaml-solo5/ocaml-solo5.1.2.2/opam
+++ b/packages/ocaml-solo5/ocaml-solo5.1.2.2/opam
@@ -31,7 +31,7 @@ depends: [
   "opatch" {build} # to patch the compiler sources
   "ocamlfind" {build}
   "ocaml-src" {build}
-  "ocaml" {= "5.4.1"}
+  "ocaml" {>= "5.4.1" & <"5.4.2~~"}
   "solo5" {>= "0.9.1"}
 ]
 conflicts: [


### PR DESCRIPTION
reported by @samoht ; this allows (e.g.) ocaml.5.4.1+relocatable to work with solo5