### PR TITLE
[new release] rtree (0.2.0)

### DIFF
--- a/packages/rtree/rtree.0.2.0/opam
+++ b/packages/rtree/rtree.0.2.0/opam
@@ -1,0 +1,43 @@
+opam-version: "2.0"
+synopsis: "A pure OCaml R-Tree implementation"
+description:
+  "This implements a simple, functional R-Tree library in pure OCaml with support for efficient bulk loading of values."
+maintainer: ["patrick@sirref.org"]
+authors: ["Marius A. Eriksen" "Patrick Ferris"]
+license: "BSD-3-Clause"
+tags: ["spatial" "index"]
+homepage: "https://github.com/geocaml/ocaml-rtree"
+bug-reports: "https://github.com/geocaml/ocaml-rtree/issues"
+depends: [
+  "dune" {>= "3.6"}
+  "repr" {>= "0.4.0"}
+  "bechamel" {with-test}
+  "vg" {with-test}
+  "ounit2" {with-test}
+  "mdx" {with-test & >= "2.2.0"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/geocaml/ocaml-rtree.git"
+url {
+  src:
+    "https://github.com/geocaml/ocaml-rtree/releases/download/v0.2.0/rtree-0.2.0.tbz"
+  checksum: [
+    "sha256=e7679552ebaf3b16fe441811436ddc3a13732912632f94e2473a9c2ea7e19991"
+    "sha512=7be935e9ce89e2629174efb55a07902fc7a3a1b490b2c78aa799bd24f9e57b907fe215e9c2a6cfce7ce6cb2ac8999fa39152ef63602ef911b35f7c9f513b8462"
+  ]
+}
+x-commit-hash: "81f329be53907f4870b576cec8c68e5d0c678c93"


### PR DESCRIPTION
A pure OCaml R-Tree implementation

- Project page: <a href="https://github.com/geocaml/ocaml-rtree">https://github.com/geocaml/ocaml-rtree</a>

##### CHANGES:

- Add a set of `remove` functions (geocaml/ocaml-rtree#44, @FayCarsons)

## Bugs, Fixes and Optimisations

- Fix `values` not returning entire tree (geocaml/ocaml-rtree#40, @mdales)
- Added bounds function to get overall tree dimensions (geocaml/ocaml-rtree#42, @mdales)
