### PR TITLE
Release patricia-tree.0.14.0

### DIFF
--- a/packages/patricia-tree/patricia-tree.0.14.0/opam
+++ b/packages/patricia-tree/patricia-tree.0.14.0/opam
@@ -1,0 +1,48 @@
+opam-version: "2.0"
+synopsis:
+  "Patricia Tree data structure in OCaml for maps and sets. Supports generic key-value pairs"
+maintainer: ["Dorian Lesbre <dorian.lesbre@cea.fr>"]
+authors: [
+  "Matthieu Lemerre <matthieu.lemerre@cea.fr>"
+  "Dorian Lesbre <dorian.lesbre@cea.fr>"
+]
+license: "LGPL-2.1-only"
+homepage: "https://codex.top/api/patricia-tree/"
+doc: "https://codex.top/api/patricia-tree/"
+bug-reports:
+  "https://github.com/codex-semantics-library/patricia-tree/issues"
+depends: [
+  "ocaml" {>= "4.14"}
+  "dune" {>= "3.0"}
+  "qcheck" {>= "0.90" & with-test}
+  "ppx_inline_test" {>= "v0.16.0" & with-test}
+  "mdx" {>= "2.4.1" & with-test}
+  "odoc" {>= "2.4.0" & with-doc}
+  "sherlodoc" {with-doc}
+  "bechamel" {with-dev-setup}
+  "csv" {with-dev-setup}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/codex-semantics-library/patricia-tree.git"
+url {
+  src:
+    "https://github.com/codex-semantics-library/patricia-tree/releases/download/v0.14.0/patricia-tree-0.14.0.tbz"
+  checksum: [
+    "sha256=32e5639ec6af0f7763d6bf48a8711d8d9cd0d79af1fc8cecf1c73a442c1c1fa7"
+    "sha512=749fb6696e83b88b782d70248cb646a8a7ac02d1e781f15d680ff1b41949b936259abd6979680fc9812b9c9cf8406ca24ccf3e785b8b7977519394a04d53f451"
+  ]
+}
+x-commit-hash: "6a9f9174ad7c27778a5f344e4b0de7a07f8aa14e"


### PR DESCRIPTION
Patricia Tree data structure in OCaml for maps and sets. Supports generic key-value pairs
-  Project page: https://codex.top/api/patricia-tree/
-  Documentation: https://codex.top/api/patricia-tree/

## Changes

- Change type of `nonreflexive_subset_domain_for_all2` to allows usage with maps of different type.
- Add JS stubs for use with js-of-ocaml ([#34](https://github.com/codex-semantics-library/patricia-tree/pull/34)).