### PR TITLE
[new release] mnet (6 packages) (0.0.3)

### DIFF
--- a/packages/mnet-cli/mnet-cli.0.0.3/opam
+++ b/packages/mnet-cli/mnet-cli.0.0.3/opam
@@ -13,6 +13,7 @@ depends: [
   "mnet" {= version}
   "mirage-ptime"
   "duration"
+  "re"
   "dns"
   "tls"
   "cmdliner" {>= "2.0.0"}

--- a/packages/mnet-cli/mnet-cli.0.0.3/opam
+++ b/packages/mnet-cli/mnet-cli.0.0.3/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+maintainer: "Robur <team@robur.coop>"
+authors: ["Robur <team@robur.coop>"]
+homepage: "https://github.com/robur-coop/mnet"
+dev-repo: "git+https://github.com/robur-coop/mnet.git"
+bug-reports: "https://github.com/robur-coop/mnet/issues"
+license: "MIT"
+
+depends: [
+  "ocaml" {>= "5.0.0"}
+  "utcp"
+  "dune" {>= "2.7.0"}
+  "mnet" {= version}
+  "mirage-ptime"
+  "duration"
+  "dns"
+  "tls"
+  "cmdliner" {>= "2.0.0"}
+  "ca-certs-nss" {>= "3.118"}
+  "mirage-ptime" {>= "5.2.0"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+synopsis: "A library for defining the options required by a unikernel to configure its TCP/IP stack"
+url {
+  src:
+    "https://github.com/robur-coop/mnet/releases/download/v0.0.3/mnet-0.0.3.tbz"
+  checksum: [
+    "sha256=85ceac44091bae441d88789b3ce9efe9e206e9905edb37fb8de10121d89c870a"
+    "sha512=cad757a660625c085f7c1f337ca7b85cf0145d1e8ef9886200be75174f51519e3443fe5757e061d76b14852a7082728448a7a484949c4a0ebd3011f328b7a25f"
+  ]
+}
+x-commit-hash: "760675f9dbdf8d63a39af318eae054d306f4816e"

--- a/packages/mnet-dns/mnet-dns.0.0.3/opam
+++ b/packages/mnet-dns/mnet-dns.0.0.3/opam
@@ -1,0 +1,34 @@
+opam-version: "2.0"
+maintainer: "Robur <team@robur.coop>"
+authors: ["Robur <team@robur.coop>"]
+homepage: "https://github.com/robur-coop/mnet"
+dev-repo: "git+https://github.com/robur-coop/mnet.git"
+bug-reports: "https://github.com/robur-coop/mnet/issues"
+license: "MIT"
+
+depends: [
+  "ocaml" {>= "5.0.0"}
+  "utcp"
+  "dune" {>= "2.7.0"}
+  "mnet" {= version}
+  "mnet-tls" {= version}
+  "mnet-happy-eyeballs" {= version}
+  "dns"
+  "dns-client"
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+synopsis: "An implementation of DNS in OCaml for Miou & Solo5"
+url {
+  src:
+    "https://github.com/robur-coop/mnet/releases/download/v0.0.3/mnet-0.0.3.tbz"
+  checksum: [
+    "sha256=85ceac44091bae441d88789b3ce9efe9e206e9905edb37fb8de10121d89c870a"
+    "sha512=cad757a660625c085f7c1f337ca7b85cf0145d1e8ef9886200be75174f51519e3443fe5757e061d76b14852a7082728448a7a484949c4a0ebd3011f328b7a25f"
+  ]
+}
+x-commit-hash: "760675f9dbdf8d63a39af318eae054d306f4816e"

--- a/packages/mnet-happy-eyeballs/mnet-happy-eyeballs.0.0.3/opam
+++ b/packages/mnet-happy-eyeballs/mnet-happy-eyeballs.0.0.3/opam
@@ -1,0 +1,31 @@
+opam-version: "2.0"
+maintainer: "Robur <team@robur.coop>"
+authors: ["Robur <team@robur.coop>"]
+homepage: "https://github.com/robur-coop/mnet"
+dev-repo: "git+https://github.com/robur-coop/mnet.git"
+bug-reports: "https://github.com/robur-coop/mnet/issues"
+license: "MIT"
+
+depends: [
+  "ocaml" {>= "5.0.0"}
+  "utcp"
+  "dune" {>= "2.7.0"}
+  "mnet" {= version}
+  "happy-eyeballs" {>= "2.0.0"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+synopsis: "Connecting to a remote host via IP version 4 or 6 using mnet"
+url {
+  src:
+    "https://github.com/robur-coop/mnet/releases/download/v0.0.3/mnet-0.0.3.tbz"
+  checksum: [
+    "sha256=85ceac44091bae441d88789b3ce9efe9e206e9905edb37fb8de10121d89c870a"
+    "sha512=cad757a660625c085f7c1f337ca7b85cf0145d1e8ef9886200be75174f51519e3443fe5757e061d76b14852a7082728448a7a484949c4a0ebd3011f328b7a25f"
+  ]
+}
+x-commit-hash: "760675f9dbdf8d63a39af318eae054d306f4816e"

--- a/packages/mnet-ssh/mnet-ssh.0.0.3/opam
+++ b/packages/mnet-ssh/mnet-ssh.0.0.3/opam
@@ -1,0 +1,33 @@
+opam-version: "2.0"
+maintainer: "Robur <team@robur.coop>"
+authors: ["Robur <team@robur.coop>"]
+homepage: "https://github.com/robur-coop/mnet"
+dev-repo: "git+https://github.com/robur-coop/mnet.git"
+bug-reports: "https://github.com/robur-coop/mnet/issues"
+license: "MIT"
+
+depends: [
+  "ocaml" {>= "5.0.0"}
+  "utcp"
+  "miou" {>= "0.7.0"}
+  "dune" {>= "2.7.0"}
+  "mnet" {= version}
+  "awa"
+  "flux"
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+synopsis: "An implementation of SSH in OCaml for Miou & Solo5"
+url {
+  src:
+    "https://github.com/robur-coop/mnet/releases/download/v0.0.3/mnet-0.0.3.tbz"
+  checksum: [
+    "sha256=85ceac44091bae441d88789b3ce9efe9e206e9905edb37fb8de10121d89c870a"
+    "sha512=cad757a660625c085f7c1f337ca7b85cf0145d1e8ef9886200be75174f51519e3443fe5757e061d76b14852a7082728448a7a484949c4a0ebd3011f328b7a25f"
+  ]
+}
+x-commit-hash: "760675f9dbdf8d63a39af318eae054d306f4816e"

--- a/packages/mnet-ssh/mnet-ssh.0.0.3/opam
+++ b/packages/mnet-ssh/mnet-ssh.0.0.3/opam
@@ -12,7 +12,7 @@ depends: [
   "miou" {>= "0.7.0"}
   "dune" {>= "2.7.0"}
   "mnet" {= version}
-  "awa"
+  "awa" {>= "0.6.1"}
   "flux"
 ]
 build: [

--- a/packages/mnet-tls/mnet-tls.0.0.3/opam
+++ b/packages/mnet-tls/mnet-tls.0.0.3/opam
@@ -1,0 +1,31 @@
+opam-version: "2.0"
+maintainer: "Robur <team@robur.coop>"
+authors: ["Robur <team@robur.coop>"]
+homepage: "https://github.com/robur-coop/mnet"
+dev-repo: "git+https://github.com/robur-coop/mnet.git"
+bug-reports: "https://github.com/robur-coop/mnet/issues"
+license: "MIT"
+
+depends: [
+  "ocaml" {>= "5.0.0"}
+  "utcp"
+  "dune" {>= "2.7.0"}
+  "mnet" {= version}
+  "tls"
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+synopsis: "An implementation of TLS in OCaml for Miou & Solo5"
+url {
+  src:
+    "https://github.com/robur-coop/mnet/releases/download/v0.0.3/mnet-0.0.3.tbz"
+  checksum: [
+    "sha256=85ceac44091bae441d88789b3ce9efe9e206e9905edb37fb8de10121d89c870a"
+    "sha512=cad757a660625c085f7c1f337ca7b85cf0145d1e8ef9886200be75174f51519e3443fe5757e061d76b14852a7082728448a7a484949c4a0ebd3011f328b7a25f"
+  ]
+}
+x-commit-hash: "760675f9dbdf8d63a39af318eae054d306f4816e"

--- a/packages/mnet/mnet.0.0.3/opam
+++ b/packages/mnet/mnet.0.0.3/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+maintainer: "Robur <team@robur.coop>"
+authors: ["Robur <team@robur.coop>"]
+homepage: "https://github.com/robur-coop/mnet"
+dev-repo: "git+https://github.com/robur-coop/mnet.git"
+bug-reports: "https://github.com/robur-coop/mnet/issues"
+license: "MIT"
+
+depends: [
+  "ocaml" {>= "5.0.0"}
+  "utcp"
+  "dune" {>= "2.7.0"}
+  "bstr" {>= "0.0.4"}
+  "bin"
+  "slice"
+  "mkernel"
+  "mirage-crypto-rng"
+  "duration"
+  "fmt"
+  "ipaddr"
+  "macaddr"
+  "hxd"
+  "tls"
+  "happy-eyeballs"
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+synopsis: "An implementation of TCP (Transmission Control Protocol) in OCaml for Miou & Solo5"
+url {
+  src:
+    "https://github.com/robur-coop/mnet/releases/download/v0.0.3/mnet-0.0.3.tbz"
+  checksum: [
+    "sha256=85ceac44091bae441d88789b3ce9efe9e206e9905edb37fb8de10121d89c870a"
+    "sha512=cad757a660625c085f7c1f337ca7b85cf0145d1e8ef9886200be75174f51519e3443fe5757e061d76b14852a7082728448a7a484949c4a0ebd3011f328b7a25f"
+  ]
+}
+x-commit-hash: "760675f9dbdf8d63a39af318eae054d306f4816e"


### PR DESCRIPTION
An implementation of TCP (Transmission Control Protocol) in OCaml for Miou & Solo5

- Project page: <a href="https://github.com/robur-coop/mnet">https://github.com/robur-coop/mnet</a>

##### CHANGES:

- Minor simplification of `mnet-tls` about handshake (@hannesm, [!28][28])
- Improve `mnet-cli` (add `setup_logs`) (@dinosaure, [!30][30])
- Be able to return the TCP daemon (and be able to kill it)
  (@dinosaure, [!31][30])
- Add a new `mnet-ssh` package which implements SSH for unikernels
  (@dinosaure, [!29][29])

[28]: https://git.robur.coop/robur/mnet/pulls/28
[29]: https://git.robur.coop/robur/mnet/pulls/29
[30]: https://git.robur.coop/robur/mnet/pulls/30
[31]: https://git.robur.coop/robur/mnet/pulls/31
