### PR TITLE
Release catala.1.2.0

### DIFF
--- a/packages/catala-format/catala-format.1.2.0/opam
+++ b/packages/catala-format/catala-format.1.2.0/opam
@@ -1,0 +1,38 @@
+opam-version: "2.0"
+version: "1.2.0"
+maintainer: "vincent.botbol@inria.fr"
+authors: [ "Vincent Botbol" ]
+homepage: "https://github.com/CatalaLang/catala-format"
+bug-reports: "https://github.com/CatalaLang/catala-format"
+dev-repo: "git+https://github.com/CatalaLang/catala-format.git"
+license: "Apache-2.0"
+depends: [
+  "ocaml" {>= "4.14.0" }
+  "dune" {>= "3.13"}
+  "cmdliner" {>= "2.0.0"}
+  "lwt" {with-test}
+  "topiary" {>= "0.5.1" & < "0.6"}
+  "conf-c++"
+  "re" {>= "1.11"}
+]
+build:[
+  "dune" "build"
+  "-p" name
+  "-j" jobs
+  "@install"
+]
+synopsis: "A formatter for Catala based on the Topiary universal formatting engine"
+description: """
+A formatter for Catala based on the Topiary universal formatting engine.
+
+Topiary repository: https://github.com/tweag/topiary
+"""
+url {
+  src:
+    "https://github.com/CatalaLang/catala-format/archive/refs/tags/1.2.0.tar.gz"
+  checksum: [
+    "md5=1eb897490a60ba45878e8aefb222ed28"
+    "sha512=ba487f73b88a4120c931f81c8ebfa431d823c09467ebebc60ac74c04229333b5d6627104643dd99aa25d577a54c1dbe5f04ed33040e66cfafa2492556309e629"
+  ]
+}
+x-maintenance-intent: ["(latest)"]

--- a/packages/catala-lsp/catala-lsp.1.2.0/opam
+++ b/packages/catala-lsp/catala-lsp.1.2.0/opam
@@ -1,0 +1,48 @@
+opam-version: "2.0"
+version: "1.2.0"
+name: "catala-lsp"
+maintainer: "Vincent Botbol"
+authors: [ "Vincent Botbol" ]
+license: "Apache-2.0"
+build: [
+  "dune"
+  "build"
+  "-p"
+  name
+  "-j"
+  jobs
+  "@install"
+  "@runtest" {with-test}
+]
+depends: [
+  "ocaml"          {>= "4.14.1"}
+  "dune"           {>= "3.0"}
+  "catala"         {= version}
+  "logs"
+  "uri"
+  "linol"          {= "0.10"}
+  "linol-lwt"      {= "0.10"}
+  "dap"            {= "1.0.6"}
+  "qcheck"         {with-test & >= "0.21.3"}
+  "tezt"           {with-test}
+  "atdgen"         {build}
+  "atdgen-runtime"
+  "ptime"
+  "atdts"          {with-dev-setup & >= "2.16.0"}
+  "ocamlformat"    {with-dev-setup & = "0.28.1"}
+]
+tags: [ "catala" "lsp" ]
+homepage: "https://github.com/CatalaLang/catala-language-server"
+dev-repo: "git+https://github.com/CatalaLang/catala-language-server.git"
+bug-reports: "https://github.com/CatalaLang/catala-language-server/issues"
+synopsis: "Catala Language Server Protocol (LSP)"
+description:"Implementation of a Language Server Protocol (LSP) for Catala."
+url {
+  src:
+    "https://github.com/CatalaLang/catala-language-server/archive/refs/tags/1.2.0.tar.gz"
+  checksum: [
+    "md5=c3a347a6766523604a842bb186330aa6"
+    "sha512=f9fd1085af469d3323387b3e6b2dfae054409a9338594a92e01384992c142ddca8d354a9c1e36b2ab63c718fabffa3ea5eec3558ba19f5c4c8594c10691f16a0"
+  ]
+}
+x-maintenance-intent: ["(latest)"]

