### PR TITLE
[new release] awa (2 packages) (0.6.1)

### DIFF
--- a/packages/awa-mirage/awa-mirage.0.6.1/opam
+++ b/packages/awa-mirage/awa-mirage.0.6.1/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+maintainer: [ "Christiano F. Haesbaert <haesbaert@haesbaert.org>" "Hannes Mehnert <hannes@mehnert.org>" "Reynir Björnsson <reynir@reynir.dk>" "Romain Calascibetta <romain.calascibetta@gmail.com>" "Pierre Alain <pierre.alain@tuta.io>" ]
+authors: [ "Christiano F. Haesbaert <haesbaert@haesbaert.org>" "Hannes Mehnert <hannes@mehnert.org>" "Reynir Björnsson <reynir@reynir.dk>" "Romain Calascibetta <romain.calascibetta@gmail.com>" "Pierre Alain <pierre.alain@tuta.io>" ]
+license: "ISC"
+homepage: "https://github.com/mirage/awa-ssh"
+bug-reports: "https://github.com/mirage/awa-ssh/issues"
+dev-repo: "git+https://github.com/mirage/awa-ssh.git"
+doc: "https://mirage.github.io/awa-ssh/api"
+
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "2.7"}
+  "awa" {= version}
+  "cstruct" {>= "6.0.0"}
+  "mtime" {>= "1.0.0"}
+  "lwt" {>= "5.3.0"}
+  "mirage-sleep" {>= "4.0.0"}
+  "duration" {>= "0.2.0"}
+  "mirage-flow" {>= "4.0.0"}
+  "mirage-mtime" {>= "4.0.0"}
+  "logs"
+]
+synopsis: "SSH implementation in OCaml"
+description: """The OpenSSH protocol implemented in OCaml."""
+x-maintenance-intent: [ "(latest)" ]
+url {
+  src:
+    "https://github.com/mirage/awa-ssh/releases/download/v0.6.1/awa-0.6.1.tbz"
+  checksum: [
+    "sha256=c62b37f88e1c63d8105526663026af225f6a19eee78e845029f159eb28759101"
+    "sha512=92016a7ddfbc8c1aacad285627ac39ede79888aa7ce03686873db9040363fd1f677285086be4b2acd368a8fc8eec45fec95ab4d602c6a0a6126521bb7881cb66"
+  ]
+}
+x-commit-hash: "7d7d21260ffbfb927d707ee0b3684f2f4bf7ba63"

--- a/packages/awa/awa.0.6.1/opam
+++ b/packages/awa/awa.0.6.1/opam
@@ -1,0 +1,46 @@
+opam-version: "2.0"
+maintainer: [ "Christiano F. Haesbaert <haesbaert@haesbaert.org>" "Hannes Mehnert <hannes@mehnert.org>" "Reynir Björnsson <reynir@reynir.dk>" "Romain Calascibetta <romain.calascibetta@gmail.com>" "Pierre Alain <pierre.alain@tuta.io>" ]
+authors: [ "Christiano F. Haesbaert <haesbaert@haesbaert.org>" "Hannes Mehnert <hannes@mehnert.org>" "Reynir Björnsson <reynir@reynir.dk>" "Romain Calascibetta <romain.calascibetta@gmail.com>" "Pierre Alain <pierre.alain@tuta.io>" ]
+license: "ISC"
+homepage: "https://github.com/mirage/awa-ssh"
+bug-reports: "https://github.com/mirage/awa-ssh/issues"
+dev-repo: "git+https://github.com/mirage/awa-ssh.git"
+doc: "https://mirage.github.io/awa-ssh/api"
+
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+depends: [
+  "ocaml" {>= "4.10.0"}
+  "dune" {>= "2.7"}
+  "mirage-crypto" {>= "1.0.0"}
+  "mirage-crypto-rng" {>= "1.2.0"}
+  "mirage-crypto-pk"
+  "mirage-crypto-ec" {>= "1.0.0"}
+  "x509" {>= "1.0.0"}
+  "mtime" {>= "1.0.0"}
+  "logs"
+  "fmt"
+  "cmdliner" {>= "1.1.0"}
+  "base64" {>= "3.0.0"}
+  "zarith"
+  "eqaf" {>= "0.8"}
+  "mirage-mtime" {>= "4.0.0"}
+  "ohex" {>= "0.2.0"}
+]
+conflicts: [ "result" {< "1.5"} ]
+synopsis: "SSH implementation in OCaml"
+description: """The OpenSSH protocol implemented in OCaml."""
+x-maintenance-intent: [ "(latest)" ]
+url {
+  src:
+    "https://github.com/mirage/awa-ssh/releases/download/v0.6.1/awa-0.6.1.tbz"
+  checksum: [
+    "sha256=c62b37f88e1c63d8105526663026af225f6a19eee78e845029f159eb28759101"
+    "sha512=92016a7ddfbc8c1aacad285627ac39ede79888aa7ce03686873db9040363fd1f677285086be4b2acd368a8fc8eec45fec95ab4d602c6a0a6126521bb7881cb66"
+  ]
+}
+x-commit-hash: "7d7d21260ffbfb927d707ee0b3684f2f4bf7ba63"


### PR DESCRIPTION
SSH implementation in OCaml

- Project page: <a href="https://github.com/mirage/awa-ssh">https://github.com/mirage/awa-ssh</a>
- Documentation: <a href="https://mirage.github.io/awa-ssh/api">https://mirage.github.io/awa-ssh/api</a>

##### CHANGES:

* Core: fix parsing of MSG_KEX_n and MSG_USERAUTH_n (mirage/awa-ssh#86 @dinosaure)
