### PR TITLE
[new release] hxd (0.5.0)

### DIFF
--- a/packages/hxd/hxd.0.5.0/opam
+++ b/packages/hxd/hxd.0.5.0/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+maintainer:   "Romain Calascibetta <romain.calascibetta@gmail.com>"
+authors:      "Romain Calascibetta <romain.calascibetta@gmail.com>"
+homepage:     "https://github.com/dinosaure/hxd"
+bug-reports:  "https://github.com/dinosaure/hxd/issues"
+dev-repo:     "git+https://github.com/dinosaure/hxd.git"
+doc:          "https://dinosaure.github.io/hxd/"
+license:      "MIT"
+synopsis:     "Hexdump in OCaml"
+description: """Please, help me to debug ocaml-git
+"""
+
+build: [
+  [ "dune" "build" "-p" name "-j" jobs ]
+  [ "dune" "runtest" "-p" name "-j" jobs ] {with-test & arch != "x86_32" & arch != "arm32"}
+]
+
+depends: [
+  "ocaml"             {>= "4.08.0"}
+  "dune"              {>= "2.7"}
+  "dune-configurator" {>= "2.7"}
+  "cmdliner"          {>= "1.1.0"}
+]
+
+depopts: [
+  "lwt"
+]
+x-maintenance-intent: [ "(latest)" ]
+url {
+  src:
+    "https://github.com/dinosaure/hxd/releases/download/v0.5.0/hxd-0.5.0.tbz"
+  checksum: [
+    "sha256=453c394ec15678c5ce6ef12356e4d5806a0261176600facca765dec41671faa9"
+    "sha512=19ba577350347c6a144a0ff2bc181f421547766c533f0a63b0d3b5ce987ccbfb6099b640b0aab24b27c84f854e52dd0de37667b50b7466af9e97ffc1db66d86f"
+  ]
+}
+x-commit-hash: "8da4db8f5873bbd2813848717dae7e79f0ad17f5"


### PR DESCRIPTION
Hexdump in OCaml

- Project page: <a href="https://github.com/dinosaure/hxd">https://github.com/dinosaure/hxd</a>
- Documentation: <a href="https://dinosaure.github.io/hxd/">https://dinosaure.github.io/hxd/</a>

##### CHANGES:

- Add `Hxd.is_caml`, `Hxd.{input,output}_buffer_size`, `Hxd.with_uppercase`
  & `Hxd.cols` and be able to introspect a `cfg` value (@dinosaure, dinosaure/hxd#25)
- Apply `ocamlformat.0.29.0` (@dinosaure, dinosaure/hxd#26)
