### PR TITLE
[new release] awskit packages (10 packages, 0.1.0)

### DIFF
--- a/packages/awskit-eio/awskit-eio.0.1.0/opam
+++ b/packages/awskit-eio/awskit-eio.0.1.0/opam
@@ -1,0 +1,55 @@
+opam-version: "2.0"
+synopsis: "Eio runtime adapter for Awskit"
+description: "Direct-style Eio runtime adapter for Awskit using Cohttp Eio."
+maintainer: ["Abdullah Elsayed <hey@abdufelsayed.dev>"]
+authors: ["Abdullah Elsayed <hey@abdufelsayed.dev>"]
+license: "MIT"
+homepage: "https://github.com/abdufelsayed/awskit"
+bug-reports: "https://github.com/abdufelsayed/awskit/issues"
+depends: [
+  "dune" {>= "3.22"}
+  "ocaml" {>= "5.2"}
+  "awskit" {= version}
+  "base" {>= "v0.16.3"}
+  "eio" {>= "1.3"}
+  "cohttp" {>= "6.2.1"}
+  "cohttp-eio" {>= "6.2.1"}
+  "uri"
+  "ptime"
+  "fmt" {>= "0.11.0"}
+  "logs"
+  "ca-certs"
+  "domain-name"
+  "tls" {>= "2.1.0"}
+  "tls-eio" {>= "2.1.0"}
+  "mirage-crypto-rng"
+  "ppx_deriving"
+  "eio_main" {with-test & >= "1.3"}
+  "alcotest" {with-test}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/abdufelsayed/awskit.git"
+x-maintenance-intent: ["(latest)"]
+url {
+  src:
+    "https://github.com/abdufelsayed/awskit/releases/download/v0.1.0/awskit-v0.1.0.tbz"
+  checksum: [
+    "sha256=788e91d57b9eed047bdef011aec476e94588be20e2e2f1b8495cf48b1a90cf0f"
+    "sha512=0d441d599f3f3efb766270258bb4d8c9cd660943eb7f90ced0ec6f61a6790f5fb8977ca5cf87f466d84701ee34dbfdf81fe5043b568a2236411f577e698c6d1e"
+  ]
+}
+x-commit-hash: "ec732daf03b07c283a4211f4176f9920d5ffb238"

--- a/packages/awskit-lwt-unix/awskit-lwt-unix.0.1.0/opam
+++ b/packages/awskit-lwt-unix/awskit-lwt-unix.0.1.0/opam
@@ -1,0 +1,50 @@
+opam-version: "2.0"
+synopsis: "Lwt Unix runtime adapter for Awskit"
+description:
+  "Ready-to-use Lwt and Unix runtime adapter for Awskit using Cohttp Lwt Unix."
+maintainer: ["Abdullah Elsayed <hey@abdufelsayed.dev>"]
+authors: ["Abdullah Elsayed <hey@abdufelsayed.dev>"]
+license: "MIT"
+homepage: "https://github.com/abdufelsayed/awskit"
+bug-reports: "https://github.com/abdufelsayed/awskit/issues"
+depends: [
+  "dune" {>= "3.22"}
+  "ocaml" {>= "4.14"}
+  "awskit" {= version}
+  "awskit-unix" {= version}
+  "awskit-lwt" {= version}
+  "cohttp" {>= "6.2.1"}
+  "cohttp-lwt" {>= "6.2.1"}
+  "cohttp-lwt-unix" {>= "6.2.1"}
+  "lwt"
+  "uri"
+  "ptime"
+  "yojson"
+  "alcotest" {with-test}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/abdufelsayed/awskit.git"
+x-maintenance-intent: ["(latest)"]
+url {
+  src:
+    "https://github.com/abdufelsayed/awskit/releases/download/v0.1.0/awskit-v0.1.0.tbz"
+  checksum: [
+    "sha256=788e91d57b9eed047bdef011aec476e94588be20e2e2f1b8495cf48b1a90cf0f"
+    "sha512=0d441d599f3f3efb766270258bb4d8c9cd660943eb7f90ced0ec6f61a6790f5fb8977ca5cf87f466d84701ee34dbfdf81fe5043b568a2236411f577e698c6d1e"
+  ]
+}
+x-commit-hash: "ec732daf03b07c283a4211f4176f9920d5ffb238"

--- a/packages/awskit-lwt/awskit-lwt.0.1.0/opam
+++ b/packages/awskit-lwt/awskit-lwt.0.1.0/opam
@@ -1,0 +1,51 @@
+opam-version: "2.0"
+synopsis: "Lwt runtime adapter for Awskit"
+description:
+  "Generic Lwt runtime adapter for Awskit over a caller-supplied Cohttp Lwt client."
+maintainer: ["Abdullah Elsayed <hey@abdufelsayed.dev>"]
+authors: ["Abdullah Elsayed <hey@abdufelsayed.dev>"]
+license: "MIT"
+homepage: "https://github.com/abdufelsayed/awskit"
+bug-reports: "https://github.com/abdufelsayed/awskit/issues"
+depends: [
+  "dune" {>= "3.22"}
+  "ocaml" {>= "4.14"}
+  "awskit" {= version}
+  "base" {>= "v0.16.3"}
+  "lwt"
+  "cohttp" {>= "6.2.1"}
+  "cohttp-lwt" {>= "6.2.1"}
+  "uri"
+  "ptime"
+  "fmt" {>= "0.11.0"}
+  "logs"
+  "ppx_deriving"
+  "cohttp-lwt-unix" {with-test & >= "6.2.1"}
+  "alcotest" {with-test}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/abdufelsayed/awskit.git"
+x-maintenance-intent: ["(latest)"]
+url {
+  src:
+    "https://github.com/abdufelsayed/awskit/releases/download/v0.1.0/awskit-v0.1.0.tbz"
+  checksum: [
+    "sha256=788e91d57b9eed047bdef011aec476e94588be20e2e2f1b8495cf48b1a90cf0f"
+    "sha512=0d441d599f3f3efb766270258bb4d8c9cd660943eb7f90ced0ec6f61a6790f5fb8977ca5cf87f466d84701ee34dbfdf81fe5043b568a2236411f577e698c6d1e"
+  ]
+}
+x-commit-hash: "ec732daf03b07c283a4211f4176f9920d5ffb238"

--- a/packages/awskit-s3-eio/awskit-s3-eio.0.1.0/opam
+++ b/packages/awskit-s3-eio/awskit-s3-eio.0.1.0/opam
@@ -1,0 +1,48 @@
+opam-version: "2.0"
+synopsis: "Eio adapter for Awskit S3"
+description: "S3 client adapter over the Awskit Eio runtime."
+maintainer: ["Abdullah Elsayed <hey@abdufelsayed.dev>"]
+authors: ["Abdullah Elsayed <hey@abdufelsayed.dev>"]
+license: "MIT"
+homepage: "https://github.com/abdufelsayed/awskit"
+bug-reports: "https://github.com/abdufelsayed/awskit/issues"
+depends: [
+  "dune" {>= "3.22"}
+  "ocaml" {>= "5.2"}
+  "awskit" {= version}
+  "awskit-eio" {= version}
+  "awskit-s3" {= version}
+  "fmt" {>= "0.11.0"}
+  "eio" {>= "1.3"}
+  "ptime"
+  "awskit-unix" {with-test & = version}
+  "eio_main" {with-test & >= "1.3"}
+  "digestif" {with-test & >= "1.3.0"}
+  "alcotest" {with-test}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/abdufelsayed/awskit.git"
+x-maintenance-intent: ["(latest)"]
+url {
+  src:
+    "https://github.com/abdufelsayed/awskit/releases/download/v0.1.0/awskit-v0.1.0.tbz"
+  checksum: [
+    "sha256=788e91d57b9eed047bdef011aec476e94588be20e2e2f1b8495cf48b1a90cf0f"
+    "sha512=0d441d599f3f3efb766270258bb4d8c9cd660943eb7f90ced0ec6f61a6790f5fb8977ca5cf87f466d84701ee34dbfdf81fe5043b568a2236411f577e698c6d1e"
+  ]
+}
+x-commit-hash: "ec732daf03b07c283a4211f4176f9920d5ffb238"

--- a/packages/awskit-s3-lwt-unix/awskit-s3-lwt-unix.0.1.0/opam
+++ b/packages/awskit-s3-lwt-unix/awskit-s3-lwt-unix.0.1.0/opam
@@ -1,0 +1,48 @@
+opam-version: "2.0"
+synopsis: "Lwt Unix adapter for Awskit S3"
+description:
+  "Ready-to-use S3 client adapter over the Awskit Lwt Unix runtime."
+maintainer: ["Abdullah Elsayed <hey@abdufelsayed.dev>"]
+authors: ["Abdullah Elsayed <hey@abdufelsayed.dev>"]
+license: "MIT"
+homepage: "https://github.com/abdufelsayed/awskit"
+bug-reports: "https://github.com/abdufelsayed/awskit/issues"
+depends: [
+  "dune" {>= "3.22"}
+  "ocaml" {>= "4.14"}
+  "awskit" {= version}
+  "awskit-lwt-unix" {= version}
+  "awskit-s3" {= version}
+  "awskit-s3-lwt" {= version}
+  "cohttp-lwt-unix" {>= "6.2.1"}
+  "lwt"
+  "fmt" {>= "0.11.0"}
+  "ptime"
+  "alcotest" {with-test}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/abdufelsayed/awskit.git"
+x-maintenance-intent: ["(latest)"]
+url {
+  src:
+    "https://github.com/abdufelsayed/awskit/releases/download/v0.1.0/awskit-v0.1.0.tbz"
+  checksum: [
+    "sha256=788e91d57b9eed047bdef011aec476e94588be20e2e2f1b8495cf48b1a90cf0f"
+    "sha512=0d441d599f3f3efb766270258bb4d8c9cd660943eb7f90ced0ec6f61a6790f5fb8977ca5cf87f466d84701ee34dbfdf81fe5043b568a2236411f577e698c6d1e"
+  ]
+}
+x-commit-hash: "ec732daf03b07c283a4211f4176f9920d5ffb238"

--- a/packages/awskit-s3-lwt/awskit-s3-lwt.0.1.0/opam
+++ b/packages/awskit-s3-lwt/awskit-s3-lwt.0.1.0/opam
@@ -1,0 +1,46 @@
+opam-version: "2.0"
+synopsis: "Lwt adapter for Awskit S3"
+description: "S3 client adapter over the generic Awskit Lwt runtime."
+maintainer: ["Abdullah Elsayed <hey@abdufelsayed.dev>"]
+authors: ["Abdullah Elsayed <hey@abdufelsayed.dev>"]
+license: "MIT"
+homepage: "https://github.com/abdufelsayed/awskit"
+bug-reports: "https://github.com/abdufelsayed/awskit/issues"
+depends: [
+  "dune" {>= "3.22"}
+  "ocaml" {>= "4.14"}
+  "awskit" {= version}
+  "awskit-lwt" {= version}
+  "awskit-s3" {= version}
+  "cohttp-lwt" {>= "6.2.1"}
+  "lwt"
+  "ptime"
+  "cohttp-lwt-unix" {with-test & >= "6.2.1"}
+  "alcotest" {with-test}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/abdufelsayed/awskit.git"
+x-maintenance-intent: ["(latest)"]
+url {
+  src:
+    "https://github.com/abdufelsayed/awskit/releases/download/v0.1.0/awskit-v0.1.0.tbz"
+  checksum: [
+    "sha256=788e91d57b9eed047bdef011aec476e94588be20e2e2f1b8495cf48b1a90cf0f"
+    "sha512=0d441d599f3f3efb766270258bb4d8c9cd660943eb7f90ced0ec6f61a6790f5fb8977ca5cf87f466d84701ee34dbfdf81fe5043b568a2236411f577e698c6d1e"
+  ]
+}
+x-commit-hash: "ec732daf03b07c283a4211f4176f9920d5ffb238"

--- a/packages/awskit-s3-sim/awskit-s3-sim.0.1.0/opam
+++ b/packages/awskit-s3-sim/awskit-s3-sim.0.1.0/opam
@@ -1,0 +1,47 @@
+opam-version: "2.0"
+synopsis: "In-memory simulator for Awskit S3 tests"
+description:
+  "Deterministic in-memory S3 implementation for tests, including buckets, objects, multipart uploads, versioning, checksums, and fault injection."
+maintainer: ["Abdullah Elsayed <hey@abdufelsayed.dev>"]
+authors: ["Abdullah Elsayed <hey@abdufelsayed.dev>"]
+license: "MIT"
+homepage: "https://github.com/abdufelsayed/awskit"
+bug-reports: "https://github.com/abdufelsayed/awskit/issues"
+depends: [
+  "dune" {>= "3.22"}
+  "ocaml" {>= "4.14"}
+  "awskit" {= version}
+  "awskit-s3" {= version}
+  "digestif" {>= "1.3.0"}
+  "ptime"
+  "fmt" {>= "0.11.0"}
+  "base64" {>= "3.5.2"}
+  "uri"
+  "alcotest" {with-test}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/abdufelsayed/awskit.git"
+x-maintenance-intent: ["(latest)"]
+url {
+  src:
+    "https://github.com/abdufelsayed/awskit/releases/download/v0.1.0/awskit-v0.1.0.tbz"
+  checksum: [
+    "sha256=788e91d57b9eed047bdef011aec476e94588be20e2e2f1b8495cf48b1a90cf0f"
+    "sha512=0d441d599f3f3efb766270258bb4d8c9cd660943eb7f90ced0ec6f61a6790f5fb8977ca5cf87f466d84701ee34dbfdf81fe5043b568a2236411f577e698c6d1e"
+  ]
+}
+x-commit-hash: "ec732daf03b07c283a4211f4176f9920d5ffb238"

--- a/packages/awskit-s3/awskit-s3.0.1.0/opam
+++ b/packages/awskit-s3/awskit-s3.0.1.0/opam
@@ -1,0 +1,51 @@
+opam-version: "2.0"
+synopsis: "S3 client core — objects, buckets, multipart, and policies"
+description:
+  "S3 operations, bucket configuration, multipart uploads, presigned URLs, policies, and XML wire types. Runtime adapters are available as separate packages."
+maintainer: ["Abdullah Elsayed <hey@abdufelsayed.dev>"]
+authors: ["Abdullah Elsayed <hey@abdufelsayed.dev>"]
+license: "MIT"
+homepage: "https://github.com/abdufelsayed/awskit"
+bug-reports: "https://github.com/abdufelsayed/awskit/issues"
+depends: [
+  "dune" {>= "3.22"}
+  "ocaml" {>= "4.14"}
+  "awskit" {= version}
+  "digestif" {>= "1.3.0"}
+  "ptime"
+  "fmt" {>= "0.11.0"}
+  "yojson"
+  "base64" {>= "3.5.2"}
+  "uri"
+  "ezxmlm"
+  "ppx_protocol_conv_xmlm"
+  "ppx_deriving"
+  "ppx_yojson_conv"
+  "alcotest" {with-test}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/abdufelsayed/awskit.git"
+x-maintenance-intent: ["(latest)"]
+url {
+  src:
+    "https://github.com/abdufelsayed/awskit/releases/download/v0.1.0/awskit-v0.1.0.tbz"
+  checksum: [
+    "sha256=788e91d57b9eed047bdef011aec476e94588be20e2e2f1b8495cf48b1a90cf0f"
+    "sha512=0d441d599f3f3efb766270258bb4d8c9cd660943eb7f90ced0ec6f61a6790f5fb8977ca5cf87f466d84701ee34dbfdf81fe5043b568a2236411f577e698c6d1e"
+  ]
+}
+x-commit-hash: "ec732daf03b07c283a4211f4176f9920d5ffb238"

--- a/packages/awskit-unix/awskit-unix.0.1.0/opam
+++ b/packages/awskit-unix/awskit-unix.0.1.0/opam
@@ -1,0 +1,43 @@
+opam-version: "2.0"
+synopsis: "Unix helpers for Awskit"
+description:
+  "Unix-specific AWS helpers for wall-clock time, environment variables, and shared credential files."
+maintainer: ["Abdullah Elsayed <hey@abdufelsayed.dev>"]
+authors: ["Abdullah Elsayed <hey@abdufelsayed.dev>"]
+license: "MIT"
+homepage: "https://github.com/abdufelsayed/awskit"
+bug-reports: "https://github.com/abdufelsayed/awskit/issues"
+depends: [
+  "dune" {>= "3.22"}
+  "ocaml" {>= "4.14"}
+  "awskit" {= version}
+  "base" {>= "v0.16.3"}
+  "ptime"
+  "fmt" {>= "0.11.0"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/abdufelsayed/awskit.git"
+x-maintenance-intent: ["(latest)"]
+url {
+  src:
+    "https://github.com/abdufelsayed/awskit/releases/download/v0.1.0/awskit-v0.1.0.tbz"
+  checksum: [
+    "sha256=788e91d57b9eed047bdef011aec476e94588be20e2e2f1b8495cf48b1a90cf0f"
+    "sha512=0d441d599f3f3efb766270258bb4d8c9cd660943eb7f90ced0ec6f61a6790f5fb8977ca5cf87f466d84701ee34dbfdf81fe5043b568a2236411f577e698c6d1e"
+  ]
+}
+x-commit-hash: "ec732daf03b07c283a4211f4176f9920d5ffb238"

--- a/packages/awskit/awskit.0.1.0/opam
+++ b/packages/awskit/awskit.0.1.0/opam
@@ -1,0 +1,51 @@
+opam-version: "2.0"
+synopsis:
+  "AWS infrastructure — signing, credentials, endpoints, and core types"
+description:
+  "SigV4 signing, credentials, endpoints, error types, request/response types, and the Runtime module type. Runtime adapters are available as separate packages."
+maintainer: ["Abdullah Elsayed <hey@abdufelsayed.dev>"]
+authors: ["Abdullah Elsayed <hey@abdufelsayed.dev>"]
+license: "MIT"
+homepage: "https://github.com/abdufelsayed/awskit"
+bug-reports: "https://github.com/abdufelsayed/awskit/issues"
+depends: [
+  "dune" {>= "3.22"}
+  "ocaml" {>= "4.14"}
+  "base" {>= "v0.16.3"}
+  "digestif" {>= "1.3.0"}
+  "ptime"
+  "fmt" {>= "0.11.0"}
+  "logs"
+  "ppx_deriving"
+  "dune-release" {with-dev-setup}
+  "opam-publish" {with-dev-setup}
+  "alcotest" {with-test}
+  "qcheck-core" {with-test}
+  "qcheck-alcotest" {with-test}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/abdufelsayed/awskit.git"
+x-maintenance-intent: ["(latest)"]
+url {
+  src:
+    "https://github.com/abdufelsayed/awskit/releases/download/v0.1.0/awskit-v0.1.0.tbz"
+  checksum: [
+    "sha256=788e91d57b9eed047bdef011aec476e94588be20e2e2f1b8495cf48b1a90cf0f"
+    "sha512=0d441d599f3f3efb766270258bb4d8c9cd660943eb7f90ced0ec6f61a6790f5fb8977ca5cf87f466d84701ee34dbfdf81fe5043b568a2236411f577e698c6d1e"
+  ]
+}
+x-commit-hash: "ec732daf03b07c283a4211f4176f9920d5ffb238"


### PR DESCRIPTION
AWS infrastructure — signing, credentials, endpoints, and core types

- Project page: <a href="https://github.com/abdufelsayed/awskit">https://github.com/abdufelsayed/awskit</a>

##### CHANGES:

Initial public release of Awskit.

Includes core AWS signing, credentials, endpoints, request/response types,
retry support, runtime abstractions, Unix credential helpers, Lwt and Eio
runtime adapters, and focused S3 support for general-purpose buckets.

The S3 packages include bucket configuration primitives, object operations,
multipart upload primitives, presigned URLs, and adapter-level transfer helpers
for streaming file upload and download. The optional S3 simulator package
provides deterministic in-memory S3 for tests.
