### PR TITLE
Package contract.0.1.0

### DIFF
--- a/packages/contract/contract.0.1.0/opam
+++ b/packages/contract/contract.0.1.0/opam
@@ -1,0 +1,33 @@
+opam-version: "2.0"
+maintainer: "Thomas B. <29905917+funwithcthulhu@users.noreply.github.com>"
+authors: ["Thomas B."]
+license: "MIT"
+homepage: "https://github.com/funwithcthulhu/contract"
+bug-reports: "https://github.com/funwithcthulhu/contract/issues"
+dev-repo: "git+https://github.com/funwithcthulhu/contract.git"
+doc: "https://github.com/funwithcthulhu/contract#readme"
+tags: ["http" "api" "contract" "openapi"]
+synopsis: "Typed HTTP API contracts for OCaml"
+description: """
+contract describes REST-style HTTP API contracts as typed OCaml values.
+The current package provides a pure core for endpoint definitions, parameter
+and JSON decoding, request validation, and OpenAPI 3.0.3 output.
+"""
+depends: [
+  "ocaml" {>= "5.0"}
+  "dune" {>= "3.11"}
+  "yojson" {>= "2.0.0"}
+  "alcotest" {with-test & >= "1.9.0"}
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name] {with-test}
+]
+url {
+  src:
+    "https://github.com/funwithcthulhu/contract/archive/refs/tags/0.1.0.tar.gz"
+  checksum: [
+    "md5=c51c9108224fdadd034d5f6f405624db"
+    "sha512=5a8cb930abdc33382051b392caea40af98da35e82befc5a1c13374565178c6b91e4371758daa60062063540306672a8064ff3ca185d0ab93934be724ec52a58d"
+  ]
+}

--- a/packages/contract/contract.0.1.0/opam
+++ b/packages/contract/contract.0.1.0/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "Thomas B. <29905917+funwithcthulhu@users.noreply.github.com>"
+maintainer: "Thomas B."
 authors: ["Thomas B."]
 license: "MIT"
 homepage: "https://github.com/funwithcthulhu/contract"


### PR DESCRIPTION
### `contract.0.1.0`
Typed HTTP API contracts for OCaml
contract describes REST-style HTTP API contracts as typed OCaml values.
The current package provides a pure core for endpoint definitions, parameter
and JSON decoding, request validation, and OpenAPI 3.0.3 output.



---
* Homepage: https://github.com/funwithcthulhu/contract
* Source repo: git+https://github.com/funwithcthulhu/contract.git
* Bug tracker: https://github.com/funwithcthulhu/contract/issues

---
:camel: Pull-request generated by opam-publish v3.0.0