### PR TITLE
fix: sha256 and -512 for bigstringaf (md5 only)

### DIFF
--- a/packages/bigstringaf/bigstringaf.0.10.0/opam
+++ b/packages/bigstringaf/bigstringaf.0.10.0/opam
@@ -44,5 +44,9 @@ So here they are. Go crazy.
 """
 url {
   src: "https://github.com/inhabitedtype/bigstringaf/archive/0.10.0.tar.gz"
-  checksum: "md5=be0a44416840852777651150757a0a3b"
+  checksum: [
+    "sha512=b51c756925d7016ffd7eac49e69393a1897391ca2685a8c30c7b6e3917b4d66c9400b49e8986d0f03329197b95ad52e096ff83dea5e03571cb5bc3d9a5170602"
+    "sha256=ed92f5b05fbc11b9defcec734d59b1068f3717a9ae4f9705c16c7f7ac3729f28"
+    "md5=be0a44416840852777651150757a0a3b"
+  ]
 }


### PR DESCRIPTION
In the spirit of #25960, #25876 and ocurrent/opam-repo-ci#304.

```command
$ curl -sSL https://github.com/inhabitedtype/bigstringaf/archive/0.10.0.tar.gz  | tee >(md5sum >&2) | tee >(sha256sum >&2) | sha512sum
b51c756925d7016ffd7eac49e69393a1897391ca2685a8c30c7b6e3917b4d66c9400b49e8986d0f03329197b95ad52e096ff83dea5e03571cb5bc3d9a5170602  -
ed92f5b05fbc11b9defcec734d59b1068f3717a9ae4f9705c16c7f7ac3729f28  -
be0a44416840852777651150757a0a3b  -
```