### PR TITLE
OCaml 5.5.0: first release candidate

### DIFF
--- a/packages/ocaml-base-compiler/ocaml-base-compiler.5.5.0~rc1/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.5.5.0~rc1/opam
@@ -1,0 +1,29 @@
+opam-version: "2.0"
+synopsis: "First release candidate for OCaml 5.5.0"
+maintainer: [
+  "David Allsopp <dra27@dra27.uk>"
+  "Florian Angeletti <florian.angeletti@inria.fr>"
+]
+license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
+authors: [
+  "Xavier Leroy"
+  "Damien Doligez"
+  "Alain Frisch"
+  "Jacques Garrigue"
+  "Didier Rémy"
+  "KC Sivaramakrishnan"
+  "Jérôme Vouillon"
+]
+homepage: "https://ocaml.org"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
+dev-repo: "git+https://github.com/ocaml/ocaml.git#5.5"
+depends: [
+  "ocaml-compiler" {= "5.5.0~rc1"}
+
+  "ocaml-beta" {opam-version < "2.1.0"}
+
+  # OCaml with default configuration (no flambda, TSAN, etc.)
+  "ocaml-options-vanilla" {post}
+]
+conflict-class: "ocaml-core-compiler"
+flags: [ compiler avoid-version ]

--- a/packages/ocaml-compiler/ocaml-compiler.5.5.0~rc1/opam
+++ b/packages/ocaml-compiler/ocaml-compiler.5.5.0~rc1/opam
@@ -1,0 +1,131 @@
+opam-version: "2.0"
+# These packages are part of the infrastructure for maintaining the OCaml
+# compiler dependencies in opam. It's not possible to version the metadata
+# itself, because opam's versioning provides no mechanism to ignore the
+# revision (i.e. we don't have a way to have two revisions of ocaml.5.4.1 but
+# where "ocaml" {= "5.4.1"} would always mean to use the latest revision).
+# It is however useful to know which version of the metadata is installed.
+# This number should be bumped whenever a pertinent change is made.
+x-revision: "2"
+license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
+synopsis: "First release candidate for OCaml 5.5.0"
+maintainer: [
+  "David Allsopp <dra27@dra27.uk>"
+  "Florian Angeletti <florian.angeletti@inria.fr>"
+]
+authors: [
+  "Xavier Leroy"
+  "Damien Doligez"
+  "Alain Frisch"
+  "Jacques Garrigue"
+  "Didier Rémy"
+  "KC Sivaramakrishnan"
+  "Jérôme Vouillon"
+]
+homepage: "https://ocaml.org"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
+dev-repo: "git+https://github.com/ocaml/ocaml.git#5.5"
+depends: [
+  # This is OCaml 5.5.0
+  "ocaml" {= "5.5.0" & post}
+  "compiler-cloning" {build}
+
+  # General base- packages
+  "base-unix" {post}
+  "base-bigarray" {post}
+  "base-threads" {post}
+  "base-domains" {post}
+  "base-nnp" {post}
+  "base-effects" {post}
+
+  "ocaml-beta" {opam-version < "2.1.0"}
+
+  # Port selection (Windows)
+  # amd64 mingw-w64 / MSVC
+  (("arch-x86_64" {os = "win32" & arch = "x86_64"} &
+     ("system-mingw" |
+      ("system-msvc" & "ocaml-option-no-compression" {os = "win32"}))) |
+  # i686 mingw-w64 / MSVC
+   ("arch-x86_32" {os = "win32"} & "ocaml-option-bytecode-only" {os = "win32"} &
+     ("system-mingw" |
+      ("system-msvc" & "ocaml-option-no-compression" {os = "win32"}))) |
+  # Non-Windows systems need to install something to satisfy this formula, so
+  # repeat the base-unix dependency
+   "base-unix" {os != "win32" & post})
+
+  # All the 32-bit architectures are bytecode-only
+  "ocaml-option-bytecode-only" {arch != "arm64" & arch != "x86_64" & arch != "s390x" & arch != "riscv64" & arch != "ppc64"}
+
+  # Support Packages
+  "flexdll" {>= "0.44" & os = "win32"}
+]
+flags: [ avoid-version ]
+build-env: [
+  [MSYS2_ARG_CONV_EXCL = "*"]
+  [LSAN_OPTIONS = "detect_leaks=0,exitcode=0"]
+  [ASAN_OPTIONS = "detect_leaks=0,exitcode=0"]
+]
+build: [
+  [
+    "sh" "tools/opam/process.sh" make "-j%{jobs}%" _:build-id _:name compiler-cloning:version
+    "--host=x86_64-pc-windows"  {system-msvc:installed & arch-x86_64:installed}
+    "--host=x86_64-w64-mingw32" {os-distribution = "cygwin" & system-mingw:installed & arch-x86_64:installed}
+    "--host=i686-pc-windows"    {system-msvc:installed & arch-x86_32:installed}
+    "--host=i686-w64-mingw32"   {os-distribution = "cygwin" & system-mingw:installed & arch-x86_32:installed}
+    "--prefix=%{prefix}%"
+    "--docdir=%{doc}%/ocaml"
+    "--with-additional-stublibsdir"
+    "--with-relative-libdir"
+    "--enable-runtime-search"
+    "--enable-runtime-search-target=fallback"
+    "--with-flexdll=%{flexdll:share}%" {os = "win32" & flexdll:installed}
+    "--with-afl" {ocaml-option-afl:installed}
+    "--disable-native-compiler" {ocaml-option-bytecode-only:installed}
+    "--disable-flat-float-array" {ocaml-option-no-flat-float-array:installed}
+    "--enable-flambda" {ocaml-option-flambda:installed}
+    "--enable-frame-pointers" {ocaml-option-fp:installed}
+    "--without-zstd" {ocaml-option-no-compression:installed}
+    "--enable-tsan" {ocaml-option-tsan:installed}
+    "CC=cc" {!ocaml-option-32bit:installed & !ocaml-option-musl:installed & (os = "openbsd" | os = "macos")}
+    "CC=clang" {ocaml-option-tsan:installed & (os="macos")}
+    "CC=musl-gcc" {ocaml-option-musl:installed & os-distribution!="alpine"}
+    "CFLAGS=-Os" {ocaml-option-musl:installed & arch != "arm64"}
+    "CFLAGS=-Os -mno-outline-atomics" {ocaml-option-musl:installed & arch = "arm64"}
+    "LDFLAGS=-Wl,--no-as-needed,-ldl" {ocaml-option-leak-sanitizer:installed | (ocaml-option-address-sanitizer:installed & os!="macos")}
+    "CC=gcc -ldl -fsanitize=leak -fno-omit-frame-pointer -O1 -g" {ocaml-option-leak-sanitizer:installed}
+    "CC=gcc -ldl -fsanitize=address -fno-omit-frame-pointer -O1 -g" {ocaml-option-address-sanitizer:installed & os!="macos"}
+    "CC=clang -fsanitize=address -fno-omit-frame-pointer -O1 -g" {ocaml-option-address-sanitizer:installed & os="macos"}
+    "CC=gcc -m32" {ocaml-option-32bit:installed & os="linux"}
+    "CC=gcc -Wl,-read_only_relocs,suppress -arch i386 -m32" {ocaml-option-32bit:installed & os="macos"}
+    "ASPP=musl-gcc -c" {ocaml-option-musl:installed & os-distribution!="alpine"}
+    "--host=i386-linux" {ocaml-option-32bit:installed & os="linux"}
+    "--host=i386-apple-darwin13.2.0" {ocaml-option-32bit:installed & os="macos"}
+    "LIBS=-static" {ocaml-option-static:installed}
+    "--disable-warn-error"
+  ]
+]
+install: ["sh" "tools/opam/process.sh" make "install" _:build-id _:name prefix]
+url {
+  src: "https://github.com/ocaml/ocaml/archive/5.5.0-rc1.tar.gz"
+  checksum: "sha256=00c5da0ab159f5089476430ad250f22e689df8c17b3403bd1635d0d40c4bc748"
+}
+depopts: [
+  "ocaml-option-32bit"
+  "ocaml-option-afl"
+  "ocaml-option-bytecode-only"
+  "ocaml-option-no-flat-float-array"
+  "ocaml-option-flambda"
+  "ocaml-option-fp"
+  "ocaml-option-no-compression"
+  "ocaml-option-musl"
+  "ocaml-option-leak-sanitizer"
+  "ocaml-option-address-sanitizer"
+  "ocaml-option-static"
+  "ocaml-option-tsan"
+]
+post-messages: [
+"This switch had to be compiled from sources, but future switches with the 🐌
+same compiler version and configuration should assemble instantly." {!failure & !_:cloned & compiler-cloning:version != "disabled"}
+"As requested, this switch was compiled from sources 😴" {!failure & compiler-cloning:version = "disabled"}
+"Switch cloned by %{_:clone-mechanism}% from %{_:clone-source}% 💨" {!failure & _:cloned}
+]

