### PR TITLE
Remove test running for currently published mdx versions

### DIFF
--- a/packages/mdx/mdx.1.10.0/opam
+++ b/packages/mdx/mdx.1.10.0/opam
@@ -47,7 +47,6 @@ build: [
     "-j"
     jobs
     "@install"
-    "@runtest" {with-test}
     "@doc" {with-doc}
   ]
 ]

--- a/packages/mdx/mdx.1.10.1/opam
+++ b/packages/mdx/mdx.1.10.1/opam
@@ -47,7 +47,6 @@ build: [
     "-j"
     jobs
     "@install"
-    "@runtest" {with-test}
     "@doc" {with-doc}
   ]
 ]

--- a/packages/mdx/mdx.1.11.0/opam
+++ b/packages/mdx/mdx.1.11.0/opam
@@ -48,7 +48,6 @@ build: [
     "-j"
     jobs
     "@install"
-    "@runtest" {with-test}
     "@doc" {with-doc}
   ]
 ]

--- a/packages/mdx/mdx.1.11.1/opam
+++ b/packages/mdx/mdx.1.11.1/opam
@@ -48,7 +48,6 @@ build: [
     "-j"
     jobs
     "@install"
-    "@runtest" {with-test}
     "@doc" {with-doc}
   ]
 ]

--- a/packages/mdx/mdx.1.8.0/opam
+++ b/packages/mdx/mdx.1.8.0/opam
@@ -47,7 +47,6 @@ build: [
     "-j"
     jobs
     "@install"
-    "@runtest" {with-test}
     "@doc" {with-doc}
   ]
 ]

--- a/packages/mdx/mdx.1.8.1/opam
+++ b/packages/mdx/mdx.1.8.1/opam
@@ -47,7 +47,6 @@ build: [
     "-j"
     jobs
     "@install"
-    "@runtest" {with-test}
     "@doc" {with-doc}
   ]
 ]

--- a/packages/mdx/mdx.1.9.0/opam
+++ b/packages/mdx/mdx.1.9.0/opam
@@ -47,7 +47,6 @@ build: [
     "-j"
     jobs
     "@install"
-    "@runtest" {with-test}
     "@doc" {with-doc}
   ]
 ]

--- a/packages/mdx/mdx.2.0.0/opam
+++ b/packages/mdx/mdx.2.0.0/opam
@@ -45,7 +45,6 @@ build: [
     "-j"
     jobs
     "@install"
-    "@runtest" {with-test}
     "@doc" {with-doc}
   ]
 ]

--- a/packages/mdx/mdx.2.1.0/opam
+++ b/packages/mdx/mdx.2.1.0/opam
@@ -45,7 +45,6 @@ build: [
     "-j"
     jobs
     "@install"
-    "@runtest" {with-test}
     "@doc" {with-doc}
   ]
 ]

--- a/packages/mdx/mdx.2.2.0/opam
+++ b/packages/mdx/mdx.2.2.0/opam
@@ -46,7 +46,6 @@ build: [
     "-j"
     jobs
     "@install"
-    "@runtest" {with-test}
     "@doc" {with-doc}
   ]
 ]

--- a/packages/mdx/mdx.2.2.1/opam
+++ b/packages/mdx/mdx.2.2.1/opam
@@ -46,7 +46,6 @@ build: [
     "-j"
     jobs
     "@install"
-    "@runtest" {with-test}
     "@doc" {with-doc}
   ]
 ]

--- a/packages/mdx/mdx.2.3.0/opam
+++ b/packages/mdx/mdx.2.3.0/opam
@@ -46,7 +46,6 @@ build: [
     "-j"
     jobs
     "@install"
-    "@runtest" {with-test}
     "@doc" {with-doc}
   ]
 ]

--- a/packages/mdx/mdx.2.3.1/opam
+++ b/packages/mdx/mdx.2.3.1/opam
@@ -47,7 +47,6 @@ build: [
     "-j"
     jobs
     "@install"
-    "@runtest" {with-test}
     "@doc" {with-doc}
   ]
 ]

--- a/packages/mdx/mdx.2.4.0/opam
+++ b/packages/mdx/mdx.2.4.0/opam
@@ -47,7 +47,6 @@ build: [
     "-j"
     jobs
     "@install"
-    "@runtest" {with-test}
     "@doc" {with-doc}
   ]
 ]

--- a/packages/mdx/mdx.2.4.1/opam
+++ b/packages/mdx/mdx.2.4.1/opam
@@ -47,7 +47,6 @@ build: [
     "-j"
     jobs
     "@install"
-    "@runtest" {with-test}
     "@doc" {with-doc}
   ]
 ]

--- a/packages/mdx/mdx.2.5.0/opam
+++ b/packages/mdx/mdx.2.5.0/opam
@@ -47,7 +47,6 @@ build: [
     "-j"
     jobs
     "@install"
-    "@runtest" {with-test}
     "@doc" {with-doc}
   ]
 ]

--- a/packages/mdx/mdx.2.5.1/opam
+++ b/packages/mdx/mdx.2.5.1/opam
@@ -47,7 +47,6 @@ build: [
     "-j"
     jobs
     "@install"
-    "@runtest" {with-test}
     "@doc" {with-doc}
   ]
 ]

--- a/packages/mdx/mdx.2.5.2/opam
+++ b/packages/mdx/mdx.2.5.2/opam
@@ -47,7 +47,6 @@ build: [
     "-j"
     jobs
     "@install"
-    "@runtest" {with-test}
     "@doc" {with-doc}
   ]
 ]


### PR DESCRIPTION
These versions of mdx depend on an unstable target for their build harness, which was available as a unintended quirk of the implementation of dune prior to 3.24, and no longer supported from 3.24 on.

This adds a conditional upper bound that only applies when mdx is installed `with-test`, since the limitation only applies to mdx's custom test runner.

See https://github.com/ocaml/dune/issues/14724

A fix for upstream mdx is pending at https://github.com/realworldocaml/mdx/pull/478

FYI @talex5 and @samoht 

An alternative wold be to add a patch release to all versions, [since patching the released versions is prohibited by our policies](https://github.com/ocaml/opam-repository/tree/master/governance/policies#11-changes-to-a-packages-source-archive-are-prohibited-including-patches-and-other-ways-to-modify-the-source). But I would argue that this isn't worth the work, as the best solution is just to update to the next released version of mdx.

UPDATE: As requested by Anil, this now just removes the test running on install from the current versions of mdx.