--- a/packages/catala/catala.1.2.0/opam
+++ b/packages/catala/catala.1.2.0/opam
@@ -1,0 +1,88 @@
+opam-version: "2.0"
+version: "1.2.0"
+synopsis:
+  "Compiler and library for the literate programming language for tax code specification"
+description: """
+Catala is a domain-specific language for deriving faithful-by-construction algorithms from legislative texts. See https://catala-lang.org for more information
+"""
+maintainer: "contact@catala-lang.org"
+authors: [
+  "Vincent Botbol"
+  "Nicolas Chataing"
+  "Alain Delaët-Tixeuil"
+  "Louis Gesbert"
+  "Aymeric Fromherz"
+  "Denis Merigoux"
+  "Raphaël Monat"
+  "Romain Primet"
+  "Emile Rolley"
+]
+license: "Apache-2.0"
+tags: [ "catala" ]
+homepage: "https://github.com/CatalaLang/catala"
+bug-reports: "https://github.com/CatalaLang/catala/issues"
+depends: [
+  "ocaml" {>= "4.14.0" }
+  "ocamlfind" {!= "1.9.5"}
+  "dune" {>= "3.13"}
+  "cppo" {>= "1"}
+  "menhir" {>= "20200211" & < "20260112"}
+  # See https://github.com/CatalaLang/catala/issues/939 for the upper bound
+  "menhirLib" {>= "20200211" & < "20260112"}
+  "ocolor" {>= "1.3.0"}
+  "bindlib" {>= "6.0"}
+  "cmdliner" {>= "2.0.0"}
+  "ocamlgraph" {>= "1.8.8"}
+  "re" {>= "1.11"}
+  "sedlex" {>= "3.2"}
+  "uucp" {>= "10"}
+  "ubase" {>= "0.05"}
+  "zarith" {>= "1.12"}
+  "yojson" {>= "2.1.0" & < "3"}
+   # Not a strict upper bound for catala, but other tools (adgen) have it and we
+   # don't want them to need a catala recompile
+  "crunch" {>= "3.0.0"}
+  "hex" { >= "1.5.0"}
+  "alcotest" {>= "1.5.0"}
+  "ninja_utils" {= "1.0.0"}
+  "otoml" {>= "1.0"}
+  "json-data-encoding" { >= "1.0.1" }
+  "odoc" {with-doc}
+  "ocamlformat" {?cataladevmode & cataladevmode & = "0.28.1"}
+  "obelisk" {?cataladevmode & cataladevmode}
+  "conf-ninja" {post}
+  # --- the following are "optional runtime dependencies" ---
+  # they're listed here mostly for documentation ; one can export
+  # OPAMVAR_cataladevmode=1 before installation to automatically get them
+  "conf-npm" {post & ?cataladevmode & cataladevmode}
+  "conf-python-3-dev" {post & ?cataladevmode & cataladevmode}
+  "conf-openjdk" {post & ?cataladevmode & cataladevmode}
+  "conf-pandoc" {post & ?cataladevmode & cataladevmode}
+]
+build: [
+  "dune" "build" "-p" name "-j" jobs "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+]
+run-test: [
+  "dune" "exec" "--" "clerk" "test" "tests/"
+]
+build-env: [ CATALA_VERSION = "%{version}%" ]
+depexts: [
+  ["groff"] {with-doc}
+  # --- the following are "optional runtime dependencies" ---
+  # See above
+  ["python3-pip"] {?cataladevmode & cataladevmode & os-family = "debian"}
+  ["py3-pip" "py3-pygments"] {?cataladevmode & cataladevmode & os-distribution = "alpine"}
+  ["python-pygments"] {?cataladevmode & cataladevmode & os-family = "arch"}
+]
+dev-repo: "git+https://github.com/CatalaLang/catala"
+url {
+  src:
+    "https://github.com/CatalaLang/catala/archive/refs/tags/1.2.0.tar.gz"
+  checksum: [
+    "md5=8d4db84b36a2e0c301724b41233837d8"
+    "sha512=28ce5b1ef5835bb0e0d520d4bc279c5c752055b77e6e8d000e41868a027dedb4ecf5301295e796815e6b1fb6476912ebce7cc65459a053cc4857510f65216a7e"
+  ]
+}
+x-maintenance-intent: ["(latest)"]


### PR DESCRIPTION
New release of [catala](https://github.com/CatalaLang/catala/)

Includes:
- `catala` package splitted in 3 packages for lighter dependencies management (main package, js plugin and z3 proof plugin)
- `catala-lsp` 
- `catala-format`

Pre-release notes: https://github.com/CatalaLang/catala/releases/tag/1.2.0