--- a/packages/ocaml-variants/ocaml-variants.5.5.0~rc1+options/opam
+++ b/packages/ocaml-variants/ocaml-variants.5.5.0~rc1+options/opam
@@ -1,0 +1,26 @@
+opam-version: "2.0"
+license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
+synopsis: "First release candidate for OCaml 5.5.0"
+maintainer: [
+  "David Allsopp <dra27@dra27.uk>"
+  "Florian Angeletti <florian.angeletti@inria.fr>"
+]
+authors: [
+  "Xavier Leroy"
+  "Damien Doligez"
+  "Alain Frisch"
+  "Jacques Garrigue"
+  "Didier Rémy"
+  "KC Sivaramakrishnan"
+  "Jérôme Vouillon"
+]
+homepage: "https://ocaml.org"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
+dev-repo: "git+https://github.com/ocaml/ocaml.git#5.4"
+depends: [
+  "ocaml-compiler" {= "5.5.0~rc1"}
+
+  "ocaml-beta" {opam-version < "2.1.0"}
+]
+conflict-class: "ocaml-core-compiler"
+flags: [ compiler avoid-version ]


### PR DESCRIPTION
This PR adds the three packages for the first release candidate for OCaml 5.5.0:

- ocaml-compiler: core compiler
- ocaml-base-compiler: vanilla configuration
- ocaml-variants...+options: customizable configurations

