### PR TITLE
[new release] ortools (2 packages) (9.15.0-2)

### DIFF
--- a/packages/ortools/ortools.9.15.0-2/opam
+++ b/packages/ortools/ortools.9.15.0-2/opam
@@ -1,0 +1,54 @@
+opam-version: "2.0"
+
+synopsis:
+"Build and export Google OR-Tools models"
+
+description: """
+Google OR-Tools is an open source software suite for optimization, tuned
+for tackling the world's toughest problems in vehicle routing, flows,
+integer and linear programming, and constraint programming. This package
+provides OCaml functions for working with the Protocol Buffer formats that
+are read and written by the different solvers. It does not actually depend
+on the OR-Tools software, which need not even be installed. The interface
+currently only supports a subset of the features provided by the CP-SAT solver.
+Pull requests for more features and solvers are welcome."""
+
+maintainer:  ["Timothy Bourke <tim@tbrk.org>"]
+authors:     ["Timothy Bourke <tim@tbrk.org>"]
+license:     "Apache-2.0"
+homepage:    "https://github.com/inria/ocaml-ortools"
+bug-reports: "https://github.com/inria/ocaml-ortools/issues"
+dev-repo:    "git+https://github.com/inria/ocaml-ortools.git"
+x-maintenance-intent: ["(latest)"]
+
+depends: [
+  "ocaml"	{>= "4.14.2"}
+  "dune"	{>= "3.21"}
+  "pbrt"	{>= "4.0"}
+  "odoc"	{with-doc}
+]
+
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src:
+    "https://github.com/INRIA/ocaml-ortools/releases/download/9.15.0-2/ortools-9.15.0-2.tbz"
+  checksum: [
+    "sha256=b4de105eb8df75b0600459b333f274a4da558145aff3f0754897742a63881b61"
+    "sha512=063de9edfea678a60ed34f6640cd094f02bfe7d34bf744f2b35e58bcfbde35fb59496061d33b2de39a57e56e7a8286288e6cb663f0b05cf1f488fa359102d28e"
+  ]
+}
+x-commit-hash: "389e8ddd5e2d4c699f5e1c44ebd61ce42e762467"
+

--- a/packages/ortools_solvers/ortools_solvers.9.15.0-2/opam
+++ b/packages/ortools_solvers/ortools_solvers.9.15.0-2/opam
@@ -1,0 +1,93 @@
+opam-version: "2.0"
+
+synopsis:
+"Call Google OR-Tools solvers"
+
+description: """
+Google OR-Tools is an open source software suite for optimization, tuned
+for tackling the world's toughest problems in vehicle routing, flows,
+integer and linear programming, and constraint programming. This package
+provides OCaml wrappers for calling the OR-Tools solvers. It currently only
+supports the CP-SAT solver. Pull requests for other solvers are welcome."""
+
+maintainer:  ["Timothy Bourke <tim@tbrk.org>"]
+authors:     ["Timothy Bourke <tim@tbrk.org>"]
+license:     "Apache-2.0"
+homepage:    "https://github.com/inria/ocaml-ortools"
+bug-reports: "https://github.com/inria/ocaml-ortools/issues"
+dev-repo:    "git+https://github.com/inria/ocaml-ortools.git"
+x-maintenance-intent: ["(latest)"]
+
+depends: [
+  "ocaml"	{>= "4.14.2"}
+  "dune"	{>= "3.21"}
+  "ortools"	{>= "9.15"}
+  "conf-cmake"	{build}
+  "sexplib0"	{build}
+  "csexp"	{build}
+  "odoc"	{with-doc}
+  "conf-zlib"
+  "conf-bzip2"
+]
+
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+
+depexts: [
+  # debian, alpine, arch: build with OCaml ortools_solvers package
+
+  # needed to compile abseil (linux/futex.h)
+  ["linux-headers"]	    {os-distribution = "alpine"}
+
+  # abseil 20260107.0
+  ["abseil"]		    {os = "macos" & os-distribution = "homebrew"}
+
+
+  # protobuf 33.4
+  ["protobuf"]		    {os = "macos" & os-distribution = "homebrew"}
+
+  # protobuf-c 1.5.2
+  ["protobuf-c"]	    {os = "macos" & os-distribution = "homebrew"}
+
+  # re2 2025-11-05
+  ["re2"]		    {os = "macos" & os-distribution = "homebrew"}
+]
+
+x-ci-accept-failures: [
+  "centos-9"		# c++ compilation fails
+  "opensuse-15.6"	# cannot compile with cmake
+  "opensuse-16.0"	# zlib-devel conflicts with zlib-ng-compat-devel
+			# and the zlib-ng-compat-devel cmake files are wrong
+  "opensuse-tumbleweed"	# zlib-devel conflicts with zlib-ng-compat-devel
+			# and the zlib-ng-compat-devel cmake files are wrong
+]
+
+post-messages: [
+  """Failed to install ortools_solvers.
+Ensure the required dependencies are properly installed.
+See https://github.com/inria/ocaml-ortools.
+"""
+  {failure}
+]
+url {
+  src:
+    "https://github.com/INRIA/ocaml-ortools/releases/download/9.15.0-2/ortools-9.15.0-2.tbz"
+  checksum: [
+    "sha256=b4de105eb8df75b0600459b333f274a4da558145aff3f0754897742a63881b61"
+    "sha512=063de9edfea678a60ed34f6640cd094f02bfe7d34bf744f2b35e58bcfbde35fb59496061d33b2de39a57e56e7a8286288e6cb663f0b05cf1f488fa359102d28e"
+  ]
+}
+x-commit-hash: "389e8ddd5e2d4c699f5e1c44ebd61ce42e762467"
+

--- a/packages/ortools_solvers/ortools_solvers.9.15.0-2/opam
+++ b/packages/ortools_solvers/ortools_solvers.9.15.0-2/opam
@@ -21,7 +21,7 @@ x-maintenance-intent: ["(latest)"]
 depends: [
   "ocaml"	{>= "4.14.2"}
   "dune"	{>= "3.21"}
-  "ortools"	{>= "9.15"}
+  "ortools"	{>= "9.15.0-2"}
   "conf-cmake"	{build}
   "sexplib0"	{build}
   "csexp"	{build}


### PR DESCRIPTION
Build and export Google OR-Tools models

- Project page: <a href="https://github.com/inria/ocaml-ortools">https://github.com/inria/ocaml-ortools</a>

##### CHANGES:

Expose more of the underlying protocol buffers machinery to facilitate the
iterative use of the CP-SAT solver from OCaml, e.g., to complete hints, or
to solve multiple objectives in sequence.
