### PR TITLE
[new release] awa (2 packages) (0.6.0)

### DIFF
--- a/packages/awa-mirage/awa-mirage.0.6.0/opam
+++ b/packages/awa-mirage/awa-mirage.0.6.0/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+maintainer: [ "Christiano F. Haesbaert <haesbaert@haesbaert.org>" "Hannes Mehnert <hannes@mehnert.org>" "Reynir Björnsson <reynir@reynir.dk>" "Romain Calascibetta <romain.calascibetta@gmail.com>" "Pierre Alain <pierre.alain@tuta.io>" ]
+authors: [ "Christiano F. Haesbaert <haesbaert@haesbaert.org>" "Hannes Mehnert <hannes@mehnert.org>" "Reynir Björnsson <reynir@reynir.dk>" "Romain Calascibetta <romain.calascibetta@gmail.com>" "Pierre Alain <pierre.alain@tuta.io>" ]
+license: "ISC"
+homepage: "https://github.com/mirage/awa-ssh"
+bug-reports: "https://github.com/mirage/awa-ssh/issues"
+dev-repo: "git+https://github.com/mirage/awa-ssh.git"
+doc: "https://mirage.github.io/awa-ssh/api"
+
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "2.7"}
+  "awa" {= version}
+  "cstruct" {>= "6.0.0"}
+  "mtime" {>= "1.0.0"}
+  "lwt" {>= "5.3.0"}
+  "mirage-sleep" {>= "4.0.0"}
+  "duration" {>= "0.2.0"}
+  "mirage-flow" {>= "4.0.0"}
+  "mirage-mtime" {>= "4.0.0"}
+  "logs"
+]
+synopsis: "SSH implementation in OCaml"
+description: """The OpenSSH protocol implemented in OCaml."""
+x-maintenance-intent: [ "(latest)" ]
+url {
+  src:
+    "https://github.com/mirage/awa-ssh/releases/download/v0.6.0/awa-0.6.0.tbz"
+  checksum: [
+    "sha256=4cee0eda7f8bd5abc81862819d9d30a3a8d24019a5e589fa0b8e955843ef72f1"
+    "sha512=c3b2fed43bad957f580ac9f88f25103de3e6dc0a6b9a7328dc4b40f0f6418ada2f228c4239d195ed6ffca85d6a05a9aa0cb4cda37f795f860b5bce67d3c5c789"
+  ]
+}
+x-commit-hash: "f33fec96b58bfce2e7e2310da7cd86163be49912"

--- a/packages/awa/awa.0.6.0/opam
+++ b/packages/awa/awa.0.6.0/opam
@@ -1,0 +1,46 @@
+opam-version: "2.0"
+maintainer: [ "Christiano F. Haesbaert <haesbaert@haesbaert.org>" "Hannes Mehnert <hannes@mehnert.org>" "Reynir Björnsson <reynir@reynir.dk>" "Romain Calascibetta <romain.calascibetta@gmail.com>" "Pierre Alain <pierre.alain@tuta.io>" ]
+authors: [ "Christiano F. Haesbaert <haesbaert@haesbaert.org>" "Hannes Mehnert <hannes@mehnert.org>" "Reynir Björnsson <reynir@reynir.dk>" "Romain Calascibetta <romain.calascibetta@gmail.com>" "Pierre Alain <pierre.alain@tuta.io>" ]
+license: "ISC"
+homepage: "https://github.com/mirage/awa-ssh"
+bug-reports: "https://github.com/mirage/awa-ssh/issues"
+dev-repo: "git+https://github.com/mirage/awa-ssh.git"
+doc: "https://mirage.github.io/awa-ssh/api"
+
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+depends: [
+  "ocaml" {>= "4.10.0"}
+  "dune" {>= "2.7"}
+  "mirage-crypto" {>= "1.0.0"}
+  "mirage-crypto-rng" {>= "1.2.0"}
+  "mirage-crypto-pk"
+  "mirage-crypto-ec" {>= "1.0.0"}
+  "x509" {>= "1.0.0"}
+  "mtime" {>= "1.0.0"}
+  "logs"
+  "fmt"
+  "cmdliner" {>= "1.1.0"}
+  "base64" {>= "3.0.0"}
+  "zarith"
+  "eqaf" {>= "0.8"}
+  "mirage-mtime" {>= "4.0.0"}
+  "ohex" {>= "0.2.0"}
+]
+conflicts: [ "result" {< "1.5"} ]
+synopsis: "SSH implementation in OCaml"
+description: """The OpenSSH protocol implemented in OCaml."""
+x-maintenance-intent: [ "(latest)" ]
+url {
+  src:
+    "https://github.com/mirage/awa-ssh/releases/download/v0.6.0/awa-0.6.0.tbz"
+  checksum: [
+    "sha256=4cee0eda7f8bd5abc81862819d9d30a3a8d24019a5e589fa0b8e955843ef72f1"
+    "sha512=c3b2fed43bad957f580ac9f88f25103de3e6dc0a6b9a7328dc4b40f0f6418ada2f228c4239d195ed6ffca85d6a05a9aa0cb4cda37f795f860b5bce67d3c5c789"
+  ]
+}
+x-commit-hash: "f33fec96b58bfce2e7e2310da7cd86163be49912"


### PR DESCRIPTION
SSH implementation in OCaml

- Project page: <a href="https://github.com/mirage/awa-ssh">https://github.com/mirage/awa-ssh</a>
- Documentation: <a href="https://mirage.github.io/awa-ssh/api">https://mirage.github.io/awa-ssh/api</a>

##### CHANGES:

* Server: add function eof, use it in test server (mirage/awa-ssh#83 @reynir)
* Core: use string and Buffer.t instead of cstruct.t (mirage/awa-ssh#85 @hannesm)
