### PR TITLE
Release cabal.0.1.0

### DIFF
--- a/packages/cabal/cabal.0.1.0/opam
+++ b/packages/cabal/cabal.0.1.0/opam
@@ -11,7 +11,7 @@ doc: "https://epure-team.github.io/cabal/"
 bug-reports: "https://github.com/epure-team/cabal/issues"
 depends: [
   "ocaml" {>= "5.3.0"}
-  "dune" {>= "3.13"}
+  "dune" {>= "3.22"}
   "yojson"
   "jsonschema" {>= "0.1.0"}
   "eio" {>= "1.0"}
@@ -26,6 +26,7 @@ depends: [
   "bisect_ppx" {with-test}
   "odoc" {with-doc}
 ]
+available: [os != "win32"]
 build: [
   ["dune" "subst"] {dev}
   [

--- a/packages/cabal/cabal.0.1.0/opam
+++ b/packages/cabal/cabal.0.1.0/opam
@@ -1,0 +1,50 @@
+opam-version: "2.0"
+synopsis: "Caml Agent Backend Abstraction Library"
+description:
+  "Backend-agnostic agent execution primitives, configuration generation, and session logging for OCaml projects."
+maintainer: ["Julien Tesson <tesson.julien@free.fr>"]
+authors: ["Epure Team"]
+license: "MIT"
+tags: ["agentic" "backend" "abstraction" "cli" "llm"]
+homepage: "https://github.com/epure-team/cabal"
+doc: "https://epure-team.github.io/cabal/"
+bug-reports: "https://github.com/epure-team/cabal/issues"
+depends: [
+  "ocaml" {>= "5.3.0"}
+  "dune" {>= "3.13"}
+  "yojson"
+  "jsonschema" {>= "0.1.0"}
+  "eio" {>= "1.0"}
+  "eio_posix" {>= "1.0"}
+  "eio_main" {with-test & >= "1.0"}
+  "yaml"
+  "ppx_deriving"
+  "ppx_deriving_yojson"
+  "ppx_blob"
+  "alcotest" {with-test}
+  "conf-git" {with-test}
+  "bisect_ppx" {with-test}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/epure-team/cabal.git"
+url {
+  src: "https://github.com/epure-team/cabal/archive/refs/tags/0.1.0.tar.gz"
+  checksum: [
+    "sha256=f9dc2180e4ceba25c2d2342d0e4ad84e3e3998ec247d71b1cea9e0e069b41cae"
+    "sha512=3a23ad08d81e85cd35b84e558a12c139645ffb1befa8de685880de16a69c0723df2dd2dbf48a1f6b2d54c18861963fae6d7a326f15b1767252ae698e7c013bdf"
+  ]
+}

--- a/packages/cabal/cabal.0.1.0/opam
+++ b/packages/cabal/cabal.0.1.0/opam
@@ -20,7 +20,7 @@ depends: [
   "yaml"
   "ppx_deriving"
   "ppx_deriving_yojson"
-  "ppx_blob"
+  "ppx_blob" {>= "0.9.0"}
   "alcotest" {with-test}
   "conf-git" {with-test}
   "bisect_ppx" {with-test}


### PR DESCRIPTION
This PR adds `cabal.0.1.0`.

Cabal is the Caml Agent Backend Abstraction Library. It provides
backend-agnostic agent execution primitives, backend registry metadata,
configuration generation, process invocation helpers, adapter loading, and
session log utilities for OCaml host applications that drive agentic CLI
backends.

Upstream repository: https://github.com/epure-team/cabal
Release: https://github.com/epure-team/cabal/releases/tag/0.1.0
Prepared from commit: 6c18811f18b9f5e140791f6f5bf6367f9b456c05

Local checks:

- `opam lint cabal.opam`: passed
- `opam lint packages/cabal/cabal.0.1.0/opam`: passed
- `opam install . --deps-only --with-test && dune build @install && dune runtest && opam lint cabal.opam`: passed locally.
