### PR TITLE
[new release] ocaml-ai-sdk (2 packages) (0.4)

### DIFF
--- a/packages/ai-sdk-react/ai-sdk-react.0.4/opam
+++ b/packages/ai-sdk-react/ai-sdk-react.0.4/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+synopsis: "Melange bindings for @ai-sdk/react"
+description: "Type-safe OCaml/Melange bindings for Vercel AI SDK)"
+maintainer: ["José Nogueira <jose.nogueira@ahrefs.com>"]
+authors: ["Ahrefs"]
+license: "MIT"
+homepage: "https://github.com/ahrefs/ocaml-ai-sdk"
+doc: "https://github.com/ahrefs/ocaml-ai-sdk"
+bug-reports: "https://github.com/ahrefs/ocaml-ai-sdk/issues"
+depends: [
+  "dune" {>= "3.21"}
+  "ocaml" {>= "4.14"}
+  "melange" {>= "4.0.0"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/ahrefs/ocaml-ai-sdk.git"
+x-maintenance-intent: ["(latest)"]
+url {
+  src:
+    "https://github.com/ahrefs/ocaml-ai-sdk/releases/download/0.4/ocaml-ai-sdk-0.4.tbz"
+  checksum: [
+    "sha256=4f3f22ae61d360b994cd75323bcb6b6bf915f6755fd1e7bab6844ca8a240c1e7"
+    "sha512=3c52b17096da818f5d3bcf9fe16826c3bec4533d6a1681e8ba0f957f37ee4f425696017cb78f1a24732f8851010d436cf446f873b72b6a4f5004d6b492072abf"
+  ]
+}
+x-commit-hash: "0ec8dd27d57b7767ed41dec30b2e6df42b0c1eda"

--- a/packages/ocaml-ai-sdk/ocaml-ai-sdk.0.4/opam
+++ b/packages/ocaml-ai-sdk/ocaml-ai-sdk.0.4/opam
@@ -1,0 +1,53 @@
+opam-version: "2.0"
+synopsis: "OCaml AI SDK - Provider abstraction for AI models"
+description:
+  "Type-safe, provider-agnostic AI model abstraction inspired by Vercel AI SDK"
+maintainer: ["José Nogueira <jose.nogueira@ahrefs.com>"]
+authors: ["Ahrefs"]
+license: "MIT"
+homepage: "https://github.com/ahrefs/ocaml-ai-sdk"
+doc: "https://github.com/ahrefs/ocaml-ai-sdk"
+bug-reports: "https://github.com/ahrefs/ocaml-ai-sdk/issues"
+depends: [
+  "dune" {>= "3.21"}
+  "ocaml" {>= "4.14"}
+  "lwt" {>= "5.9"}
+  "yojson" {>= "2.2"}
+  "jsonschema" {>= "0.1"}
+  "melange-json-native" {>= "2.0"}
+  "cohttp-lwt-unix" {>= "5.3"}
+  "lwt_ssl" {>= "1.2"}
+  "base64" {>= "1.3"}
+  "ppx_deriving" {>= "5.2"}
+  "lwt_ppx" {>= "5.9"}
+  "re2" {>= "0.16"}
+  "uuseg" {>= "17.0"}
+  "trace" {>= "0.12"}
+  "alcotest" {with-test}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/ahrefs/ocaml-ai-sdk.git"
+x-maintenance-intent: ["(latest)"]
+url {
+  src:
+    "https://github.com/ahrefs/ocaml-ai-sdk/releases/download/0.4/ocaml-ai-sdk-0.4.tbz"
+  checksum: [
+    "sha256=4f3f22ae61d360b994cd75323bcb6b6bf915f6755fd1e7bab6844ca8a240c1e7"
+    "sha512=3c52b17096da818f5d3bcf9fe16826c3bec4533d6a1681e8ba0f957f37ee4f425696017cb78f1a24732f8851010d436cf446f873b72b6a4f5004d6b492072abf"
+  ]
+}
+x-commit-hash: "0ec8dd27d57b7767ed41dec30b2e6df42b0c1eda"


### PR DESCRIPTION
OCaml AI SDK - Provider abstraction for AI models

- Project page: <a href="https://github.com/ahrefs/ocaml-ai-sdk">https://github.com/ahrefs/ocaml-ai-sdk</a>
- Documentation: <a href="https://github.com/ahrefs/ocaml-ai-sdk">https://github.com/ahrefs/ocaml-ai-sdk</a>

##### CHANGES:

### Breaking changes

Source-breaking for downstream code that constructs these records directly
or pattern-matches without `; _`. Code that goes through the documented
constructors (`Core_tool.create`, `Prompt_builder.resolve_messages`,
`Cache_control.ephemeral` / `ephemeral_1h`) is unaffected.

- `Ai_provider.Prompt.System` gained `provider_options : Provider_options.t`
  alongside `content`. Callers building `System { content }` literally must
  add `provider_options = Ai_provider.Provider_options.empty`.
- `Ai_provider.Tool.t` gained `provider_options : Provider_options.t`. The
  in-tree OpenAI / OpenRouter providers were updated; external providers
  constructing this record need the same.
- `Ai_provider.Stream_part.Finish` gained `provider_metadata`. The
  standalone `Provider_metadata` constructor is removed — its data now
  rides on `Finish`.
- `Ai_core.Core_tool.t` gained `provider_options`. The `create` /
  `create_with_approval` / `create_client_tool` helpers take an optional
  `?provider_options` defaulting to empty, so call sites that use them are
  unaffected.
- `Ai_provider_anthropic.Cache_control.t` gained `ttl : ttl option`.
  Construct via `Cache_control.ephemeral` (5m, default) or
  `Cache_control.ephemeral_1h`.
- Removed `Ai_provider_anthropic.Cache_control.breakpoint_to_json` /
  `breakpoint_of_json` from the public mli — they silently dropped the
  `ttl` field and had no in-tree callers.

### Anthropic provider (`ai_provider_anthropic`)

- **Prompt caching reaches the high-level API.** The `cache_control`
  plumbing landed in 0.3 was only usable through `Ai_provider.Language_model`
  directly. `Ai_core.Generate_text.generate_text`,
  `Ai_core.Stream_text.stream_text`, and `Ai_core.Server_handler.handle_chat`
  now accept `?system_provider_options` for the prepended system prompt,
  and `Core_tool.t` gains a `provider_options` field that flows through to
  the provider `Tool` record. The runnable `examples/prompt_caching` demo
  exercises the new path.
- **`Stream_part.Finish` carries `provider_metadata`** matching upstream
  `LanguageModelV4StreamPart`. The standalone `Provider_metadata` chunk is
  removed; Anthropic cache token metrics now ride on the terminal `Finish`
  chunk on cached requests, and `Stream_text_result.provider_metadata` /
  `Generate_text_result.step.provider_metadata` expose them to callers.
  Cache fields are read from `message_start.message.usage` (where Anthropic
  actually emits them) with a fallback to `message_delta.usage`.
- **System messages always serialize as array-of-blocks** on the wire,
  matching upstream `@ai-sdk/anthropic`. The previous "joined string when
  no `cache_control`, array when `cache_control` is set" behavior changed
  the model's input based on a feature flag.
- Anthropic usage decoders now ignore unknown fields, including nested
  `cache_creation` fields, so new provider-side usage metadata does not
  break response parsing.

### OpenRouter provider (`ai_provider_openrouter`)

- **Prompt caching support.** Added typed `Cache_control` /
  `Cache_control_options` modules for explicit per-block cache breakpoints,
  including Anthropic-compatible `ttl` values (`5m` / `1h`) and fallback
  support for prompts that already use the Anthropic cache-control key.
- **OpenRouter prompt conversion now mirrors upstream.** The provider no
  longer reuses the OpenAI prompt converter for chat messages. It now emits
  OpenRouter-specific `cache_control` placement for system, user, assistant,
  and tool messages, while preserving the no-cache shape for non-system
  messages.
- **Cache usage metadata.** OpenRouter `usage.prompt_tokens_details` is mapped
  into provider metadata as `cache_read_tokens` and `cache_write_tokens`.
  Added `examples/openrouter_prompt_caching` to demonstrate both top-level
  automatic caching and explicit breakpoint mode.
