### PR TITLE
Release of Solo5.0.11.0

### DIFF
--- a/packages/solo5-cross-aarch64/solo5-cross-aarch64.0.11.0/opam
+++ b/packages/solo5-cross-aarch64/solo5-cross-aarch64.0.11.0/opam
@@ -1,0 +1,46 @@
+opam-version: "2.0"
+maintainer: "martin@lucina.net"
+authors: [
+  "Dan Williams <djwillia@us.ibm.com>"
+  "Martin Lucina <martin@lucina.net>"
+  "Ricardo Koller <kollerr@us.ibm.com>"
+]
+homepage: "https://github.com/solo5/solo5"
+bug-reports: "https://github.com/solo5/solo5/issues"
+license: "ISC"
+dev-repo: "git+https://github.com/solo5/solo5.git"
+build: [
+  ["env" "TARGET_CC=aarch64-linux-gnu-gcc" "TARGET_LD=aarch64-linux-gnu-ld" "TARGET_OBJCOPY=aarch64-linux-gnu-objcopy" "./configure.sh" "--prefix=%{prefix}%"]
+  [make "V=1"]
+]
+install: [make "V=1" "install-toolchain"]
+depends: [
+  "conf-pkg-config" {build & os = "linux"}
+  "conf-libseccomp" {build & os = "linux"}
+  "solo5" {= version}
+]
+depexts: [
+  ["linux-headers"] {os-distribution = "alpine"}
+  ["kernel-headers"] {os-distribution = "fedora"}
+  ["kernel-headers"] {os-distribution = "rhel"}
+  ["linux-libc-dev"] {os-family = "debian"}
+  ["gcc-aarch64-linux-gnu"] {os-family = "debian"}
+]
+available: [
+  (arch != "arm64") &
+  (os = "linux" & os-family = "debian")
+]
+synopsis: "Solo5 sandboxed execution environment"
+description: """
+Solo5 is a sandboxed execution environment primarily intended
+for, but not limited to, running applications built using various
+unikernels (a.k.a.  library operating systems).
+
+This package provides the Solo5 components needed to cross-build
+MirageOS unikernels for the aarch64 architecture.
+"""
+x-maintenance-intent: [ "(latest)" ]
+url {
+  src: "https://github.com/Solo5/solo5/releases/download/v0.11.0/solo5-v0.11.0.tar.gz"
+  checksum: "sha512=0aa765594b6a4dbebabb7c88dc5155042b323881a577a8c23c40c3e347a1d4814dfa23808d0349ca3355e4540a35d758dfbf1848af8c4798fac1cd3d3d9457fe"
+}

--- a/packages/solo5/solo5.0.11.0/opam
+++ b/packages/solo5/solo5.0.11.0/opam
@@ -1,0 +1,54 @@
+opam-version: "2.0"
+maintainer: "martin@lucina.net"
+authors: [
+  "Dan Williams <djwillia@us.ibm.com>"
+  "Martin Lucina <martin@lucina.net>"
+  "Ricardo Koller <kollerr@us.ibm.com>"
+]
+homepage: "https://github.com/solo5/solo5"
+bug-reports: "https://github.com/solo5/solo5/issues"
+license: "ISC"
+dev-repo: "git+https://github.com/solo5/solo5.git"
+build: [
+  ["./configure.sh" "--prefix=%{prefix}%"]
+  [make "V=1"]
+]
+install: [make "V=1" "install"]
+depends: [
+  "conf-pkg-config" {build & os = "linux"}
+  "conf-libseccomp" {build & os = "linux"}
+]
+depexts: [
+  ["linux-headers"] {os-distribution = "alpine"}
+  ["kernel-headers"] {os-distribution = "fedora"}
+  ["kernel-headers"] {os-distribution = "rhel"}
+  ["linux-libc-dev"] {os-family = "debian"}
+]
+conflicts: [
+  "ocaml-freestanding" {< "0.7.0"}
+  "solo5-bindings-hvt"
+  "solo5-bindings-spt"
+  "solo5-bindings-virtio"
+  "solo5-bindings-muen"
+  "solo5-bindings-genode"
+  "solo5-bindings-xen"
+]
+available: [
+  (arch = "x86_64" | arch = "arm64" | arch = "ppc64") &
+  (os = "linux" | os = "freebsd" | os = "openbsd")
+]
+synopsis: "Solo5 sandboxed execution environment"
+description: """
+Solo5 is a sandboxed execution environment primarily intended
+for, but not limited to, running applications built using various
+unikernels (a.k.a.  library operating systems).
+
+This package provides the Solo5 components needed to build and
+run MirageOS unikernels on the host system.
+"""
+x-maintenance-intent: [ "(latest)" ]
+x-ci-accept-failures: [ "centos-7" "opensuse-15.6" ] # too old GCC compiler (OpenSUSE uses GCC 7 and we require GCC 10)
+url {
+  src: "https://github.com/Solo5/solo5/releases/download/v0.11.0/solo5-v0.11.0.tar.gz"
+  checksum: "sha512=0aa765594b6a4dbebabb7c88dc5155042b323881a577a8c23c40c3e347a1d4814dfa23808d0349ca3355e4540a35d758dfbf1848af8c4798fac1cd3d3d9457fe"
+}


### PR DESCRIPTION
- Lint our codebase with few warnings (@dinosaure, @hannesm, @MisterDA, solo5/solo5#632)

  Our codebase compiles with:
  - `-Wshadow`
  - `-Wpointer-arith`
  - `-Wcast-qual`
  - `-Wsign-compare`
  - `-Wwrite-strings`

  It ensures a better codebase and less undefined behaviors.
- Apply `clang-format` on our codebase (@dinosaure, @hannesm, solo5/solo5#633)
- Fix the CAPSICUM support on FreeBSD (@hannesm, @sg2342, spotted by @dinosaure, solo5/solo5#636)
- Improve performance on our net interfaces on Linux via `eventfd(2)` (@dinosaure, @hannesm, @reynir, solo5/solo5#637)

  This PR changes deeply how we read and write on our TAP interface. This change mainly concerns Linux and the use of `eventfd(2)` to avoid a full VM exit whenever one wishes to write to a network interface. A few benchmarks (using `iperf3`) have been carried out on Linux and FreeBSD. For the former, an improvement was observed (around three times more data can be transferred per second), whilst no regression was observed for the latter (though no improvement either).

  This change **does not involve** an ABI change, meaning that the tender can still run unikernels that have not been compiled with this version and vice versa (a unikernel compiled with this version can be run by an older tender).
- `solo5-hvt` set-up `seccomp` filters (@pocopepe, @dinosaure, @hannesm, solo5/solo5#638, solo5/solo5#282)

  `solo5-hvt` requires `libseccomp` and add some filters.