### PR TITLE
[new release] mirage-net-solo5 (0.8.1)

### DIFF
--- a/packages/mirage-net-solo5/mirage-net-solo5.0.8.1/opam
+++ b/packages/mirage-net-solo5/mirage-net-solo5.0.8.1/opam
@@ -1,0 +1,45 @@
+opam-version: "2.0"
+maintainer:    "martin@lucina.net"
+homepage:      "https://github.com/mirage/mirage-net-solo5"
+bug-reports:   "https://github.com/mirage/mirage-net-solo5/issues"
+dev-repo:      "git+https://github.com/mirage/mirage-net-solo5.git"
+doc:           "https://mirage.github.io/mirage-net-solo5/"
+license:       "ISC"
+authors: [
+  "Anil Madhavapeddy <anil@recoil.org>"
+  "Dan Williams <djwillia@us.ibm.com>"
+  "Martin Lucina <martin@lucina.net>"
+]
+tags: [
+  "org:mirage"
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name] {with-test}
+]
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "2.0"}
+  "cstruct" {>= "1.0.1"}
+  "lwt" {>= "2.4.3"}
+  "mirage-net" {>= "3.0.0"}
+  "macaddr" { >= "4.0.0"}
+  "mirage-solo5" {>= "0.7.0"}
+  "logs" {>= "0.6.0"}
+  "metrics"
+  "fmt" {>= "0.8.7"}
+]
+synopsis: "Solo5 implementation of MirageOS network interface"
+description:
+  "This library implements the MirageOS network interface for Solo5 targets."
+x-maintenance-intent: [ "(latest)" ]
+url {
+  src:
+    "https://github.com/mirage/mirage-net-solo5/releases/download/v0.8.1/mirage-net-solo5-0.8.1.tbz"
+  checksum: [
+    "sha256=75c8d7e7a299cf8a716cf0e91659b8d2f92b756d29c155b8cbef488628a4c77a"
+    "sha512=38c3f695f1f1751174a4148c187140de18126108cd1881522da6e8c2e07d16b2be6c1f6081c4430c9d651cfa25304cd4bed24300c577655940e04da2a665d2c4"
+  ]
+}
+x-commit-hash: "d366a425ec267c0f884084fc0b4df68b352e85df"


### PR DESCRIPTION
Solo5 implementation of MirageOS network interface

- Project page: <a href="https://github.com/mirage/mirage-net-solo5">https://github.com/mirage/mirage-net-solo5</a>
- Documentation: <a href="https://mirage.github.io/mirage-net-solo5/">https://mirage.github.io/mirage-net-solo5/</a>

##### CHANGES:

* Deduplicate metrics sources. There's no need to create a separate
  Metrics.Src.t for each network interface, since each measurement will include
  the name of the network interface as tag ("ifname") (@hannesm mirage/mirage-net-solo5#50)
