### PR TITLE
Package lua-ml.0.9.5

### DIFF
--- a/packages/lua-ml/lua-ml.0.9.5/opam
+++ b/packages/lua-ml/lua-ml.0.9.5/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+synopsis: "An embeddable Lua 2.5 interpreter implemented in OCaml"
+maintainer: "Daniil Baturin <daniil+opam@baturin.org>"
+authors: [
+  "Norman Ramsey <nr@cs.tufts.edu>"
+  "Christian Lindig <lindig@gmail.com>"
+  "Daniil Baturin <daniil+lua-ml@baturin.org>"
+]
+license: "BSD-2-Clause"
+homepage: "https://github.com/lindig/lua-ml"
+bug-reports: "https://github.com/lindig/lua-ml/issues"
+depends: [
+  "dune" {>= "2.9"}
+  "ocaml" {>= "4.07.0"}
+  "menhir" {>= "20260209"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+dev-repo: "git+https://github.com/lindig/lua-ml.git"
+url {
+  src: "https://github.com/lindig/lua-ml/archive/refs/tags/0.9.5.tar.gz"
+  checksum: [
+    "md5=51e4faf93439065b839972394d232491"
+    "sha512=138fe08730276941206c95af2488a1d46c28bdb0f15804491fbcd22fecca5515afb33b8c666beb45f2d8d07df9de71d5c4982998f32701cd14b6fa29bab440ee"
+  ]
+}


### PR DESCRIPTION
### `lua-ml.0.9.5`
An embeddable Lua 2.5 interpreter implemented in OCaml



---
* Homepage: https://github.com/lindig/lua-ml
* Source repo: git+https://github.com/lindig/lua-ml.git
* Bug tracker: https://github.com/lindig/lua-ml/issues

---
:camel: Pull-request generated by opam-publish v3.0.0