### PR TITLE
Package transom.0.1.0

### DIFF
--- a/packages/transom/transom.0.1.0/opam
+++ b/packages/transom/transom.0.1.0/opam
@@ -10,7 +10,7 @@ dev-repo: "git+https://github.com/funwithcthulhu/transom.git"
 depends: [
   "ocaml" {>= "5.1"}
   "dune" {>= "3.11"}
-  "cmdliner"
+  "cmdliner" {>= "1.3.0"}
   "yojson" {>= "2.0.0"}
 ]
 build: [

--- a/packages/transom/transom.0.1.0/opam
+++ b/packages/transom/transom.0.1.0/opam
@@ -1,0 +1,27 @@
+opam-version: "2.0"
+synopsis: "OCaml sidecar glue for Tauri-style desktop apps"
+description: "Transom connects a Tauri/webview frontend to an OCaml sidecar over newline-delimited JSON."
+maintainer: "funwithcthulhu29@gmail.com"
+authors: ["funwithcthulhu"]
+license: "MIT"
+homepage: "https://github.com/funwithcthulhu/transom"
+bug-reports: "https://github.com/funwithcthulhu/transom/issues"
+dev-repo: "git+https://github.com/funwithcthulhu/transom.git"
+depends: [
+  "ocaml" {>= "5.1"}
+  "dune" {>= "3.11"}
+  "cmdliner"
+  "yojson"
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+url {
+  src:
+    "https://github.com/funwithcthulhu/transom/archive/refs/tags/v0.1.0.tar.gz"
+  checksum: [
+    "md5=a6aa17a9cab249e390f574553bc22620"
+    "sha512=56ac775c6b61fc45488795f2658fcfcbf380427f9477e94d6d69770a6df288851f266fb026d27696ba579caa37386404e4059fa2d2218b23e8b1e5c59cd9994b"
+  ]
+}

--- a/packages/transom/transom.0.1.0/opam
+++ b/packages/transom/transom.0.1.0/opam
@@ -11,7 +11,7 @@ depends: [
   "ocaml" {>= "5.1"}
   "dune" {>= "3.11"}
   "cmdliner"
-  "yojson"
+  "yojson" {>= "2.0.0"}
 ]
 build: [
   ["dune" "subst"] {dev}


### PR DESCRIPTION
### `transom.0.1.0`
OCaml sidecar glue for Tauri-style desktop apps
Transom connects a Tauri/webview frontend to an OCaml sidecar over newline-delimited JSON.



---
* Homepage: https://github.com/funwithcthulhu/transom
* Source repo: git+https://github.com/funwithcthulhu/transom.git
* Bug tracker: https://github.com/funwithcthulhu/transom/issues

---
:camel: Pull-request generated by opam-publish v3.0.0