### PR TITLE
[new release] awso (7 packages) (0.9.1)

### DIFF
--- a/packages/awso-async/awso-async.0.9.1/opam
+++ b/packages/awso-async/awso-async.0.9.1/opam
@@ -1,0 +1,52 @@
+opam-version: "2.0"
+synopsis:
+  "AWS client for Async (400+ services, auto-generated from botocore)"
+description:
+  "AWS service bindings backed by Jane Street's Async I/O library. Generated from botocore for ~400 services. Use this if your codebase is already Async-flavored."
+maintainer: ["Michael Bacarella <m@bacarella.com>"]
+authors: [
+  "Ashish Agarwal <ashish@solvuu.com>"
+  "Solvuu Inc."
+  "Michael Bacarella <m@bacarella.com>"
+]
+license: "MIT"
+homepage: "https://github.com/mbacarella/ocaml-awso"
+doc: "https://mbacarella.github.io/ocaml-awso/"
+bug-reports: "https://github.com/mbacarella/ocaml-awso/issues"
+depends: [
+  "dune" {>= "3.6"}
+  "ocaml" {>= "5.3.0"}
+  "awso"
+  "cohttp-async"
+  "core_unix" {>= "v0.16.0"}
+  "ppx_jane" {>= "v0.16.0"}
+  "ppx_yojson_conv"
+  "async" {>= "v0.16.0"}
+  "async_ssl" {>= "v0.16.1-2" & (< "v0.17.0" | >= "v0.17.0-2")}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/mbacarella/ocaml-awso.git"
+available: [ os != "win32" ]
+url {
+  src:
+    "https://github.com/mbacarella/ocaml-awso/releases/download/0.9.1/awso-0.9.1.tbz"
+  checksum: [
+    "sha256=e0e7510192b7e45871cff5c60e5162a77a9fa103b6924136fb1fea5db2092b26"
+    "sha512=51a18cf74c122b021bd84ef5728b7c5b2d5e767f03d5cd2387d886edc34a68cf54a3183e2d6c4939b4c8d3e0c0e406c869d019f2ee9a0903ae4cf7ca725572f0"
+  ]
+}
+x-commit-hash: "c636fb198135987794cdbc57d766845f0fd5c9f2"

--- a/packages/awso-async/awso-async.0.9.1/opam
+++ b/packages/awso-async/awso-async.0.9.1/opam
@@ -16,7 +16,7 @@ bug-reports: "https://github.com/mbacarella/ocaml-awso/issues"
 depends: [
   "dune" {>= "3.6"}
   "ocaml" {>= "5.3.0"}
-  "awso"
+  "awso" {= version}
   "cohttp-async"
   "core_unix" {>= "v0.16.0"}
   "ppx_jane" {>= "v0.16.0"}

--- a/packages/awso-cli/awso-cli.0.9.1/opam
+++ b/packages/awso-cli/awso-cli.0.9.1/opam
@@ -1,0 +1,47 @@
+opam-version: "2.0"
+synopsis: "A pure OCaml aws-cli covering 400+ services"
+description:
+  "For fun, an umbrella command-line binary that exposes every awso-async service as a subcommand, similar in spirit to the Python aws-cli. Ships as bytecode because linking ~400 native service libraries exceeds ARM64 executable sizes. Fast enough for interactive use."
+maintainer: ["Michael Bacarella <m@bacarella.com>"]
+authors: [
+  "Ashish Agarwal <ashish@solvuu.com>"
+  "Solvuu Inc."
+  "Michael Bacarella <m@bacarella.com>"
+]
+license: "MIT"
+homepage: "https://github.com/mbacarella/ocaml-awso"
+doc: "https://mbacarella.github.io/ocaml-awso/"
+bug-reports: "https://github.com/mbacarella/ocaml-awso/issues"
+depends: [
+  "dune" {>= "3.6"}
+  "ocaml" {>= "5.3.0"}
+  "awso-async"
+  "core_unix" {>= "v0.16.0"}
+  "ppx_jane" {>= "v0.16.0"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/mbacarella/ocaml-awso.git"
+available: [ os != "win32" ]
+url {
+  src:
+    "https://github.com/mbacarella/ocaml-awso/releases/download/0.9.1/awso-0.9.1.tbz"
+  checksum: [
+    "sha256=e0e7510192b7e45871cff5c60e5162a77a9fa103b6924136fb1fea5db2092b26"
+    "sha512=51a18cf74c122b021bd84ef5728b7c5b2d5e767f03d5cd2387d886edc34a68cf54a3183e2d6c4939b4c8d3e0c0e406c869d019f2ee9a0903ae4cf7ca725572f0"
+  ]
+}
+x-commit-hash: "c636fb198135987794cdbc57d766845f0fd5c9f2"

--- a/packages/awso-cli/awso-cli.0.9.1/opam
+++ b/packages/awso-cli/awso-cli.0.9.1/opam
@@ -15,7 +15,7 @@ bug-reports: "https://github.com/mbacarella/ocaml-awso/issues"
 depends: [
   "dune" {>= "3.6"}
   "ocaml" {>= "5.3.0"}
-  "awso-async"
+  "awso-async" {= version}
   "core_unix" {>= "v0.16.0"}
   "ppx_jane" {>= "v0.16.0"}
   "odoc" {with-doc}

--- a/packages/awso-common/awso-common.0.9.1/opam
+++ b/packages/awso-common/awso-common.0.9.1/opam
@@ -1,0 +1,45 @@
+opam-version: "2.0"
+synopsis: "AWSO common library"
+description:
+  "Small compatibility shim providing Jane Street Core-like helpers (Result, Option, List combinators) without dragging Core itself into non-Async/Lwt builds. Used by awso and the codegen."
+maintainer: ["Michael Bacarella <m@bacarella.com>"]
+authors: [
+  "Ashish Agarwal <ashish@solvuu.com>"
+  "Solvuu Inc."
+  "Michael Bacarella <m@bacarella.com>"
+]
+license: "MIT"
+homepage: "https://github.com/mbacarella/ocaml-awso"
+doc: "https://mbacarella.github.io/ocaml-awso/"
+bug-reports: "https://github.com/mbacarella/ocaml-awso/issues"
+depends: [
+  "dune" {>= "3.6"}
+  "ocaml" {>= "5.3.0"}
+  "ppx_expect"
+  "yojson" {>= "2.0.0"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/mbacarella/ocaml-awso.git"
+url {
+  src:
+    "https://github.com/mbacarella/ocaml-awso/releases/download/0.9.1/awso-0.9.1.tbz"
+  checksum: [
+    "sha256=e0e7510192b7e45871cff5c60e5162a77a9fa103b6924136fb1fea5db2092b26"
+    "sha512=51a18cf74c122b021bd84ef5728b7c5b2d5e767f03d5cd2387d886edc34a68cf54a3183e2d6c4939b4c8d3e0c0e406c869d019f2ee9a0903ae4cf7ca725572f0"
+  ]
+}
+x-commit-hash: "c636fb198135987794cdbc57d766845f0fd5c9f2"

--- a/packages/awso-eio/awso-eio.0.9.1/opam
+++ b/packages/awso-eio/awso-eio.0.9.1/opam
@@ -1,0 +1,50 @@
+opam-version: "2.0"
+synopsis: "AWS client for Eio (400+ services, auto-generated from botocore)"
+description:
+  "AWS service bindings backed by the Eio I/O library. Generated from botocore for ~400 services. Use this if your codebase is Eio-flavored. Requires OCaml 5+."
+maintainer: ["Michael Bacarella <m@bacarella.com>"]
+authors: [
+  "Ashish Agarwal <ashish@solvuu.com>"
+  "Solvuu Inc."
+  "Michael Bacarella <m@bacarella.com>"
+]
+license: "MIT"
+homepage: "https://github.com/mbacarella/ocaml-awso"
+doc: "https://mbacarella.github.io/ocaml-awso/"
+bug-reports: "https://github.com/mbacarella/ocaml-awso/issues"
+depends: [
+  "dune" {>= "3.6"}
+  "ocaml" {>= "5.0"}
+  "awso"
+  "eio" {>= "0.12"}
+  "cohttp-eio" {>= "6.2.1"}
+  "tls" {>= "2.1.0"}
+  "tls-eio" {>= "2.1.0"}
+  "ca-certs"
+  "mirage-crypto-rng" {>= "1.2.0"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/mbacarella/ocaml-awso.git"
+url {
+  src:
+    "https://github.com/mbacarella/ocaml-awso/releases/download/0.9.1/awso-0.9.1.tbz"
+  checksum: [
+    "sha256=e0e7510192b7e45871cff5c60e5162a77a9fa103b6924136fb1fea5db2092b26"
+    "sha512=51a18cf74c122b021bd84ef5728b7c5b2d5e767f03d5cd2387d886edc34a68cf54a3183e2d6c4939b4c8d3e0c0e406c869d019f2ee9a0903ae4cf7ca725572f0"
+  ]
+}
+x-commit-hash: "c636fb198135987794cdbc57d766845f0fd5c9f2"

--- a/packages/awso-eio/awso-eio.0.9.1/opam
+++ b/packages/awso-eio/awso-eio.0.9.1/opam
@@ -15,7 +15,7 @@ bug-reports: "https://github.com/mbacarella/ocaml-awso/issues"
 depends: [
   "dune" {>= "3.6"}
   "ocaml" {>= "5.0"}
-  "awso"
+  "awso" {= version}
   "eio" {>= "0.12"}
   "cohttp-eio" {>= "6.2.1"}
   "tls" {>= "2.1.0"}

--- a/packages/awso-lwt/awso-lwt.0.9.1/opam
+++ b/packages/awso-lwt/awso-lwt.0.9.1/opam
@@ -15,7 +15,7 @@ bug-reports: "https://github.com/mbacarella/ocaml-awso/issues"
 depends: [
   "dune" {>= "3.6"}
   "ocaml" {>= "5.3.0"}
-  "awso"
+  "awso" {= version}
   "lwt"
   "lwt_ppx"
   "cohttp-lwt-unix"

--- a/packages/awso-lwt/awso-lwt.0.9.1/opam
+++ b/packages/awso-lwt/awso-lwt.0.9.1/opam
@@ -1,0 +1,47 @@
+opam-version: "2.0"
+synopsis: "AWS client for Lwt (400+ services, auto-generated from botocore)"
+description:
+  "AWS service bindings backed by the Lwt I/O library. Generated from botocore for ~400 services. Use this if your codebase is Lwt-flavored."
+maintainer: ["Michael Bacarella <m@bacarella.com>"]
+authors: [
+  "Ashish Agarwal <ashish@solvuu.com>"
+  "Solvuu Inc."
+  "Michael Bacarella <m@bacarella.com>"
+]
+license: "MIT"
+homepage: "https://github.com/mbacarella/ocaml-awso"
+doc: "https://mbacarella.github.io/ocaml-awso/"
+bug-reports: "https://github.com/mbacarella/ocaml-awso/issues"
+depends: [
+  "dune" {>= "3.6"}
+  "ocaml" {>= "5.3.0"}
+  "awso"
+  "lwt"
+  "lwt_ppx"
+  "cohttp-lwt-unix"
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/mbacarella/ocaml-awso.git"
+url {
+  src:
+    "https://github.com/mbacarella/ocaml-awso/releases/download/0.9.1/awso-0.9.1.tbz"
+  checksum: [
+    "sha256=e0e7510192b7e45871cff5c60e5162a77a9fa103b6924136fb1fea5db2092b26"
+    "sha512=51a18cf74c122b021bd84ef5728b7c5b2d5e767f03d5cd2387d886edc34a68cf54a3183e2d6c4939b4c8d3e0c0e406c869d019f2ee9a0903ae4cf7ca725572f0"
+  ]
+}
+x-commit-hash: "c636fb198135987794cdbc57d766845f0fd5c9f2"

--- a/packages/awso-sync/awso-sync.0.9.1/opam
+++ b/packages/awso-sync/awso-sync.0.9.1/opam
@@ -1,0 +1,47 @@
+opam-version: "2.0"
+synopsis:
+  "Synchronous (blocking) AWS client (400+ services, auto-generated from botocore)"
+description:
+  "AWS service bindings with a synchronous (blocking) I/O backend implemented over libcurl. Generated from botocore for ~400 services. Useful for scripts, CLIs, and any context where pulling in a concurrent scheduler is overkill."
+maintainer: ["Michael Bacarella <m@bacarella.com>"]
+authors: [
+  "Ashish Agarwal <ashish@solvuu.com>"
+  "Solvuu Inc."
+  "Michael Bacarella <m@bacarella.com>"
+]
+license: "MIT"
+homepage: "https://github.com/mbacarella/ocaml-awso"
+doc: "https://mbacarella.github.io/ocaml-awso/"
+bug-reports: "https://github.com/mbacarella/ocaml-awso/issues"
+depends: [
+  "dune" {>= "3.6"}
+  "ocaml" {>= "5.3.0"}
+  "awso"
+  "ocurl"
+  "ppx_expect"
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/mbacarella/ocaml-awso.git"
+url {
+  src:
+    "https://github.com/mbacarella/ocaml-awso/releases/download/0.9.1/awso-0.9.1.tbz"
+  checksum: [
+    "sha256=e0e7510192b7e45871cff5c60e5162a77a9fa103b6924136fb1fea5db2092b26"
+    "sha512=51a18cf74c122b021bd84ef5728b7c5b2d5e767f03d5cd2387d886edc34a68cf54a3183e2d6c4939b4c8d3e0c0e406c869d019f2ee9a0903ae4cf7ca725572f0"
+  ]
+}
+x-commit-hash: "c636fb198135987794cdbc57d766845f0fd5c9f2"

--- a/packages/awso-sync/awso-sync.0.9.1/opam
+++ b/packages/awso-sync/awso-sync.0.9.1/opam
@@ -16,7 +16,7 @@ bug-reports: "https://github.com/mbacarella/ocaml-awso/issues"
 depends: [
   "dune" {>= "3.6"}
   "ocaml" {>= "5.3.0"}
-  "awso"
+  "awso" {= version}
   "ocurl"
   "ppx_expect"
   "odoc" {with-doc}

--- a/packages/awso/awso.0.9.1/opam
+++ b/packages/awso/awso.0.9.1/opam
@@ -1,0 +1,53 @@
+opam-version: "2.0"
+synopsis:
+  "AWS API base library (400+ services, auto-generated from botocore)"
+description:
+  "Logic-only runtime for the awso family of packages: request signing (SigV4), HTTP plumbing, credential discovery, region/endpoint tables, and shared types. I/O bindings live in sibling packages (awso-async, awso-lwt, awso-sync)."
+maintainer: ["Michael Bacarella <m@bacarella.com>"]
+authors: [
+  "Ashish Agarwal <ashish@solvuu.com>"
+  "Solvuu Inc."
+  "Michael Bacarella <m@bacarella.com>"
+]
+license: "MIT"
+homepage: "https://github.com/mbacarella/ocaml-awso"
+doc: "https://mbacarella.github.io/ocaml-awso/"
+bug-reports: "https://github.com/mbacarella/ocaml-awso/issues"
+depends: [
+  "dune" {>= "3.6"}
+  "ocaml" {>= "5.3.0"}
+  "awso-common"
+  "cohttp" {>= "6.0.0"}
+  "cryptokit"
+  "ppx_expect"
+  "ppx_yojson_conv"
+  "re" {>= "1.7.2"}
+  "xmlm"
+  "yojson" {>= "2.0.0"}
+  "zarith"
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/mbacarella/ocaml-awso.git"
+url {
+  src:
+    "https://github.com/mbacarella/ocaml-awso/releases/download/0.9.1/awso-0.9.1.tbz"
+  checksum: [
+    "sha256=e0e7510192b7e45871cff5c60e5162a77a9fa103b6924136fb1fea5db2092b26"
+    "sha512=51a18cf74c122b021bd84ef5728b7c5b2d5e767f03d5cd2387d886edc34a68cf54a3183e2d6c4939b4c8d3e0c0e406c869d019f2ee9a0903ae4cf7ca725572f0"
+  ]
+}
+x-commit-hash: "c636fb198135987794cdbc57d766845f0fd5c9f2"

--- a/packages/awso/awso.0.9.1/opam
+++ b/packages/awso/awso.0.9.1/opam
@@ -16,7 +16,7 @@ bug-reports: "https://github.com/mbacarella/ocaml-awso/issues"
 depends: [
   "dune" {>= "3.6"}
   "ocaml" {>= "5.3.0"}
-  "awso-common"
+  "awso-common" {= version}
   "cohttp" {>= "6.0.0"}
   "cryptokit"
   "ppx_expect"


### PR DESCRIPTION
AWS API base library (400+ services, auto-generated from botocore)

- Project page: <a href="https://github.com/mbacarella/ocaml-awso">https://github.com/mbacarella/ocaml-awso</a>
- Documentation: <a href="https://mbacarella.github.io/ocaml-awso/">https://mbacarella.github.io/ocaml-awso/</a>

##### CHANGES:

### New stuff

- `awso-eio`: backend for [Eio](https://github.com/ocaml-multicore/eio). Same 400+ services exposed as `awso-eio.<svc>`. Requires OCaml 5
- 13 services re-enabled that the codegen had skipped (apigateway, apigatewayv2, appconfig, appconfigdata, cloudhsm, codeguruprofiler, health, lex-runtime, mediaconnect, medialive, mq, s3control, sagemaker-runtime); 6 others (appsync, dataexchange, iottwinmaker, lexv2-runtime, pinpoint, workmailmessageflow) still excluded with documented codegen bugs to chase later
- `CREDITS.md`

### Compatibility & dep hygiene

- minimum OCaml is 5.3.0 (we'd hoped to widen to 4.14 this release but ran out of time chasing compiler stack overflows on the giant generated tables; the door is open for 0.9.2)
- `tls >= 2.1.0`. Noticed [CVE-2026-45388](https://github.com/mirleft/ocaml-tls/security/advisories) (TLS 1.3 client missing `keyUsage`/`extendedKeyUsage` validation), decided to get ahead of it.
- `mirage-crypto-rng >= 1.2.0` for `Mirage_crypto_rng_unix.use_default` (the now-deprecated `initialize` is gone in our usage)
- `async_ssl` constrained to the `-2` opam-repository revisions that re-add `-Wno-implicit-function-declaration`. The intermediate `-1` revisions only suppressed `-Wno-incompatible-pointer-types`, which left the build broken on distros where OpenSSL ships without the deprecated `ENGINE_*` API (e.g. centos-10). Fixed upstream in [ocaml/opam-repository#29939](https://github.com/ocaml/opam-repository/pull/29939) and the corresponding source-archives PR. Note: this is broken where `async_ssl` is attempted on systems that have completely removed `openssl/engine.h`. Upstream should probably remove it.
- `core_unix`, `ppx_jane`, `async` floored at `v0.16.0` to match what we actually test against

### Code generation changes

- Parse the new botocore `enum` field on shape members
- Parse the legacy `httpChecksumRequired` operation trait (currently ignored since we don't auto-compute checksums; users still set `?contentMD5` themselves with `Awso.Client.content_md5_insecure` as a helper)
