### PR TITLE
[new release] syto (0.1.0)

### DIFF
--- a/packages/syto/syto.0.1.0/opam
+++ b/packages/syto/syto.0.1.0/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+synopsis: "POSIX fnmatch(3) filename pattern matching"
+description:
+  "Dependency-free OCaml library implementing POSIX fnmatch(3) filename pattern matching. Supports PATHNAME, NOESCAPE, PERIOD flags and CASEFOLD, GLOBSTAR extensions. UTF-8 codepoint-aware."
+maintainer: ["Sergiy Duras <sergiy@duras.org>"]
+authors: ["Sergiy Duras <sergiy@duras.org>"]
+license: "ISC"
+homepage: "https://codeberg.org/duras/syto"
+bug-reports: "https://codeberg.org/duras/syto/issues"
+depends: [
+  "dune" {>= "3.0"}
+  "ocaml" {>= "4.14"}
+  "alcotest" {with-test & >= "1.7"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/sduras/syto.git"
+url {
+  src:
+    "https://github.com/sduras/syto/releases/download/0.1.0/syto-0.1.0.tbz"
+  checksum: [
+    "sha256=4af63e149ba034dfd123ad452712d2c2dc21679c5547af671c48eb07a14e9c54"
+    "sha512=dcd7c47d117a31b5549727ec9c86902fa139deaaa1481ec0505a6f95cf4cbd5361f382ee2ceedc8ad4e402a46e3f2e18079fe48a8b20ef4113e6ca2d03d80a3d"
+  ]
+}
+x-commit-hash: "2aab4ddda619c853e92d8e6bcb31c5b05ed79428"


### PR DESCRIPTION
POSIX fnmatch(3) filename pattern matching

- Project page: <a href="https://codeberg.org/duras/syto">https://codeberg.org/duras/syto</a>

##### CHANGES:

Initial release.

- POSIX fnmatch(3) pattern matching: `match_pattern` and `filter`
- Flags: `Pathname`, `Noescape`, `Period` (POSIX); `Casefold`, `Globstar` (extensions)
- UTF-8 codepoint-aware: `?` matches one Unicode codepoint; ranges operate on codepoints
- `Casefold` is ASCII-only (A–Z); bracket range validation uses raw (unfolded) endpoints
- `Globstar` recognises `**` only at path-component boundaries; trailing `**` requires at least one name component
- Structured error type: `Error of { kind; pattern; offset }`
- `Unsupported_bracket_syntax` for collating elements and equivalence classes
- 376 tests passing (361 canonical vectors + 15 property tests)
- No dependencies beyond OCaml stdlib and alcotest (test only)
