### PR TITLE
[new release] notty-miou (4 packages) (0.0.2)

### DIFF
--- a/packages/mnottui/mnottui.0.0.2/opam
+++ b/packages/mnottui/mnottui.0.0.2/opam
@@ -1,0 +1,28 @@
+opam-version: "2.0"
+homepage:     "https://github.com/robur-coop/notty-miou"
+dev-repo:     "git+https://github.com/robur-coop/notty-miou.git"
+bug-reports:  "https://github.com/robur-coop/notty-miou/issues"
+doc:          "https://robur-coop.github.io/notty-miou/doc"
+maintainer:   "Romain Calascibetta <romain.calascibetta@gmail.com>"
+license:      "ISC"
+synopsis:     "Declaring terminals with Miou"
+
+build: [ [ "dune" "subst" ] {dev}
+         [ "dune" "build" "-p" name "-j" jobs ] ]
+depends: [
+  "ocaml" {>= "5.1.0"}
+  "dune" {>= "1.7"}
+  "notty-community" {>= "0.2.3"}
+  "mkernel"
+  "mnotty"
+]
+authors: "Romain Calascibetta <romain.calascibetta@gmail.com>"
+url {
+  src:
+    "https://github.com/robur-coop/notty-miou/releases/download/v0.0.2/notty-miou-0.0.2.tbz"
+  checksum: [
+    "sha256=9a3463ea08b15da19bb5b65887baa17a093c33d0948b41fb3f47da1ff02e7d30"
+    "sha512=222cc5ed72d2a82fbc3b033c18dd170e4332d5600ed17a324eaf3ab4380eb8bd1b8167fe2602927b4625c68ffec55c923344ee9e864d2ef5018b67a5796e02a4"
+  ]
+}
+x-commit-hash: "4124bb4450861b6c19e25fc0877beb3f6304bd72"

