### PR TITLE
Add upper bound on dune < 3.24 for coq and rocq packages that use `lang coq` or `using coq`

### DIFF
--- a/packages/coq-core/coq-core.8.17.0/opam
+++ b/packages/coq-core/coq-core.8.17.0/opam
@@ -25,7 +25,7 @@ homepage: "https://coq.inria.fr/"
 doc: "https://coq.github.io/doc/"
 bug-reports: "https://github.com/coq/coq/issues"
 depends: [
-  "dune" {>= "2.9"}
+  "dune" {>= "2.9" & < "3.24"}
   "ocaml" {>= "4.09.0"}
   "ocamlfind" {>= "1.8.1"}
   "zarith" {>= "1.11"}

--- a/packages/coq-core/coq-core.8.17.1/opam
+++ b/packages/coq-core/coq-core.8.17.1/opam
@@ -25,7 +25,7 @@ homepage: "https://coq.inria.fr/"
 doc: "https://coq.github.io/doc/"
 bug-reports: "https://github.com/coq/coq/issues"
 depends: [
-  "dune" {>= "2.9"}
+  "dune" {>= "2.9" & < "3.24"}
   "ocaml" {>= "4.09.0"}
   "ocamlfind" {>= "1.8.1"}
   "zarith" {>= "1.11"}

--- a/packages/coq-core/coq-core.8.18.0/opam
+++ b/packages/coq-core/coq-core.8.18.0/opam
@@ -26,7 +26,7 @@ homepage: "https://coq.inria.fr/"
 doc: "https://coq.github.io/doc/"
 bug-reports: "https://github.com/coq/coq/issues"
 depends: [
-  "dune" {>= "2.9"}
+  "dune" {>= "2.9" & < "3.24"}
   "ocaml" {>= "4.09.0"}
   "ocamlfind" {>= "1.8.1"}
   "zarith" {>= "1.11"}

--- a/packages/coq-core/coq-core.8.19.0/opam
+++ b/packages/coq-core/coq-core.8.19.0/opam
@@ -25,7 +25,7 @@ homepage: "https://coq.inria.fr/"
 doc: "https://coq.github.io/doc/"
 bug-reports: "https://github.com/coq/coq/issues"
 depends: [
-  "dune" {>= "2.9"}
+  "dune" {>= "2.9" & < "3.24"}
   "ocaml" {>= "4.09.0"}
   "ocamlfind" {>= "1.8.1"}
   "zarith" {>= "1.11"}

--- a/packages/coq-core/coq-core.8.19.1/opam
+++ b/packages/coq-core/coq-core.8.19.1/opam
@@ -25,7 +25,7 @@ homepage: "https://coq.inria.fr/"
 doc: "https://coq.github.io/doc/"
 bug-reports: "https://github.com/coq/coq/issues"
 depends: [
-  "dune" {>= "2.9"}
+  "dune" {>= "2.9" & < "3.24"}
   "ocaml" {>= "4.09.0"}
   "ocamlfind" {>= "1.8.1"}
   "zarith" {>= "1.11"}

--- a/packages/coq-core/coq-core.8.19.2/opam
+++ b/packages/coq-core/coq-core.8.19.2/opam
@@ -25,7 +25,7 @@ homepage: "https://coq.inria.fr/"
 doc: "https://coq.github.io/doc/"
 bug-reports: "https://github.com/coq/coq/issues"
 depends: [
-  "dune" {>= "2.9"}
+  "dune" {>= "2.9" & < "3.24"}
   "ocaml" {>= "4.09.0" & < "5.5"}
   "ocamlfind" {>= "1.8.1"}
   "zarith" {>= "1.11"}

--- a/packages/coq-core/coq-core.8.20.0/opam
+++ b/packages/coq-core/coq-core.8.20.0/opam
@@ -25,7 +25,7 @@ homepage: "https://coq.inria.fr/"
 doc: "https://coq.github.io/doc/"
 bug-reports: "https://github.com/coq/coq/issues"
 depends: [
-  "dune" {>= "3.6.1"}
+  "dune" {>= "3.6.1" & < "3.24"}
   "ocaml" {>= "4.09.0" & < "5.5"}
   "ocamlfind" {>= "1.8.1"}
   "zarith" {>= "1.11"}

--- a/packages/coq-core/coq-core.8.20.1/opam
+++ b/packages/coq-core/coq-core.8.20.1/opam
@@ -25,7 +25,7 @@ homepage: "https://coq.inria.fr/"
 doc: "https://coq.github.io/doc/"
 bug-reports: "https://github.com/coq/coq/issues"
 depends: [
-  "dune" {>= "3.6.1"}
+  "dune" {>= "3.6.1" & < "3.24"}
   "ocaml" {>= "4.09.0" & < "5.5"}
   "ocamlfind" {>= "1.8.1"}
   "zarith" {>= "1.11"}

--- a/packages/coq/coq.8.14.0/opam
+++ b/packages/coq/coq.8.14.0/opam
@@ -23,7 +23,7 @@ depopts: [
 depends: [
   "ocaml" {>= "4.05.0"}
   "ocamlfind" {build}
-  "dune" {>= "2.5.1"}
+  "dune" {>= "2.5.1" & < "3.24"}
   "conf-findutils" {build}
   "zarith" {>= "1.10"}
 ]

--- a/packages/coq/coq.8.14.1/opam
+++ b/packages/coq/coq.8.14.1/opam
@@ -23,7 +23,7 @@ depopts: [
 depends: [
   "ocaml" {>= "4.05.0"}
   "ocamlfind" {build}
-  "dune" {>= "2.5.1"}
+  "dune" {>= "2.5.1" & < "3.24"}
   "conf-findutils" {build}
   "zarith" {>= "1.10"}
 ]

--- a/packages/coq/coq.8.15.0/opam
+++ b/packages/coq/coq.8.15.0/opam
@@ -23,7 +23,7 @@ depopts: [
 depends: [
   "ocaml" {>= "4.05.0"}
   "ocamlfind" {build}
-  "dune" {>= "2.5.1"}
+  "dune" {>= "2.5.1" & < "3.24"}
   "conf-findutils" {build}
   "zarith" {>= "1.10"}
 ]

--- a/packages/coq/coq.8.15.1/opam
+++ b/packages/coq/coq.8.15.1/opam
@@ -23,7 +23,7 @@ depopts: [
 depends: [
   "ocaml" {>= "4.05.0"}
   "ocamlfind" {build}
-  "dune" {>= "2.5.1"}
+  "dune" {>= "2.5.1" & < "3.24"}
   "conf-findutils" {build}
   "zarith" {>= "1.10"}
 ]

--- a/packages/coq/coq.8.15.2/opam
+++ b/packages/coq/coq.8.15.2/opam
@@ -23,7 +23,7 @@ depopts: [
 depends: [
   "ocaml" {>= "4.05.0"}
   "ocamlfind" {build}
-  "dune" {>= "2.5.1"}
+  "dune" {>= "2.5.1" & < "3.24"}
   "conf-findutils" {build}
   "zarith" {>= "1.10"}
 ]

--- a/packages/coq/coq.8.16.0/opam
+++ b/packages/coq/coq.8.16.0/opam
@@ -23,7 +23,7 @@ depopts: [
 depends: [
   "ocaml" {>= "4.09.0"}
   "ocamlfind" {>= "1.8.1"}
-  "dune" {>= "2.5.1"}
+  "dune" {>= "2.5.1" & < "3.24"}
   "conf-findutils" {build}
   "zarith" {>= "1.11"}
 ]

--- a/packages/coq/coq.8.16.1/opam
+++ b/packages/coq/coq.8.16.1/opam
@@ -23,7 +23,7 @@ depopts: [
 depends: [
   "ocaml" {>= "4.09.0"}
   "ocamlfind" {>= "1.8.1"}
-  "dune" {>= "2.5.1"}
+  "dune" {>= "2.5.1" & < "3.24"}
   "conf-findutils" {build}
   "zarith" {>= "1.11"}
 ]

--- a/packages/farith/farith.0.1/opam
+++ b/packages/farith/farith.0.1/opam
@@ -7,7 +7,7 @@ license: "LGPL-2.1"
 homepage: "https://git.frama-c.com/pub/farith"
 bug-reports: "https://git.frama-c.com/pub/farith/issues"
 depends: [
-  "dune" {>= "3.0"}
+  "dune" {>= "3.0" & < "3.24"}
   "zarith"
   "base"
   "ppx_deriving"

--- a/packages/rocq-runtime/rocq-runtime.9.0.0/opam
+++ b/packages/rocq-runtime/rocq-runtime.9.0.0/opam
@@ -25,7 +25,7 @@ homepage: "https://rocq-prover.org"
 doc: "https://coq.github.io/doc/"
 bug-reports: "https://github.com/coq/coq/issues"
 depends: [
-  "dune" {>= "3.8"}
+  "dune" {>= "3.8" & < "3.24"}
   "ocaml" {>= "4.09.0" & < "5.5"}
   "ocamlfind" {>= "1.8.1"}
   "zarith" {>= "1.11"}

--- a/packages/rocq-runtime/rocq-runtime.9.0.1/opam
+++ b/packages/rocq-runtime/rocq-runtime.9.0.1/opam
@@ -25,7 +25,7 @@ homepage: "https://rocq-prover.org/"
 doc: "https://rocq-prover.org/docs/"
 bug-reports: "https://github.com/rocq-prover/rocq/issues"
 depends: [
-  "dune" {>= "3.8"}
+  "dune" {>= "3.8" & < "3.24"}
   "ocaml" {>= "4.09.0" & < "5.5"}
   "ocamlfind" {>= "1.8.1"}
   "zarith" {>= "1.11"}

--- a/packages/rocq-runtime/rocq-runtime.9.1.0/opam
+++ b/packages/rocq-runtime/rocq-runtime.9.1.0/opam
@@ -25,7 +25,7 @@ homepage: "https://rocq-prover.org/"
 doc: "https://rocq-prover.org/docs/"
 bug-reports: "https://github.com/rocq-prover/rocq/issues"
 depends: [
-  "dune" {>= "3.8"}
+  "dune" {>= "3.8" & < "3.24"}
   "ocaml" {>= "4.14.0" & < "5.5"}
   "ocamlfind" {>= "1.9.1" & (>= "1.9.8" | os-family != "windows")}
   "zarith" {>= "1.11"}

--- a/packages/rocq-runtime/rocq-runtime.9.1.1/opam
+++ b/packages/rocq-runtime/rocq-runtime.9.1.1/opam
@@ -25,7 +25,7 @@ homepage: "https://rocq-prover.org/"
 doc: "https://rocq-prover.org/docs/"
 bug-reports: "https://github.com/rocq-prover/rocq/issues"
 depends: [
-  "dune" {>= "3.8"}
+  "dune" {>= "3.8" & < "3.24"}
   "ocaml" {>= "4.14.0"}
   "ocamlfind" {>= "1.9.1" & (>= "1.9.8" | os-family != "windows")}
   "zarith" {>= "1.11"}

--- a/packages/rocq-runtime/rocq-runtime.9.2.0/opam
+++ b/packages/rocq-runtime/rocq-runtime.9.2.0/opam
@@ -25,7 +25,7 @@ homepage: "https://rocq-prover.org/"
 doc: "https://rocq-prover.org/docs/"
 bug-reports: "https://github.com/rocq-prover/rocq/issues"
 depends: [
-  "dune" {>= "3.8"}
+  "dune" {>= "3.8" & < "3.24"}
   "ocaml" {>= "4.14.0"}
   "ocamlfind" {>= "1.9.1" & (>= "1.9.8" | os-family != "windows")}
   "zarith" {>= "1.11"}


### PR DESCRIPTION
`lang coq` is removed in https://github.com/ocaml/dune/pull/14525 (to be replaced with `lang rocq`), but these packages are shown to use it in their build config in the CI failures from the dune 3.24 release candidate: https://github.com/ocaml/opam-repository/pull/29969 