### PR TITLE
[new release] slipshow (0.11.0): Brazlip

### DIFF
--- a/packages/slipshow/slipshow.0.11.0/opam
+++ b/packages/slipshow/slipshow.0.11.0/opam
@@ -16,7 +16,7 @@ depends: [
   "crunch" {with-dev-setup}
   "lambdasoup" {with-test}
   "cmdliner" {>= "1.3.0"}
-  "base64"
+  "base64" {>= "3.3.0"}
   "bos"
   "lwt"
   "inotify" {os = "linux"}

--- a/packages/slipshow/slipshow.0.11.0/opam
+++ b/packages/slipshow/slipshow.0.11.0/opam
@@ -1,0 +1,70 @@
+opam-version: "2.0"
+synopsis: "A compiler from markdown to slipshow"
+description:
+  "Slipshow is an engine to write slips, a concept evolved from slides."
+maintainer: ["Paul-Elliot"]
+authors: ["Paul-Elliot"]
+license: ["GPL-3.0-or-later" "ISC" "BSD-3-Clause" "Apache-2.0" "OFL-1.1"]
+tags: ["slipshow" "presentation" "slideshow" "beamer"]
+homepage: "https://github.com/panglesd/slipshow"
+doc: "https://slipshow.readthedocs.io"
+bug-reports: "https://github.com/panglesd/slipshow/issues"
+depends: [
+  "ocaml" {>= "4.14"}
+  "dune" {>= "3.6"}
+  "grace" {>= "0.3.0"}
+  "crunch" {with-dev-setup}
+  "lambdasoup" {with-test}
+  "cmdliner" {>= "1.3.0"}
+  "base64"
+  "bos"
+  "lwt"
+  "inotify" {os = "linux"}
+  "cf-lwt" {>= "0.4"}
+  "astring"
+  "fmt"
+  "logs"
+  "fsevents-lwt"
+  "js_of_ocaml-compiler" {>= "6.0.1"}
+  "js_of_ocaml-lwt"
+  "magic-mime"
+  "dream" {>= "1.0.0~alpha5"}
+  "fpath"
+  "ppx_blob" {>= "0.8.0"}
+  "sexplib"
+  "ppx_sexp_conv"
+  "ppx_deriving_yojson"
+  "ansi" {>= "0.7.0"}
+  "linol"
+  "linol-lwt"
+  "odoc" {with-doc}
+  "ocamlformat" {with-dev-setup & = "0.28.1"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/panglesd/slipshow.git"
+# We avoid 32 bits arcitecture because our usage of ppx_blob generates strings
+# whose size exceed the maximum size in 32 bits OCaml...
+available: arch != "arm32" & arch != "x86_32"
+x-maintenance-intent: [ "(latest)" ]
+url {
+  src:
+    "https://github.com/panglesd/slipshow/releases/download/v0.11.0/slipshow-0.11.0.tbz"
+  checksum: [
+    "sha256=c0cd9a2a4352d86c54e402aa46adbf94fd3ddb2f3faa865c02031a5a9239c2e7"
+    "sha512=e3a49927144af3f085ef12407e8fd4183bdc67f5fa590eb524f01d042c35cd00a061442a86b6bbab182f6a3893836eb236137739bef16e9eafd5bfca921d00d8"
+  ]
+}
+x-commit-hash: "ab6904e80e00819ed7fd71cae50f8aec191077de"

--- a/packages/slipshow/slipshow.0.11.0/opam
+++ b/packages/slipshow/slipshow.0.11.0/opam
@@ -35,7 +35,7 @@ depends: [
   "ppx_sexp_conv"
   "ppx_deriving_yojson"
   "ansi" {>= "0.7.0"}
-  "linol"
+  "linol" {>= "0.11"}
   "linol-lwt"
   "odoc" {with-doc}
   "ocamlformat" {with-dev-setup & = "0.28.1"}


### PR DESCRIPTION
See the [release page](https://github.com/panglesd/slipshow/releases/tag/v0.11.0) for the announcement!

CHANGES:

### Added

- Add a visual indicator for the state of the previewer (disconnected, refreshing, ...) (panglesd/slipshow#220, panglesd/slipshow#222)
- Allow frontmatter in included files (panglesd/slipshow#228)
- (panglesd/slipshow#229) Add an LSP server, available though the `slipshow lsp` command, to interact with your editor. The server supports:
  - Diagnostics
  - Documentation for actions on hover
  - Go to definition (from IDs in action, to the associated element)
  - Occurrences of ID
  - Completion for IDs in actions
- Add preview server capabilities to the LSP server (panglesd/slipshow#233)
- Add more syntax to include raw html, either in the file or as external file (panglesd/slipshow#236)

### Changed

- In frontmatter, distinguish between `attributes` (the attributes for the whole *file*) and `toplevel-attributes` (the attributes for the whole *presentation*). Change `toplevel-attributes` to `attributes` in your presentation to fix the breaking change. (panglesd/slipshow#229)

### Fixed

- Fixed hot-reload not resuming after a disconnect (panglesd/slipshow#220)