--- a/packages/mnottui/mnottui.0.0.2/opam
+++ b/packages/mnottui/mnottui.0.0.2/opam
@@ -15,6 +15,7 @@ depends: [
   "notty-community" {>= "0.2.3"}
   "mkernel"
   "mnotty"
+  "nottui"
 ]
 authors: "Romain Calascibetta <romain.calascibetta@gmail.com>"
 url {

--- a/packages/mnottui/mnottui.0.0.2/opam
+++ b/packages/mnottui/mnottui.0.0.2/opam
@@ -15,7 +15,7 @@ depends: [
   "notty-community" {>= "0.2.3"}
   "mkernel"
   "mnotty"
-  "nottui"
+  "nottui" {>= "0.5"}
 ]
 authors: "Romain Calascibetta <romain.calascibetta@gmail.com>"
 url {

--- a/packages/mnotty/mnotty.0.0.2/opam
+++ b/packages/mnotty/mnotty.0.0.2/opam
@@ -1,0 +1,28 @@
+opam-version: "2.0"
+homepage:     "https://github.com/robur-coop/notty-miou"
+dev-repo:     "git+https://github.com/robur-coop/notty-miou.git"
+bug-reports:  "https://github.com/robur-coop/notty-miou/issues"
+doc:          "https://robur-coop.github.io/notty-miou/doc"
+maintainer:   "Romain Calascibetta <romain.calascibetta@gmail.com>"
+license:      "ISC"
+synopsis:     "Declaring terminals with Miou"
+
+build: [ [ "dune" "subst" ] {dev}
+         [ "dune" "build" "-p" name "-j" jobs ] ]
+depends: [
+  "ocaml" {>= "5.1.0"}
+  "dune" {>= "1.7"}
+  "notty-community" {>= "0.2.3"}
+  "flux"
+  "mkernel"
+]
+authors: "Romain Calascibetta <romain.calascibetta@gmail.com>"
+url {
+  src:
+    "https://github.com/robur-coop/notty-miou/releases/download/v0.0.2/notty-miou-0.0.2.tbz"
+  checksum: [
+    "sha256=9a3463ea08b15da19bb5b65887baa17a093c33d0948b41fb3f47da1ff02e7d30"
+    "sha512=222cc5ed72d2a82fbc3b033c18dd170e4332d5600ed17a324eaf3ab4380eb8bd1b8167fe2602927b4625c68ffec55c923344ee9e864d2ef5018b67a5796e02a4"
+  ]
+}
+x-commit-hash: "4124bb4450861b6c19e25fc0877beb3f6304bd72"

--- a/packages/nottui-miou/nottui-miou.0.0.2/opam
+++ b/packages/nottui-miou/nottui-miou.0.0.2/opam
@@ -1,0 +1,33 @@
+opam-version: "2.0"
+synopsis: "Run Nottui UIs in Miou"
+maintainer: ["romain.calascibetta@gmail.com"]
+authors: ["Romain Calascibetta"]
+license: "MIT"
+homepage: "https://github.com/robur-coop/notty-miou"
+bug-reports: "https://github.com/robur-coop/notty-miou/issues"
+dev-repo: "git+https://github.com/robur-coop/notty-miou.git"
+depends: [
+  "ocaml"
+  "dune" {>= "3.5"}
+  "miou"
+  "nottui" {>= "0.5"}
+  "notty-community" {>= "0.2"}
+  "notty-miou" {= version}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [ "dune" "build" "-p" name "-j" jobs "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src:
+    "https://github.com/robur-coop/notty-miou/releases/download/v0.0.2/notty-miou-0.0.2.tbz"
+  checksum: [
+    "sha256=9a3463ea08b15da19bb5b65887baa17a093c33d0948b41fb3f47da1ff02e7d30"
+    "sha512=222cc5ed72d2a82fbc3b033c18dd170e4332d5600ed17a324eaf3ab4380eb8bd1b8167fe2602927b4625c68ffec55c923344ee9e864d2ef5018b67a5796e02a4"
+  ]
+}
+x-commit-hash: "4124bb4450861b6c19e25fc0877beb3f6304bd72"

--- a/packages/notty-miou/notty-miou.0.0.2/opam
+++ b/packages/notty-miou/notty-miou.0.0.2/opam
@@ -1,0 +1,27 @@
+opam-version: "2.0"
+homepage:     "https://github.com/robur-coop/notty-miou"
+dev-repo:     "git+https://github.com/robur-coop/notty-miou.git"
+bug-reports:  "https://github.com/robur-coop/notty-miou/issues"
+doc:          "https://robur-coop.github.io/notty-miou/doc"
+maintainer:   "Romain Calascibetta <romain.calascibetta@gmail.com>"
+license:      "ISC"
+synopsis:     "Declaring terminals with Miou"
+
+build: [ [ "dune" "subst" ] {dev}
+         [ "dune" "build" "-p" name "-j" jobs ] ]
+depends: [
+  "ocaml" {>= "5.1.0"}
+  "dune" {>= "1.7"}
+  "notty-community" {>= "0.2.3"}
+  "miou"
+]
+authors: "Romain Calascibetta <romain.calascibetta@gmail.com>"
+url {
+  src:
+    "https://github.com/robur-coop/notty-miou/releases/download/v0.0.2/notty-miou-0.0.2.tbz"
+  checksum: [
+    "sha256=9a3463ea08b15da19bb5b65887baa17a093c33d0948b41fb3f47da1ff02e7d30"
+    "sha512=222cc5ed72d2a82fbc3b033c18dd170e4332d5600ed17a324eaf3ab4380eb8bd1b8167fe2602927b4625c68ffec55c923344ee9e864d2ef5018b67a5796e02a4"
+  ]
+}
+x-commit-hash: "4124bb4450861b6c19e25fc0877beb3f6304bd72"


### PR DESCRIPTION
Declaring terminals with Miou

- Project page: <a href="https://github.com/robur-coop/notty-miou">https://github.com/robur-coop/notty-miou</a>
- Documentation: <a href="https://robur-coop.github.io/notty-miou/doc">https://robur-coop.github.io/notty-miou/doc</a>

##### CHANGES:

- Add the support for `mkernel`/`mnet` (@dinosaure, robur-coop/notty-miou#3)
