### PR TITLE
sync ctypes opam with upstream opam files

### DIFF
--- a/packages/ctypes-foreign/ctypes-foreign.0.24.0/opam
+++ b/packages/ctypes-foreign/ctypes-foreign.0.24.0/opam
@@ -34,12 +34,10 @@ build: [
     name
     "-j"
     jobs
-    "--promote-install-files=false"
     "@install"
     "@runtest" {with-test}
     "@doc" {with-doc}
   ]
-  ["dune" "install" "-p" name "--create-install-files" name]
 ]
 dev-repo: "git+https://github.com/yallop/ocaml-ctypes.git"
 url {
@@ -50,3 +48,4 @@ url {
     "md5=064316aaf508a9db203f114bb8401dee"
   ]
 }
+x-maintenance-intent: ["(latest)"]

--- a/packages/ctypes/ctypes.0.24.0/opam
+++ b/packages/ctypes/ctypes.0.24.0/opam
@@ -43,12 +43,10 @@ build: [
     name
     "-j"
     jobs
-    "--promote-install-files=false"
     "@install"
     "@runtest" {with-test}
     "@doc" {with-doc}
   ]
-  ["dune" "install" "-p" name "--create-install-files" name]
 ]
 dev-repo: "git+https://github.com/yallop/ocaml-ctypes.git"
 url {
@@ -62,4 +60,4 @@ url {
 conflicts: [
   "host-system-msvc"
 ]
-x-maintenance-intent: ["(any).(any).(latest)"]
+x-maintenance-intent: ["(latest)"]


### PR DESCRIPTION
This uses the default install file handling which results in a relocatable dune-package file (the modern default).

In practise, this means that the dune-package installed by ctypes will be relocatable:

```
(lang dune 3.23)
(name ctypes)
(version 0.24.0)
(sections (lib .) (libexec .) (doc ../../doc/ctypes) (stublibs ../stublibs))
```

(instead of hardcoded absolute paths in the sections, which is what happens currently).

cc @yallop as the maintainer for approval and also in case there's a reason for the divergence that I didn't spot!