### PR TITLE
Run mdx tests, but only on supported dune versions (< 3.24)

### DIFF
--- a/packages/mdx/mdx.1.10.0/opam
+++ b/packages/mdx/mdx.1.10.0/opam
@@ -47,6 +47,7 @@ build: [
     "-j"
     jobs
     "@install"
+    "@runtest" {with-test & dune:version < "3.24"}
     "@doc" {with-doc}
   ]
 ]

--- a/packages/mdx/mdx.1.10.1/opam
+++ b/packages/mdx/mdx.1.10.1/opam
@@ -47,6 +47,7 @@ build: [
     "-j"
     jobs
     "@install"
+    "@runtest" {with-test & dune:version < "3.24"}
     "@doc" {with-doc}
   ]
 ]

--- a/packages/mdx/mdx.1.11.0/opam
+++ b/packages/mdx/mdx.1.11.0/opam
@@ -48,6 +48,7 @@ build: [
     "-j"
     jobs
     "@install"
+    "@runtest" {with-test & dune:version < "3.24"}
     "@doc" {with-doc}
   ]
 ]

--- a/packages/mdx/mdx.1.11.1/opam
+++ b/packages/mdx/mdx.1.11.1/opam
@@ -48,6 +48,7 @@ build: [
     "-j"
     jobs
     "@install"
+    "@runtest" {with-test & dune:version < "3.24"}
     "@doc" {with-doc}
   ]
 ]

--- a/packages/mdx/mdx.1.8.0/opam
+++ b/packages/mdx/mdx.1.8.0/opam
@@ -47,6 +47,7 @@ build: [
     "-j"
     jobs
     "@install"
+    "@runtest" {with-test & dune:version < "3.24"}
     "@doc" {with-doc}
   ]
 ]

--- a/packages/mdx/mdx.1.8.1/opam
+++ b/packages/mdx/mdx.1.8.1/opam
@@ -47,6 +47,7 @@ build: [
     "-j"
     jobs
     "@install"
+    "@runtest" {with-test & dune:version < "3.24"}
     "@doc" {with-doc}
   ]
 ]

--- a/packages/mdx/mdx.1.9.0/opam
+++ b/packages/mdx/mdx.1.9.0/opam
@@ -47,6 +47,7 @@ build: [
     "-j"
     jobs
     "@install"
+    "@runtest" {with-test & dune:version < "3.24"}
     "@doc" {with-doc}
   ]
 ]

--- a/packages/mdx/mdx.2.0.0/opam
+++ b/packages/mdx/mdx.2.0.0/opam
@@ -45,6 +45,7 @@ build: [
     "-j"
     jobs
     "@install"
+    "@runtest" {with-test & dune:version < "3.24"}
     "@doc" {with-doc}
   ]
 ]

--- a/packages/mdx/mdx.2.1.0/opam
+++ b/packages/mdx/mdx.2.1.0/opam
@@ -45,6 +45,7 @@ build: [
     "-j"
     jobs
     "@install"
+    "@runtest" {with-test & dune:version < "3.24"}
     "@doc" {with-doc}
   ]
 ]

--- a/packages/mdx/mdx.2.2.0/opam
+++ b/packages/mdx/mdx.2.2.0/opam
@@ -46,6 +46,7 @@ build: [
     "-j"
     jobs
     "@install"
+    "@runtest" {with-test & dune:version < "3.24"}
     "@doc" {with-doc}
   ]
 ]

--- a/packages/mdx/mdx.2.2.1/opam
+++ b/packages/mdx/mdx.2.2.1/opam
@@ -46,6 +46,7 @@ build: [
     "-j"
     jobs
     "@install"
+    "@runtest" {with-test & dune:version < "3.24"}
     "@doc" {with-doc}
   ]
 ]

--- a/packages/mdx/mdx.2.3.0/opam
+++ b/packages/mdx/mdx.2.3.0/opam
@@ -46,6 +46,7 @@ build: [
     "-j"
     jobs
     "@install"
+    "@runtest" {with-test & dune:version < "3.24"}
     "@doc" {with-doc}
   ]
 ]

--- a/packages/mdx/mdx.2.3.1/opam
+++ b/packages/mdx/mdx.2.3.1/opam
@@ -47,6 +47,7 @@ build: [
     "-j"
     jobs
     "@install"
+    "@runtest" {with-test & dune:version < "3.24"}
     "@doc" {with-doc}
   ]
 ]

--- a/packages/mdx/mdx.2.4.0/opam
+++ b/packages/mdx/mdx.2.4.0/opam
@@ -47,6 +47,7 @@ build: [
     "-j"
     jobs
     "@install"
+    "@runtest" {with-test & dune:version < "3.24"}
     "@doc" {with-doc}
   ]
 ]

--- a/packages/mdx/mdx.2.4.1/opam
+++ b/packages/mdx/mdx.2.4.1/opam
@@ -47,6 +47,7 @@ build: [
     "-j"
     jobs
     "@install"
+    "@runtest" {with-test & dune:version < "3.24"}
     "@doc" {with-doc}
   ]
 ]

--- a/packages/mdx/mdx.2.5.0/opam
+++ b/packages/mdx/mdx.2.5.0/opam
@@ -47,6 +47,7 @@ build: [
     "-j"
     jobs
     "@install"
+    "@runtest" {with-test & dune:version < "3.24"}
     "@doc" {with-doc}
   ]
 ]

--- a/packages/mdx/mdx.2.5.1/opam
+++ b/packages/mdx/mdx.2.5.1/opam
@@ -47,6 +47,7 @@ build: [
     "-j"
     jobs
     "@install"
+    "@runtest" {with-test & dune:version < "3.24"}
     "@doc" {with-doc}
   ]
 ]

--- a/packages/mdx/mdx.2.5.2/opam
+++ b/packages/mdx/mdx.2.5.2/opam
@@ -47,6 +47,7 @@ build: [
     "-j"
     jobs
     "@install"
+    "@runtest" {with-test & dune:version < "3.24"}
     "@doc" {with-doc}
   ]
 ]


### PR DESCRIPTION
Followup to https://github.com/ocaml/opam-repository/pull/29989

Suggested as an improvement to address https://github.com/ocaml/dune/issues/14724 by @mseri 