### PR TITLE
[new release] uring (2.14.0)

### DIFF
--- a/packages/eio_linux/eio_linux.0.10/opam
+++ b/packages/eio_linux/eio_linux.0.10/opam
@@ -15,7 +15,7 @@ depends: [
   "logs" {>= "0.7.0"}
   "fmt" {>= "0.8.9"}
   "cmdliner" {>= "1.1.0" & with-test}
-  "uring" {>= "0.5"}
+  "uring" {>= "0.5" & < "2.14.0"}
   "odoc" {with-doc}
 ]
 build: [

--- a/packages/eio_linux/eio_linux.0.11/opam
+++ b/packages/eio_linux/eio_linux.0.11/opam
@@ -15,7 +15,7 @@ depends: [
   "logs" {>= "0.7.0"}
   "fmt" {>= "0.8.9"}
   "cmdliner" {>= "1.1.0" & with-test}
-  "uring" {>= "0.5"}
+  "uring" {>= "0.5" & < "2.14.0"}
   "odoc" {with-doc}
 ]
 build: [

--- a/packages/eio_linux/eio_linux.0.12/opam
+++ b/packages/eio_linux/eio_linux.0.12/opam
@@ -15,7 +15,7 @@ depends: [
   "logs" {>= "0.7.0"}
   "fmt" {>= "0.8.9"}
   "cmdliner" {>= "1.1.0" & with-test}
-  "uring" {>= "0.5"}
+  "uring" {>= "0.5" & < "2.14.0"}
   "odoc" {with-doc}
 ]
 build: [

--- a/packages/eio_linux/eio_linux.0.13/opam
+++ b/packages/eio_linux/eio_linux.0.13/opam
@@ -15,7 +15,7 @@ depends: [
   "logs" {>= "0.7.0"}
   "fmt" {>= "0.8.9"}
   "cmdliner" {>= "1.1.0" & with-test}
-  "uring" {>= "0.7"}
+  "uring" {>= "0.7" & < "2.14.0"}
   "odoc" {with-doc}
 ]
 build: [

--- a/packages/eio_linux/eio_linux.0.14/opam
+++ b/packages/eio_linux/eio_linux.0.14/opam
@@ -15,7 +15,7 @@ depends: [
   "logs" {>= "0.7.0"}
   "fmt" {>= "0.8.9"}
   "cmdliner" {>= "1.1.0" & with-test}
-  "uring" {>= "0.7"}
+  "uring" {>= "0.7" & < "2.14.0"}
   "odoc" {with-doc}
 ]
 build: [

--- a/packages/eio_linux/eio_linux.0.15/opam
+++ b/packages/eio_linux/eio_linux.0.15/opam
@@ -15,7 +15,7 @@ depends: [
   "logs" {>= "0.7.0"}
   "fmt" {>= "0.8.9"}
   "cmdliner" {>= "1.1.0" & with-test}
-  "uring" {>= "0.7"}
+  "uring" {>= "0.7" & < "2.14.0"}
   "odoc" {with-doc}
 ]
 build: [

--- a/packages/eio_linux/eio_linux.0.2/opam
+++ b/packages/eio_linux/eio_linux.0.2/opam
@@ -15,7 +15,7 @@ depends: [
   "mdx" {>= "1.10.0" & with-test}
   "logs" {>= "0.7.0"}
   "fmt" {>= "0.8.9"}
-  "uring" {>= "0.3"}
+  "uring" {>= "0.3" & < "2.14.0"}
   "odoc" {with-doc}
 ]
 build: [

--- a/packages/eio_linux/eio_linux.0.3/opam
+++ b/packages/eio_linux/eio_linux.0.3/opam
@@ -16,7 +16,7 @@ depends: [
   "logs" {>= "0.7.0"}
   "fmt" {>= "0.8.9"}
   "cmdliner" {>= "1.1.0" & with-test}
-  "uring" {>= "0.3"}
+  "uring" {>= "0.3" & < "2.14.0"}
   "odoc" {with-doc}
 ]
 build: [

--- a/packages/eio_linux/eio_linux.0.4/opam
+++ b/packages/eio_linux/eio_linux.0.4/opam
@@ -15,7 +15,7 @@ depends: [
   "logs" {>= "0.7.0"}
   "fmt" {>= "0.8.9"}
   "cmdliner" {>= "1.1.0" & with-test}
-  "uring" {>= "0.3"}
+  "uring" {>= "0.3" & < "2.14.0"}
   "odoc" {with-doc}
 ]
 build: [

--- a/packages/eio_linux/eio_linux.0.5/opam
+++ b/packages/eio_linux/eio_linux.0.5/opam
@@ -15,7 +15,7 @@ depends: [
   "logs" {>= "0.7.0"}
   "fmt" {>= "0.8.9"}
   "cmdliner" {>= "1.1.0" & with-test}
-  "uring" {>= "0.4"}
+  "uring" {>= "0.4" & < "2.14.0"}
   "odoc" {with-doc}
 ]
 build: [

--- a/packages/eio_linux/eio_linux.0.6/opam
+++ b/packages/eio_linux/eio_linux.0.6/opam
@@ -15,7 +15,7 @@ depends: [
   "logs" {>= "0.7.0"}
   "fmt" {>= "0.8.9"}
   "cmdliner" {>= "1.1.0" & with-test}
-  "uring" {>= "0.4"}
+  "uring" {>= "0.4" & < "2.14.0"}
   "odoc" {with-doc}
 ]
 build: [

--- a/packages/eio_linux/eio_linux.0.7/opam
+++ b/packages/eio_linux/eio_linux.0.7/opam
@@ -15,7 +15,7 @@ depends: [
   "logs" {>= "0.7.0"}
   "fmt" {>= "0.8.9"}
   "cmdliner" {>= "1.1.0" & with-test}
-  "uring" {>= "0.4"}
+  "uring" {>= "0.4" & < "2.14.0"}
   "odoc" {with-doc}
 ]
 build: [

--- a/packages/eio_linux/eio_linux.0.8.1/opam
+++ b/packages/eio_linux/eio_linux.0.8.1/opam
@@ -15,7 +15,7 @@ depends: [
   "logs" {>= "0.7.0"}
   "fmt" {>= "0.8.9"}
   "cmdliner" {>= "1.1.0" & with-test}
-  "uring" {>= "0.5"}
+  "uring" {>= "0.5" & < "2.14.0"}
   "odoc" {with-doc}
 ]
 build: [

--- a/packages/eio_linux/eio_linux.0.9/opam
+++ b/packages/eio_linux/eio_linux.0.9/opam
@@ -15,7 +15,7 @@ depends: [
   "logs" {>= "0.7.0"}
   "fmt" {>= "0.8.9"}
   "cmdliner" {>= "1.1.0" & with-test}
-  "uring" {>= "0.5"}
+  "uring" {>= "0.5" & < "2.14.0"}
   "odoc" {with-doc}
 ]
 build: [

--- a/packages/eio_linux/eio_linux.1.0/opam
+++ b/packages/eio_linux/eio_linux.1.0/opam
@@ -15,7 +15,7 @@ depends: [
   "logs" {>= "0.7.0" & with-test}
   "fmt" {>= "0.8.9"}
   "cmdliner" {>= "1.1.0" & with-test}
-  "uring" {>= "0.7"}
+  "uring" {>= "0.7" & < "2.14.0"}
   "odoc" {with-doc}
 ]
 build: [

--- a/packages/eio_linux/eio_linux.1.1/opam
+++ b/packages/eio_linux/eio_linux.1.1/opam
@@ -15,7 +15,7 @@ depends: [
   "logs" {>= "0.7.0" & with-test}
   "fmt" {>= "0.8.9"}
   "cmdliner" {>= "1.1.0" & with-test}
-  "uring" {>= "0.9"}
+  "uring" {>= "0.9" & < "2.14.0"}
   "odoc" {with-doc}
 ]
 build: [

--- a/packages/eio_linux/eio_linux.1.2/opam
+++ b/packages/eio_linux/eio_linux.1.2/opam
@@ -15,7 +15,7 @@ depends: [
   "logs" {>= "0.7.0" & with-test}
   "fmt" {>= "0.8.9"}
   "cmdliner" {>= "1.1.0" & with-test}
-  "uring" {>= "0.9"}
+  "uring" {>= "0.9" & < "2.14.0"}
   "odoc" {with-doc}
 ]
 build: [

--- a/packages/eio_linux/eio_linux.1.3/opam
+++ b/packages/eio_linux/eio_linux.1.3/opam
@@ -15,7 +15,7 @@ depends: [
   "logs" {>= "0.7.0" & with-test}
   "fmt" {>= "0.8.9"}
   "cmdliner" {>= "1.1.0" & with-test}
-  "uring" {>= "0.9"}
+  "uring" {>= "0.9" & < "2.14.0"}
   "odoc" {with-doc}
 ]
 build: [

--- a/packages/uring/uring.2.14.0/opam
+++ b/packages/uring/uring.2.14.0/opam
@@ -1,0 +1,56 @@
+opam-version: "2.0"
+synopsis: "OCaml bindings for Linux io_uring"
+description:
+  "Bindings to the Linux io_uring kernel IO interfaces. See https://github.com/ocaml-multicore/eio for a higher-level API using this."
+maintainer: ["anil@recoil.org"]
+authors: ["Anil Madhavapeddy" "Sadiq Jaffer" "Thomas Leonard"]
+homepage: "https://github.com/ocaml-multicore/ocaml-uring"
+doc: "https://ocaml-multicore.github.io/ocaml-uring/"
+bug-reports: "https://github.com/ocaml-multicore/ocaml-uring/issues"
+depends: [
+  "dune" {>= "3.0"}
+  "cstruct" {>= "6.0.1"}
+  "ocaml" {>= "4.12.0"}
+  "dune-configurator"
+  "lwt" {with-test & >= "5.0.0"}
+  "bechamel" {>= "0.1.0" & with-test}
+  "logs" {with-test & >= "0.5.0"}
+  "cmdliner" {with-test & >= "1.1.0"}
+  "fmt" {>= "0.8.10"}
+  "optint" {>= "0.1.0"}
+  "mdx" {>= "2.1.0" & with-test}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/ocaml-multicore/ocaml-uring.git"
+depexts: [
+  ["linux-headers"] {os-distribution = "alpine"}
+]
+available: [os = "linux"]
+license: ["ISC" "MIT"]
+x-ci-accept-failures: [
+  "centos-7" # default C compiler does not support stdatomic.h
+  "oraclelinux-7" # default C compiler does not support stdatomic.h
+]
+url {
+  src:
+    "https://github.com/ocaml-multicore/ocaml-uring/releases/download/v2.14.0/uring-2.14.0.tbz"
+  checksum: [
+    "sha256=53a077fc4c6bc82ed62d88f5888507a1765096e144e7a45fdddc0ea6ec7fa881"
+    "sha512=980b199a77bdcb6b7fda3a81e6269aec29b0d197a229220b612e07e52760f1e77f103a3aefbae75363f43c2d88b08b2d48a560792920cc48864887c74b836ddc"
+  ]
+}
+x-commit-hash: "780683861a905461846cff1d2648c68ed48b7fd5"


### PR DESCRIPTION
OCaml bindings for Linux io_uring

- Project page: <a href="https://github.com/ocaml-multicore/ocaml-uring">https://github.com/ocaml-multicore/ocaml-uring</a>
- Documentation: <a href="https://ocaml-multicore.github.io/ocaml-uring/">https://ocaml-multicore.github.io/ocaml-uring/</a>

##### CHANGES:

Breaking changes:

- Add `Uring.Res` module to handle result values (@talex5 ocaml-multicore/ocaml-uring#131).
  This avoids the need to use `Obj.magic` for operations that return
  file descriptors. Based on investigations by @dra27 in ocaml-multicore/ocaml-uring#129 and ocaml-multicore/ocaml-uring#130
  and an initial request from @koonwen.

  To upgrade, you can either use the functions in the `Res` module,
  or just cast back to `int` with `(res :> int)` and continue as before.

Other new features:

- Update to uring 2.14 (@talex5 ocaml-multicore/ocaml-uring#138).

- Add `send_zc` and `sendmsg_zc` ops (@avsm ocaml-multicore/ocaml-uring#139).

Bug fixes:

- Register `polling_timeout` with GC in `ocaml_uring_setup` (@talex5 ocaml-multicore/ocaml-uring#136, spotted by @polytypic).

- Use `MSG_CMSG_CLOEXEC` when receiving file descriptors (@talex5 ocaml-multicore/ocaml-uring#132).

Documentation:

- Warn about ZFS bug when using `write_fixed` (@talex5 ocaml-multicore/ocaml-uring#133, suggested by @toastal).

Build and tests:

- If the sending test fails, don't wait to receive (@talex5 ocaml-multicore/ocaml-uring#134).

- Fix mkdir test (@talex5 ocaml-multicore/ocaml-uring#127).

- Document and simplify the build process (@talex5 ocaml-multicore/ocaml-uring#137).
