### PR TITLE
[new release] raylib (3 packages) (2.0.0)

### DIFF
--- a/packages/qcaml/qcaml.0.1.7/opam
+++ b/packages/qcaml/qcaml.0.1.7/opam
@@ -31,7 +31,7 @@ depends: [
   "dune" {>= "3.17"}
   "ocaml" {>= "5.2"}
   "dune-configurator"
-  "raylib"
+  "raylib" {< "2.0.0"}
   "alcotest" {with-test}
   "odoc" {with-doc}
   "bisect_ppx" {with-test}

--- a/packages/qcaml/qcaml.1.0.0/opam
+++ b/packages/qcaml/qcaml.1.0.0/opam
@@ -31,7 +31,7 @@ depends: [
   "dune" {>= "3.17"}
   "ocaml" {>= "5.2"}
   "dune-configurator"
-  "raylib"
+  "raylib" {< "2.0.0"}
   "alcotest" {with-test}
   "odoc" {with-doc}
   "bisect_ppx" {with-test}

--- a/packages/raygui/raygui.2.0.0/opam
+++ b/packages/raygui/raygui.2.0.0/opam
@@ -1,0 +1,43 @@
+opam-version: "2.0"
+synopsis: "OCaml bindings for raygui"
+description: "OCaml bindings for raygui"
+maintainer: ["tobiasjammer@gmail.com"]
+authors: ["Tobias Mock"]
+license: "MIT"
+homepage: "https://github.com/tjammer/raylib-ocaml"
+bug-reports: "https://github.com/tjammer/raylib-ocaml/issues"
+depends: [
+  "dune" {>= "3.20"}
+  "raylib" {= version}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/tjammer/raylib-ocaml.git"
+x-maintenance-intent: ["(latest)"]
+available: [arch != "arm32" & arch != "ppc64"]
+x-ci-accept-failures: [
+  "centos-7" # C compiler is too old
+  "oraclelinux-7" # C compiler is too old
+]
+url {
+  src:
+    "https://github.com/tjammer/raylib-ocaml/releases/download/2.0.0/raylib-2.0.0.tbz"
+  checksum: [
+    "sha256=6e86f44506722c89fef8d62a3f2087f7265f90f8c5aaba37edd15644c45d7007"
+    "sha512=ece8be2bd9409ba927063f33a73990462b864ee837ae3d87ad8198cd295cf421be7f47114873742877b3262a5c6079e9d6b371f5fe22853bd751576b824c2c07"
+  ]
+}
+x-commit-hash: "30fe4298b02b842774369d45bc0ab595367b7d95"

--- a/packages/raylib-callbacks/raylib-callbacks.2.0.0/opam
+++ b/packages/raylib-callbacks/raylib-callbacks.2.0.0/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+synopsis: "OCaml bindings for callbacks of raylib"
+description: "OCaml bindings for callbacks of raylib"
+maintainer: ["tobiasjammer@gmail.com"]
+authors: ["Tobias Mock"]
+license: "MIT"
+homepage: "https://github.com/tjammer/raylib-ocaml"
+bug-reports: "https://github.com/tjammer/raylib-ocaml/issues"
+depends: [
+  "dune" {>= "3.20"}
+  "ctypes-foreign" {>= "0.14"}
+  "raylib" {= version}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/tjammer/raylib-ocaml.git"
+x-maintenance-intent: ["(latest)"]
+url {
+  src:
+    "https://github.com/tjammer/raylib-ocaml/releases/download/2.0.0/raylib-2.0.0.tbz"
+  checksum: [
+    "sha256=6e86f44506722c89fef8d62a3f2087f7265f90f8c5aaba37edd15644c45d7007"
+    "sha512=ece8be2bd9409ba927063f33a73990462b864ee837ae3d87ad8198cd295cf421be7f47114873742877b3262a5c6079e9d6b371f5fe22853bd751576b824c2c07"
+  ]
+}
+x-commit-hash: "30fe4298b02b842774369d45bc0ab595367b7d95"

--- a/packages/raylib/raylib.2.0.0/opam
+++ b/packages/raylib/raylib.2.0.0/opam
@@ -1,0 +1,55 @@
+opam-version: "2.0"
+synopsis: "OCaml bindings for raylib"
+description: "OCaml bindings for raylib"
+maintainer: ["tobiasjammer@gmail.com"]
+authors: ["Tobias Mock"]
+license: "MIT"
+homepage: "https://github.com/tjammer/raylib-ocaml"
+bug-reports: "https://github.com/tjammer/raylib-ocaml/issues"
+depends: [
+  "dune" {>= "3.20"}
+  "ocaml" {>= "4.08.0"}
+  "dune-configurator"
+  "ctypes" {>= "0.23.0"}
+  "integers" {>= "0.5"}
+  "patch" {>= "3.0.0"}
+  "conf-mesa" {os = "linux" | os-family = "bsd"}
+  "conf-libxcursor" {os = "linux" | os-family = "bsd"}
+  "conf-libxi" {os = "linux" | os-family = "bsd"}
+  "conf-libxinerama" {os = "linux" | os-family = "bsd"}
+  "conf-libxrandr" {os = "linux" | os-family = "bsd"}
+  "ocaml-lsp-server" {with-dev-setup}
+  "ocamlformat" {= "0.29.0" & with-dev-setup}
+  "odoc" {with-doc}
+]
+conflicts: ["ocaml-option-bytecode-only"]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/tjammer/raylib-ocaml.git"
+x-maintenance-intent: ["(latest)"]
+available: [arch != "arm32" & arch != "ppc64"]
+x-ci-accept-failures: [
+  "centos-7" # C compiler is too old
+  "oraclelinux-7" # C compiler is too old
+]
+url {
+  src:
+    "https://github.com/tjammer/raylib-ocaml/releases/download/2.0.0/raylib-2.0.0.tbz"
+  checksum: [
+    "sha256=6e86f44506722c89fef8d62a3f2087f7265f90f8c5aaba37edd15644c45d7007"
+    "sha512=ece8be2bd9409ba927063f33a73990462b864ee837ae3d87ad8198cd295cf421be7f47114873742877b3262a5c6079e9d6b371f5fe22853bd751576b824c2c07"
+  ]
+}
+x-commit-hash: "30fe4298b02b842774369d45bc0ab595367b7d95"


### PR DESCRIPTION
CHANGES:

* Upgrade to raylib 6.0
* Re-work constant binding: Flag-like constants are now values instead of variants, with a `( + )` combinator for or-ing constants together. Instead of a list of constructors for flags, functions now take a single value. The unsafe function `of_int` has been removed from enum constants. `to_int` has been removed from most enum constants, only index-like constants (`MaterialMapIndex`, `ShaderLocationIndex`) keep it.
* Separate Raylib into libraries for raylib modules, individual raylib modules can now be used separately if linking all of raylib is not desired.
* Complete rlgl bindings, upgrade to 6.0
* Use strong types for integer constants in rlgl