### PR TITLE
Package contract.0.2.0

### DIFF
--- a/packages/contract/contract.0.2.0/opam
+++ b/packages/contract/contract.0.2.0/opam
@@ -1,0 +1,33 @@
+opam-version: "2.0"
+maintainer: "Thomas B. <funwithcthulhu29@gmail.com>"
+authors: ["Thomas B."]
+license: "MIT"
+homepage: "https://github.com/funwithcthulhu/contract"
+bug-reports: "https://github.com/funwithcthulhu/contract/issues"
+dev-repo: "git+https://github.com/funwithcthulhu/contract.git"
+doc: "https://github.com/funwithcthulhu/contract#readme"
+tags: ["http" "api" "contract" "openapi"]
+synopsis: "Typed HTTP API contracts for OCaml"
+description: """
+contract describes REST-style HTTP API contracts as typed OCaml values.
+The current package provides a pure core for endpoint definitions, parameter
+and JSON decoding, request and response validation, and OpenAPI 3.0.3 output.
+"""
+depends: [
+  "ocaml" {>= "5.0"}
+  "dune" {>= "3.11"}
+  "yojson" {>= "2.0.0"}
+  "alcotest" {with-test & >= "1.9.0"}
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name] {with-test}
+]
+url {
+  src:
+    "https://github.com/funwithcthulhu/contract/archive/refs/tags/0.2.0.tar.gz"
+  checksum: [
+    "md5=22bb7430b72c2dd9c141679cc76c0ea5"
+    "sha512=d8e8687fd81b1191158ec6d7356887278eb7b7cd60114c4a7f13e52914e9c1ee17eeff37ffa81dd39b4104a553c3e457bacc78907f32ab279130ff5a76b5256f"
+  ]
+}


### PR DESCRIPTION
### `contract.0.2.0`
Typed HTTP API contracts for OCaml
contract describes REST-style HTTP API contracts as typed OCaml values.
The current package provides a pure core for endpoint definitions, parameter
and JSON decoding, request and response validation, and OpenAPI 3.0.3 output.



---
* Homepage: https://github.com/funwithcthulhu/contract
* Source repo: git+https://github.com/funwithcthulhu/contract.git
* Bug tracker: https://github.com/funwithcthulhu/contract/issues

---
:camel: Pull-request generated by opam-publish v2.6.0