Compared to the first beta, this potentially final version contains :
- three runtime fixes
-  a stdlib fix for a possible injection attack channel on Windows
-  a compiler CLI fix
- two configuration fixes
- an update to the manual and manpage documentation for ocamlc, ocamlopt, OCAMLRUNPARAM

---------------------

## Changes since the first beta

### Runtime fixes

- 14820: caml_ba_alloc must account for memory it allocated itself.
  CAML_BA_SUBARRAY (introduced in 5.2) with data=NULL would result in the
  Gc accounting for the allocation as 0 bytes, which can eventually lead
  to OOM. This condition never occurs in the compiler itself, but occurs
  in external C bindings that attempt to create a new bigarray in the
  shape of an existing one. For backwards compatibility ignore CAML_BA_SUBARRAY
  when data is NULL.
  (Edwin Török, review by Damien Doligez)

- 13700, 14454, +14715: Use POSIX thread-safe getgrnam_r, getgrgid_r,
  getpwnam_r, getpwuid_r, gmtime_r, localtime_r, getlogin_r, and fix mktime
  error checking.
  (Antonin Décimo, review by Florian Angeletti, David Allsopp, Stefan Muenzel,
   Gabriel Scherer, and Miod Vallat)

- 14349, 14718, +14722: runtime, fix in the orphaning of ephemerons
  (Gabriel Scherer, review by Olivier Nicole and Damien Doligez,
   report by Jan Midtgaard)

### Standard library fix

- 14853: fix quoting of filenames passed to Filename.quote_command on Windows.
  (David Allsopp, report by Andrew Nesbitt, review by Florian Angeletti)

### Compiler user-interface fix

- 14702: Fix hidden directory files leaking into the visible load path table.
  When a hidden directory contained a file whose basename was already present,
  the file could be incorrectly added to the visible table.
  (Hugo Heuzard, review by Florian Angeletti)

### Compilerlibs fix

- 14797: avoid dropping attributes attached to package types when pretty
  printing in surface syntax.
  (Chet Murthy, review by Nicolás Ojeda Bär)

### Configuration fix

- 14484: Set `_WIN32_WINNT` to require Windows 8/Server 2012 Windows header SDK
  support.
  (Antonin Décimo, review by David Allsopp)

- 14760, 14802, +14846: Correct the detection of argument defaults in
  configure, fixing an incorrect error message when installing OCaml through
  opam on OpenSUSE with the site-config package installed.
  (David Allsopp, report and review by Edwin Török)

### Documentation fix

- 14684, 14782, 14838: Improve ocamlc's and ocamlopt's manual pages and fix
  small issues in the manual
  (Samuel Hym, review by Florian Angeletti, Antonin Décimo, Gabriel Scherer and
  Nicolás Ojeda Bär)

### Internal fix

- 14435, 14455, +14550: Add the not-root builtin ocamltest action. This
  allows to skip tests that fail if the current user is root (superuser).
  (Kate Deplaix, review by Gabriel Scherer, Nicolás Ojeda Bär, and
   Antonin Décimo)