### PR TITLE
[new release] migra (1.0.1)

### DIFF
--- a/packages/migra/migra.1.0.1/opam
+++ b/packages/migra/migra.1.0.1/opam
@@ -1,0 +1,56 @@
+opam-version: "2.0"
+synopsis:
+  "A database migration tool and library for OCaml supporting PostgreSQL, MariaDB/MySQL, and SQLite"
+description:
+  "A database migration tool and library for OCaml. Migrations are plain SQL with up and down sections, and the database (PostgreSQL, MariaDB/MySQL, or SQLite) is selected from the connection URL. Applied migrations are tracked with checksums, and drift (a modified, missing, or out-of-order migration) is detected before anything runs. It can be used from the command line or embedded as a library to migrate on application startup."
+maintainer: ["David Sinclair <dsincl12@gmail.com>"]
+authors: ["David Sinclair"]
+license: "MIT"
+tags: ["database" "migrations" "postgresql" "mariadb" "mysql" "sqlite"]
+homepage: "https://github.com/dsincl12/migra"
+doc: "https://github.com/dsincl12/migra"
+bug-reports: "https://github.com/dsincl12/migra/issues"
+depends: [
+  "dune" {>= "3.12"}
+  "ocaml" {>= "4.14.0"}
+  "dune-build-info" {>= "3.12"}
+  "lwt" {>= "5.6.0"}
+  "alcotest" {with-test & >= "1.7.0"}
+  "alcotest-lwt" {with-test & >= "1.7.0"}
+  "caqti" {>= "2.0.0"}
+  "caqti-lwt" {>= "2.0.0"}
+  "caqti-dynload" {>= "2.0.0"}
+  "uri" {>= "4.4.0"}
+  "cmdliner" {>= "2.0.0"}
+  "logs" {>= "0.7.0"}
+  "logs-ppx" {>= "0.2.0"}
+  "fmt" {>= "0.9.0"}
+  "odoc" {with-doc}
+]
+depopts: [
+  "caqti-driver-postgresql" "caqti-driver-mariadb" "caqti-driver-sqlite3"
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/dsincl12/migra.git"
+url {
+  src:
+    "https://github.com/dsincl12/migra/releases/download/1.0.1/migra-1.0.1.tbz"
+  checksum: [
+    "sha256=daaaab416e580e5b8dc9f0a74482e142cef6d77b248d995d320f6f882d3a9e35"
+    "sha512=8f60494b9ee6ac2e7e69a16eefce69d1e8c22e831fe28f600a42200e3086e2f4d15331323ad1848f7165e1c8ff30fe320445185b7e988325588293a66937966a"
+  ]
+}
+x-commit-hash: "3d87ac7d013312cfa1ec9607bf422be193a4abd7"


### PR DESCRIPTION
A database migration tool and library for OCaml supporting PostgreSQL, MariaDB/MySQL, and SQLite

- Project page: <a href="https://github.com/dsincl12/migra">https://github.com/dsincl12/migra</a>
- Documentation: <a href="https://github.com/dsincl12/migra">https://github.com/dsincl12/migra</a>

##### CHANGES:

### Fixed
- `rollback` and `redo` now validate applied migrations against the files on
  disk before running and return `Error` on drift (a modified or missing
  applied migration), just like `migrate`. Previously they could roll back
  using modified down SQL or silently skip a migration whose file was gone.
- `status` now includes an applied migration whose file is missing (shown as
  `(migration file missing)`) instead of hiding it and understating the applied
  count.
- Database lifecycle commands (`create_database`/`drop_database`) now quote and
  escape the database identifier in the generated DDL, so PostgreSQL names such
  as `my-db` work and MariaDB names containing backticks are handled safely.
