### PR TITLE
CI: GHA red lights on opam syntax errors

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -81,9 +81,14 @@ jobs:
           }
           Foreach ($pkg in '${{ matrix.packages }}' -split ' ') {
             Write-Host "::group::Testing `e[1;34m$pkg`e[0m"
+            $pkg_dir = $pkg.Split('.')[0]
+            opam lint -v "packages/$pkg_dir/$pkg"
+            if ($LASTEXITCODE -ne 0) {
+              Write-Host "$pkg failed linting."; $failed = $true
+            }
             opam install -v --color=always --confirm-level=unsafe-yes "$pkg"
             $install_exit_code = $LASTEXITCODE
-            opam config list $pkg.Split('.')[0] | Skip-Until ':opamfile'
+            opam config list $pkg_dir | Skip-Until ':opamfile'
             Write-Host "::endgroup::"
             switch ($install_exit_code) {
               0 { Write-Host "`e[1;32m$pkg installed successfully`e[0m."; Break }
@@ -95,5 +100,5 @@ jobs:
             Write-Host
           }
           if ($failed) {
-            throw "One or more packages failed to build"
+            throw "One or more packages failed to lint or build"
           }


### PR DESCRIPTION
Fixes https://github.com/ocaml/opam-repository/issues/29513

In the above, our GHA CI tricked me, as it was green despite running on an opam file with syntax errors.

Now it happened again today in https://github.com/ocaml/opam-repository/pull/29957, which had only green GHA CI lights and a seemingly pending `opam-ci` run before it got merged, and with https://github.com/ocaml/opam-repository/pull/29958 following up to fix it.

It seems bad practice that GHA turns green on what should be considered errors.

This PR thus adjusts the Windows GHA CI to signal error and turn red.
It does so by running an `opam lint` on each changed package.

Pardon my Powershell! :sweat_smile: