### PR TITLE
Package doctor.0.4.0

### DIFF
--- a/packages/doctor/doctor.0.4.0/opam
+++ b/packages/doctor/doctor.0.4.0/opam
@@ -1,0 +1,53 @@
+opam-version: "2.0"
+
+synopsis: "Diagnostic CLI for OCaml development environments"
+description: """
+doctor checks common OCaml development environment problems, including
+opam setup, active switches, dune, ocaml-lsp-server, ocamlformat, PATH issues,
+and editor integration hints.
+"""
+
+maintainer: "Thomas B. <funwithcthulhu29@gmail.com>"
+authors: "Thomas B."
+
+license: "MIT"
+
+flags: plugin
+
+tags: [
+  "cli"
+  "diagnostics"
+  "developer-tools"
+  "opam"
+  "dune"
+  "lsp"
+  "windows"
+]
+
+homepage: "https://github.com/funwithcthulhu/doctor"
+doc: "https://github.com/funwithcthulhu/doctor#readme"
+bug-reports: "https://github.com/funwithcthulhu/doctor/issues"
+dev-repo: "git+https://github.com/funwithcthulhu/doctor.git"
+
+depends: [
+  "ocaml" {>= "5.1"}
+  "dune" {>= "3.11"}
+  "cmdliner" {>= "1.1.0"}
+]
+
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+
+run-test: [
+  ["dune" "runtest" "-p" name "-j" jobs]
+]
+url {
+  src:
+    "https://github.com/funwithcthulhu/doctor/archive/refs/tags/0.4.0.tar.gz"
+  checksum: [
+    "md5=f5718339acd3f2ab3cf82e5226a61484"
+    "sha512=0d0f795f20c2cfdfd7b9c77769242a9576aa82c0023758caf9656564d58e80805195cfd9b45c4fe15f0526ae55236cfdb414d1c969ede184128e046d08228f1f"
+  ]
+}


### PR DESCRIPTION
### `doctor.0.4.0`
Diagnostic CLI for OCaml development environments
doctor checks common OCaml development environment problems, including
opam setup, active switches, dune, ocaml-lsp-server, ocamlformat, PATH issues,
and editor integration hints.



---
* Homepage: https://github.com/funwithcthulhu/doctor
* Source repo: git+https://github.com/funwithcthulhu/doctor.git
* Bug tracker: https://github.com/funwithcthulhu/doctor/issues

---
:camel: Pull-request generated by opam-publish v2.6.0