### PR TITLE
release store.0.2, store-dict.0.1, store-pushqueue.0.1

### DIFF
--- a/packages/store-dict/store-dict.0.1/opam
+++ b/packages/store-dict/store-dict.0.1/opam
@@ -1,0 +1,43 @@
+opam-version: "2.0"
+version: "0.1"
+synopsis: "Snapshottable dictonaries and hashtables"
+maintainer: [
+  "Basile Clément <basile.clement@ocamlpro.com>"
+  "Gabriel Scherer <gabriel.scherer@inria.fr>"
+]
+authors: [
+  "Basile Clément <basile.clement@ocamlpro.com>"
+  "Gabriel Scherer <gabriel.scherer@inria.fr>"
+]
+license: "MIT"
+homepage: "https://gitlab.com/basile.clement/store"
+bug-reports: "https://gitlab.com/basile.clement/store/-/issues"
+depends: [
+  "dune" {>= "3.7"}
+  "ocaml" {>= "4.14"}
+  "store" {>= "0.2"}
+  "monolith" {with-test}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://gitlab.com/basile.clement/store.git"
+url {
+  src: "https://gitlab.com/basile.clement/store/-/archive/v0.2/store-v0.2.tar.bz2"
+  checksum: [
+    "sha512=42d6c7a850a7ac113c5470d6ebe9b5a160a9aa57d009b7eda17a14cda5a54a1dcecd146281322da70579bab08ede70ebe23aa5c48cc3ad3c2c90098424fafbb7"
+  ]
+}
+x-commit-hash: "f9b8b106b67a07763cb9937f0db3ef050490dcaa"

--- a/packages/store-pushqueue/store-pushqueue.0.1/opam
+++ b/packages/store-pushqueue/store-pushqueue.0.1/opam
@@ -1,0 +1,43 @@
+opam-version: "2.0"
+version: "0.1"
+synopsis: "Snapshottable push-only queues"
+maintainer: [
+  "Basile Clément <basile.clement@ocamlpro.com>"
+  "Gabriel Scherer <gabriel.scherer@inria.fr>"
+]
+authors: [
+  "Basile Clément <basile.clement@ocamlpro.com>"
+  "Gabriel Scherer <gabriel.scherer@inria.fr>"
+]
+license: "MIT"
+homepage: "https://gitlab.com/basile.clement/store"
+bug-reports: "https://gitlab.com/basile.clement/store/-/issues"
+depends: [
+  "dune" {>= "3.7"}
+  "ocaml" {>= "5.2"}
+  "store" {>= "0.2"}
+  "monolith" {with-test}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://gitlab.com/basile.clement/store.git"
+url {
+  src: "https://gitlab.com/basile.clement/store/-/archive/v0.2/store-v0.2.tar.bz2"
+  checksum: [
+    "sha512=42d6c7a850a7ac113c5470d6ebe9b5a160a9aa57d009b7eda17a14cda5a54a1dcecd146281322da70579bab08ede70ebe23aa5c48cc3ad3c2c90098424fafbb7"
+  ]
+}
+x-commit-hash: "f9b8b106b67a07763cb9937f0db3ef050490dcaa"

--- a/packages/store/store.0.2/opam
+++ b/packages/store/store.0.2/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+synopsis: "Snapshottable data structures"
+maintainer: [
+  "Basile Clément <basile.clement@ocamlpro.com>"
+  "Gabriel Scherer <gabriel.scherer@inria.fr>"
+]
+authors: [
+  "Basile Clément <basile.clement@ocamlpro.com>"
+  "Gabriel Scherer <gabriel.scherer@inria.fr>"
+]
+license: "MIT"
+homepage: "https://gitlab.com/basile.clement/store"
+dev-repo: "git+https://gitlab.com/basile.clement/store.git"
+bug-reports: "https://gitlab.com/basile.clement/store/-/issues"
+depends: [
+  "dune" {>= "3.7"}
+  "ocaml" {>= "4.14"}
+  "monolith" {with-test}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src: "https://gitlab.com/basile.clement/store/-/archive/v0.2/store-v0.2.tar.bz2"
+  checksum: [
+    "sha512=42d6c7a850a7ac113c5470d6ebe9b5a160a9aa57d009b7eda17a14cda5a54a1dcecd146281322da70579bab08ede70ebe23aa5c48cc3ad3c2c90098424fafbb7"
+  ]
+}
+x-commit-hash: "f9b8b106b67a07763cb9937f0db3ef050490dcaa"


### PR DESCRIPTION
The main news of store 0.2 is the support for user-defined storable types (which can be backtraced upon, snapshotted and restored), as we described on paper:

> Storable types: free, absorbing, custom
> Basile Clément, Camille Noûs, Gabriel Scherer, 2024.
> https://inria.hal.science/hal-04859464

We also added two sub-packages that offer standard/convenient storable types on top of this machinery (and thus depend on store):

- store-dict.0.1 offers a storable hashtable
- store-pushqueue.0.1 offers a storable push-only queue

(store-pushqueue uses Dynarray so it relies on recent-enough OCaml versions, while store and store-dict still support OCaml 4.14.)