### PR TITLE
Update integers.0.8.0 source url

### DIFF
--- a/packages/integers/integers.0.8.0/opam
+++ b/packages/integers/integers.0.8.0/opam
@@ -23,7 +23,7 @@ depends: [
 doc: "http://yallop.github.io/ocaml-integers/api.docdir/"
 synopsis: "Various signed and unsigned integer types for OCaml"
 url {
-  src: "https://github.com/yallop/ocaml-integers/archive/0.8.0.tar.gz"
+  src: "https://github.com/yallop/ocaml-integers/archive/refs/tags/0.8.0.tar.gz"
   checksum: [
     "sha256=04a1a6d5cc1ecfd3f354a83caed27e59995bb26adec64d88193ccc36268929fa"
     "md5=5155b252a1143ebe7f895003a7103f5e"


### PR DESCRIPTION
The previous url gives an error, using the tag url fixes instead.

```
#=== ERROR while fetching sources for integers.0.8.0 ==========================#
OpamSolution.Fetch_fail("https://github.com/yallop/ocaml-integers/archive/0.8.0.tar.gz (code 502 while downloading https://github.com/yallop/ocaml-integers/archive/0.8.0.tar.gz)")
```

@yallop 