### PR TITLE
Tweak conf- packages to aid the 0install solver on Windows

### DIFF
--- a/packages/conf-ao/conf-ao.1/opam
+++ b/packages/conf-ao/conf-ao.1/opam
@@ -5,14 +5,10 @@ bug-reports: "https://github.com/ocaml/opam-repository/issues"
 authors: "libao dev team"
 license: "GPL-2.0-only"
 build: [
-  ["pkgconf" {os = "win32" & os-distribution != "cygwinports"}
-     "--personality=i686-w64-mingw32" {os = "win32" & os-distribution != "cygwinports" & host-arch-x86_32:installed}
-     "--personality=x86_64-w64-mingw32" {os = "win32" & os-distribution != "cygwinports" & host-arch-x86_64:installed}
-   "pkg-config" {os != "win32" | os-distribution = "cygwinports"}
-   "--print-errors" "--exists" "ao"]
+  [conf-pkg-config:command "--print-errors" "--exists" "ao"]
 ]
 depends: [
-  "conf-pkg-config" {build}
+  "conf-pkg-config" {>= "5"}
   ("host-arch-x86_64" {os = "win32" & os-distribution != "cygwinports"} & "conf-mingw-w64-ao-x86_64" {os = "win32" & os-distribution != "cygwinports"} |
    "host-arch-x86_32" {os = "win32" & os-distribution != "cygwinports"} & "conf-mingw-w64-ao-i686" {os = "win32" & os-distribution != "cygwinports"})
 ]

--- a/packages/conf-ao/conf-ao.1/opam
+++ b/packages/conf-ao/conf-ao.1/opam
@@ -13,8 +13,8 @@ build: [
 ]
 depends: [
   "conf-pkg-config" {build}
-  ("host-arch-x86_32" {os = "win32" & os-distribution != "cygwinports"} & "conf-mingw-w64-ao-i686" {os = "win32" & os-distribution != "cygwinports"} |
-   "host-arch-x86_64" {os = "win32" & os-distribution != "cygwinports"} & "conf-mingw-w64-ao-x86_64" {os = "win32" & os-distribution != "cygwinports"})
+  ("host-arch-x86_64" {os = "win32" & os-distribution != "cygwinports"} & "conf-mingw-w64-ao-x86_64" {os = "win32" & os-distribution != "cygwinports"} |
+   "host-arch-x86_32" {os = "win32" & os-distribution != "cygwinports"} & "conf-mingw-w64-ao-i686" {os = "win32" & os-distribution != "cygwinports"})
 ]
 depexts: [
   ["libao-devel"] {os-distribution = "centos" | os-family = "fedora" | os-family = "suse" | os-family = "opensuse"}

--- a/packages/conf-ao/conf-ao.1/opam
+++ b/packages/conf-ao/conf-ao.1/opam
@@ -5,10 +5,17 @@ bug-reports: "https://github.com/ocaml/opam-repository/issues"
 authors: "libao dev team"
 license: "GPL-2.0-only"
 build: [
-  [conf-pkg-config:command "--print-errors" "--exists" "ao"]
+  # When the version is next bumped, this package can depend on
+  # conf-pkg-config.5 and instead use:
+  # [conf-pkg-config:command "--print-errors" "--exists" "ao"]
+  ["pkgconf" {os = "win32" & os-distribution != "cygwinports"}
+     "--personality=i686-w64-mingw32" {os = "win32" & os-distribution != "cygwinports" & host-arch-x86_32:installed}
+     "--personality=x86_64-w64-mingw32" {os = "win32" & os-distribution != "cygwinports" & host-arch-x86_64:installed}
+   "pkg-config" {os != "win32" | os-distribution = "cygwinports"}
+   "--print-errors" "--exists" "ao"]
 ]
 depends: [
-  "conf-pkg-config" {>= "5"}
+  "conf-pkg-config" {build}
   ("host-arch-x86_64" {os = "win32" & os-distribution != "cygwinports"} & "conf-mingw-w64-ao-x86_64" {os = "win32" & os-distribution != "cygwinports"} |
    "host-arch-x86_32" {os = "win32" & os-distribution != "cygwinports"} & "conf-mingw-w64-ao-i686" {os = "win32" & os-distribution != "cygwinports"})
 ]

--- a/packages/conf-bzip2/conf-bzip2.1/opam
+++ b/packages/conf-bzip2/conf-bzip2.1/opam
@@ -6,7 +6,12 @@ authors:      ["Julian Seward"]
 license:      "bzip2-1.0.6"
 
 build: [
-  "pkgconf" {os-distribution = "netbsd"} conf-pkg-config:command {os-distribution != "netbsd"} "bzip2"
+  # When the version is next bumped, this package can depend on
+  # conf-pkg-config.5 and instead use:
+  # "pkgconf" {os-distribution = "netbsd"} conf-pkg-config:command {os-distribution != "netbsd"} "bzip2"
+  "pkgconf" { (os = "win32" & os-distribution != "cygwinports") | os-distribution = "netbsd" }
+  "pkg-config" { !((os = "win32" & os-distribution != "cygwinports") | os-distribution = "netbsd") }
+    "bzip2"
 ] {os-distribution != "freebsd"
      # https://cgit.freebsd.org/ports/tree/archivers/bzip2/pkg-plist
      # missing libdata/pkgconfig/bzip2.pc
@@ -21,7 +26,7 @@ build: [
      # no bzip2.pc file in cygwin package
 
 depends: [
-  "conf-pkg-config" {>= "5"}
+  "conf-pkg-config"	    {build}
   (("host-arch-x86_64" {os = "win32" & os-distribution != "cygwinports"} & "conf-mingw-w64-bzip2-x86_64" {os = "win32" & os-distribution != "cygwinports"}) |
    ("host-arch-x86_32" {os = "win32" & os-distribution != "cygwinports"} & "conf-mingw-w64-bzip2-i686" {os = "win32" & os-distribution != "cygwinports"}))
 ]

--- a/packages/conf-bzip2/conf-bzip2.1/opam
+++ b/packages/conf-bzip2/conf-bzip2.1/opam
@@ -24,8 +24,8 @@ build: [
 
 depends: [
   "conf-pkg-config"	    {build}
-  (("host-arch-x86_32" {os = "win32" & os-distribution != "cygwinports"} & "conf-mingw-w64-bzip2-i686" {os = "win32" & os-distribution != "cygwinports"}) |
-   ("host-arch-x86_64" {os = "win32" & os-distribution != "cygwinports"} & "conf-mingw-w64-bzip2-x86_64" {os = "win32" & os-distribution != "cygwinports"}))
+  (("host-arch-x86_64" {os = "win32" & os-distribution != "cygwinports"} & "conf-mingw-w64-bzip2-x86_64" {os = "win32" & os-distribution != "cygwinports"}) |
+   ("host-arch-x86_32" {os = "win32" & os-distribution != "cygwinports"} & "conf-mingw-w64-bzip2-i686" {os = "win32" & os-distribution != "cygwinports"}))
 ]
 
 depexts: [

--- a/packages/conf-bzip2/conf-bzip2.1/opam
+++ b/packages/conf-bzip2/conf-bzip2.1/opam
@@ -6,9 +6,7 @@ authors:      ["Julian Seward"]
 license:      "bzip2-1.0.6"
 
 build: [
-  "pkgconf" { (os = "win32" & os-distribution != "cygwinports") | os-distribution = "netbsd" }
-  "pkg-config" { !((os = "win32" & os-distribution != "cygwinports") | os-distribution = "netbsd") }
-    "bzip2"
+  "pkgconf" {os-distribution = "netbsd"} conf-pkg-config:command {os-distribution != "netbsd"} "bzip2"
 ] {os-distribution != "freebsd"
      # https://cgit.freebsd.org/ports/tree/archivers/bzip2/pkg-plist
      # missing libdata/pkgconfig/bzip2.pc
@@ -23,7 +21,7 @@ build: [
      # no bzip2.pc file in cygwin package
 
 depends: [
-  "conf-pkg-config"	    {build}
+  "conf-pkg-config" {>= "5"}
   (("host-arch-x86_64" {os = "win32" & os-distribution != "cygwinports"} & "conf-mingw-w64-bzip2-x86_64" {os = "win32" & os-distribution != "cygwinports"}) |
    ("host-arch-x86_32" {os = "win32" & os-distribution != "cygwinports"} & "conf-mingw-w64-bzip2-i686" {os = "win32" & os-distribution != "cygwinports"}))
 ]

--- a/packages/conf-c++/conf-c++.1.0/opam
+++ b/packages/conf-c++/conf-c++.1.0/opam
@@ -22,8 +22,8 @@ depexts: [
   ["gcc-g++"] {os = "win32" & os-distribution = "cygwinports"}
 ]
 depends:
-  (("host-arch-x86_32" {os = "win32" & os-distribution != "cygwinports"} & "conf-mingw-w64-g++-i686" {os = "win32" & os-distribution != "cygwinports"}) |
-   ("host-arch-x86_64" {os = "win32" & os-distribution != "cygwinports"} & "conf-mingw-w64-g++-x86_64" {os = "win32" & os-distribution != "cygwinports"}))
+  (("host-arch-x86_64" {os = "win32" & os-distribution != "cygwinports"} & "conf-mingw-w64-g++-x86_64" {os = "win32" & os-distribution != "cygwinports"}) |
+   ("host-arch-x86_32" {os = "win32" & os-distribution != "cygwinports"} & "conf-mingw-w64-g++-i686" {os = "win32" & os-distribution != "cygwinports"}))
 synopsis: "Virtual package relying on the c++ compiler"
 description:
   "This package can only install if the c++ compiler is installed on the system."

--- a/packages/conf-cairo/conf-cairo.1/opam
+++ b/packages/conf-cairo/conf-cairo.1/opam
@@ -4,15 +4,13 @@ homepage: "http://cairographics.org/"
 authors: ["Keith Packard" "Carl Worth" "Behdad Esfahbod"]
 license: ["LGPL-2.1-only" "MPL-1.1"]
 build: [
-  ["pkgconf" "--personality=i686-w64-mingw32" "cairo"] {os = "win32" & os-distribution != "cygwinports" & host-arch-x86_32:installed}
-  ["pkgconf" "--personality=x86_64-w64-mingw32" "cairo"] {os = "win32" & os-distribution != "cygwinports" & host-arch-x86_64:installed}
-  ["pkg-config" "cairo"] {os != "macos" & os != "win32"}
+  [conf-pkg-config:command "cairo"] {os != "macos"}
   ["sh" "-exc"
    "export PKG_CONFIG_PATH=/usr/local/lib/pkgconfig/; pkg-config --libs cairo"]
    {os = "macos" & os-distribution = "homebrew"}
 ]
 depends: [
-  "conf-pkg-config" {>= "3" & build}
+  "conf-pkg-config" {>= "5"}
   ("host-arch-x86_64" {os = "win32" & os-distribution != "cygwinports"} & "conf-mingw-w64-cairo-x86_64" {os = "win32" & os-distribution != "cygwinports"} |
    "host-arch-x86_32" {os = "win32" & os-distribution != "cygwinports"} & "conf-mingw-w64-cairo-i686" {os = "win32" & os-distribution != "cygwinports"})
 ]

--- a/packages/conf-cairo/conf-cairo.1/opam
+++ b/packages/conf-cairo/conf-cairo.1/opam
@@ -4,13 +4,18 @@ homepage: "http://cairographics.org/"
 authors: ["Keith Packard" "Carl Worth" "Behdad Esfahbod"]
 license: ["LGPL-2.1-only" "MPL-1.1"]
 build: [
-  [conf-pkg-config:command "cairo"] {os != "macos"}
+  # When the version is next bumped, this package can depend on
+  # conf-pkg-config.5 and instead use:
+  # [conf-pkg-config:command "cairo"] {os != "macos"}
+  ["pkgconf" "--personality=i686-w64-mingw32" "cairo"] {os = "win32" & os-distribution != "cygwinports" & host-arch-x86_32:installed}
+  ["pkgconf" "--personality=x86_64-w64-mingw32" "cairo"] {os = "win32" & os-distribution != "cygwinports" & host-arch-x86_64:installed}
+  ["pkg-config" "cairo"] {os != "macos" & os != "win32"}
   ["sh" "-exc"
    "export PKG_CONFIG_PATH=/usr/local/lib/pkgconfig/; pkg-config --libs cairo"]
    {os = "macos" & os-distribution = "homebrew"}
 ]
 depends: [
-  "conf-pkg-config" {>= "5"}
+  "conf-pkg-config" {>= "3" & build}
   ("host-arch-x86_64" {os = "win32" & os-distribution != "cygwinports"} & "conf-mingw-w64-cairo-x86_64" {os = "win32" & os-distribution != "cygwinports"} |
    "host-arch-x86_32" {os = "win32" & os-distribution != "cygwinports"} & "conf-mingw-w64-cairo-i686" {os = "win32" & os-distribution != "cygwinports"})
 ]

--- a/packages/conf-cairo/conf-cairo.1/opam
+++ b/packages/conf-cairo/conf-cairo.1/opam
@@ -13,8 +13,8 @@ build: [
 ]
 depends: [
   "conf-pkg-config" {>= "3" & build}
-  ("host-arch-x86_32" {os = "win32" & os-distribution != "cygwinports"} & "conf-mingw-w64-cairo-i686" {os = "win32" & os-distribution != "cygwinports"} |
-   "host-arch-x86_64" {os = "win32" & os-distribution != "cygwinports"} & "conf-mingw-w64-cairo-x86_64" {os = "win32" & os-distribution != "cygwinports"})
+  ("host-arch-x86_64" {os = "win32" & os-distribution != "cygwinports"} & "conf-mingw-w64-cairo-x86_64" {os = "win32" & os-distribution != "cygwinports"} |
+   "host-arch-x86_32" {os = "win32" & os-distribution != "cygwinports"} & "conf-mingw-w64-cairo-i686" {os = "win32" & os-distribution != "cygwinports"})
 ]
 depexts: [
   ["libcairo2-dev"] {os-family = "debian"}

--- a/packages/conf-freeglut/conf-freeglut.1/opam
+++ b/packages/conf-freeglut/conf-freeglut.1/opam
@@ -5,11 +5,14 @@ homepage: "https://freeglut.sourceforge.net/"
 license: "X11"
 bug-reports: "https://github.com/ocaml/opam-repository/issues"
 build: [
-  [conf-pkg-config:command "--print-errors" "--exists" "freeglut" {os = "win32"} "glut" {os != "win32"}]
-    {(os != "win32" | os-distribution = "msys2") & os-distribution != "debian" & os-distribution != "ubuntu" & !(os-distribution = "ol" & os-version < "9")}
+  # When the version is next bumped, this package can depend on
+  # conf-pkg-config.5 and instead use:
+  # [conf-pkg-config:command "--print-errors" "--exists" "freeglut" {os = "win32"} "glut" {os != "win32"}]
+  ["pkg-config" "--print-errors" "--exists" "freeglut"] {os = "win32" & os-distribution = "msys2"}
+  ["pkg-config" "--print-errors" "--exists" "glut"] {os != "win32" & os-distribution != "debian" & os-distribution != "ubuntu" & !(os-distribution = "ol" & os-version < "9")}
 ]
 depends: [
-  "conf-pkg-config" {>= "5" & os-distribution != "debian" & os-distribution != "ubuntu" & !(os-distribution = "ol" & os-version < "9")}
+  "conf-pkg-config" {build & os-distribution != "debian" & os-distribution != "ubuntu" & !(os-distribution = "ol" & os-version < "9")}
   ("host-arch-x86_64" {os = "win32" & os-distribution != "cygwinports"} &
    "conf-mingw-w64-freeglut-x86_64" {os = "win32" & os-distribution != "cygwinports"} |
    "host-arch-x86_32" {os = "win32" & os-distribution != "cygwinports"} &

--- a/packages/conf-freeglut/conf-freeglut.1/opam
+++ b/packages/conf-freeglut/conf-freeglut.1/opam
@@ -5,11 +5,11 @@ homepage: "https://freeglut.sourceforge.net/"
 license: "X11"
 bug-reports: "https://github.com/ocaml/opam-repository/issues"
 build: [
-  ["pkg-config" "--print-errors" "--exists" "freeglut"] {os = "win32" & os-distribution = "msys2"}
-  ["pkg-config" "--print-errors" "--exists" "glut"] {os != "win32" & os-distribution != "debian" & os-distribution != "ubuntu" & !(os-distribution = "ol" & os-version < "9")}
+  [conf-pkg-config:command "--print-errors" "--exists" "freeglut" {os = "win32"} "glut" {os != "win32"}]
+    {(os != "win32" | os-distribution = "msys2") & os-distribution != "debian" & os-distribution != "ubuntu" & !(os-distribution = "ol" & os-version < "9")}
 ]
 depends: [
-  "conf-pkg-config" {build & os-distribution != "debian" & os-distribution != "ubuntu" & !(os-distribution = "ol" & os-version < "9")}
+  "conf-pkg-config" {>= "5" & os-distribution != "debian" & os-distribution != "ubuntu" & !(os-distribution = "ol" & os-version < "9")}
   ("host-arch-x86_64" {os = "win32" & os-distribution != "cygwinports"} &
    "conf-mingw-w64-freeglut-x86_64" {os = "win32" & os-distribution != "cygwinports"} |
    "host-arch-x86_32" {os = "win32" & os-distribution != "cygwinports"} &

--- a/packages/conf-freeglut/conf-freeglut.1/opam
+++ b/packages/conf-freeglut/conf-freeglut.1/opam
@@ -10,10 +10,10 @@ build: [
 ]
 depends: [
   "conf-pkg-config" {build & os-distribution != "debian" & os-distribution != "ubuntu" & !(os-distribution = "ol" & os-version < "9")}
-  ("host-arch-x86_32" {os = "win32" & os-distribution != "cygwinports"} &
-   "conf-mingw-w64-freeglut-i686" {os = "win32" & os-distribution != "cygwinports"} |
-   "host-arch-x86_64" {os = "win32" & os-distribution != "cygwinports"} &
-   "conf-mingw-w64-freeglut-x86_64" {os = "win32" & os-distribution != "cygwinports"})
+  ("host-arch-x86_64" {os = "win32" & os-distribution != "cygwinports"} &
+   "conf-mingw-w64-freeglut-x86_64" {os = "win32" & os-distribution != "cygwinports"} |
+   "host-arch-x86_32" {os = "win32" & os-distribution != "cygwinports"} &
+   "conf-mingw-w64-freeglut-i686" {os = "win32" & os-distribution != "cygwinports"})
 ]
 depexts: [
   ["freeglut3-dev"] {os-family = "debian" | os-family = "ubuntu"}

--- a/packages/conf-freetype/conf-freetype.1/opam
+++ b/packages/conf-freetype/conf-freetype.1/opam
@@ -11,8 +11,8 @@ build: [
 ]
 depends: [
   "conf-pkg-config" {build}
-  ("host-arch-x86_32" {os = "win32" & os-distribution != "cygwinports"} & "conf-mingw-w64-freetype-i686" {os = "win32" & os-distribution != "cygwinports"} |
-   "host-arch-x86_64" {os = "win32" & os-distribution != "cygwinports"} & "conf-mingw-w64-freetype-x86_64" {os = "win32" & os-distribution != "cygwinports"})
+  ("host-arch-x86_64" {os = "win32" & os-distribution != "cygwinports"} & "conf-mingw-w64-freetype-x86_64" {os = "win32" & os-distribution != "cygwinports"} |
+   "host-arch-x86_32" {os = "win32" & os-distribution != "cygwinports"} & "conf-mingw-w64-freetype-i686" {os = "win32" & os-distribution != "cygwinports"})
 ]
 depexts: [
   ["libfreetype6-dev"] {os-family = "debian" | os-family = "ubuntu"}

--- a/packages/conf-freetype/conf-freetype.1/opam
+++ b/packages/conf-freetype/conf-freetype.1/opam
@@ -5,10 +5,15 @@ homepage: "http://www.freetype.org"
 bug-reports: "https://github.com/ocaml/opam-repository/issues"
 license: "GPL-1.0-or-later"
 build: [
-  [conf-pkg-config:command "freetype2"]
+  # When the version is next bumped, this package can depend on
+  # conf-pkg-config.5 and instead use:
+  # [conf-pkg-config:command "freetype2"]
+  ["pkgconf" "--personality=i686-w64-mingw32" "freetype2"] {os = "win32" & os-distribution != "cygwinports" & host-arch-x86_32:installed}
+  ["pkgconf" "--personality=x86_64-w64-mingw32" "freetype2"] {os = "win32" & os-distribution != "cygwinports" & host-arch-x86_64:installed}
+  ["pkg-config" "freetype2"] {os != "win32" | os-distribution = "cygwinports"}
 ]
 depends: [
-  "conf-pkg-config" {>= "5"}
+  "conf-pkg-config" {build}
   ("host-arch-x86_64" {os = "win32" & os-distribution != "cygwinports"} & "conf-mingw-w64-freetype-x86_64" {os = "win32" & os-distribution != "cygwinports"} |
    "host-arch-x86_32" {os = "win32" & os-distribution != "cygwinports"} & "conf-mingw-w64-freetype-i686" {os = "win32" & os-distribution != "cygwinports"})
 ]

--- a/packages/conf-freetype/conf-freetype.1/opam
+++ b/packages/conf-freetype/conf-freetype.1/opam
@@ -5,12 +5,10 @@ homepage: "http://www.freetype.org"
 bug-reports: "https://github.com/ocaml/opam-repository/issues"
 license: "GPL-1.0-or-later"
 build: [
-  ["pkgconf" "--personality=i686-w64-mingw32" "freetype2"] {os = "win32" & os-distribution != "cygwinports" & host-arch-x86_32:installed}
-  ["pkgconf" "--personality=x86_64-w64-mingw32" "freetype2"] {os = "win32" & os-distribution != "cygwinports" & host-arch-x86_64:installed}
-  ["pkg-config" "freetype2"] {os != "win32" | os-distribution = "cygwinports"}
+  [conf-pkg-config:command "freetype2"]
 ]
 depends: [
-  "conf-pkg-config" {build}
+  "conf-pkg-config" {>= "5"}
   ("host-arch-x86_64" {os = "win32" & os-distribution != "cygwinports"} & "conf-mingw-w64-freetype-x86_64" {os = "win32" & os-distribution != "cygwinports"} |
    "host-arch-x86_32" {os = "win32" & os-distribution != "cygwinports"} & "conf-mingw-w64-freetype-i686" {os = "win32" & os-distribution != "cygwinports"})
 ]

--- a/packages/conf-glade/conf-glade.2/opam
+++ b/packages/conf-glade/conf-glade.2/opam
@@ -36,11 +36,11 @@ description:
   "This package can only install if libglade2-dev is installed on the system."
 depends: [
   "conf-pkg-config" {build}
-  ("host-arch-x86_32" {os = "win32" & os-distribution != "cygwinports"} &
-   "conf-mingw-w64-glade-i686"
-     {os = "win32" & os-distribution != "cygwinports"} |
-   "host-arch-x86_64" {os = "win32" & os-distribution != "cygwinports"} &
+  ("host-arch-x86_64" {os = "win32" & os-distribution != "cygwinports"} &
    "conf-mingw-w64-glade-x86_64"
+     {os = "win32" & os-distribution != "cygwinports"} |
+   "host-arch-x86_32" {os = "win32" & os-distribution != "cygwinports"} &
+   "conf-mingw-w64-glade-i686"
      {os = "win32" & os-distribution != "cygwinports"})
 ]
 flags: conf

--- a/packages/conf-glade/conf-glade.2/opam
+++ b/packages/conf-glade/conf-glade.2/opam
@@ -5,15 +5,7 @@ homepage: "https://glade.gnome.org/"
 bug-reports: "https://github.com/ocaml/opam-repository/issues"
 license: "LGPL-2.1-or-later"
 build: [
-  "pkgconf" {os = "win32" & os-distribution != "cygwinports"}
-  "--personality=i686-w64-mingw32"
-    {os = "win32" & os-distribution != "cygwinports" &
-     host-arch-x86_32:installed}
-  "--personality=x86_64-w64-mingw32"
-    {os = "win32" & os-distribution != "cygwinports" &
-     host-arch-x86_64:installed}
-  "pkg-config" {os != "win32" | os-distribution = "cygwinports"}
-  "libglade-2.0"
+  [conf-pkg-config:command "libglade-2.0"]
 ]
 depexts: [
   ["libglade2-dev"] {os-family = "debian" | os-family = "ubuntu"}
@@ -35,7 +27,7 @@ synopsis: "Virtual package relying on a libglade system installation"
 description:
   "This package can only install if libglade2-dev is installed on the system."
 depends: [
-  "conf-pkg-config" {build}
+  "conf-pkg-config" {>= "5"}
   ("host-arch-x86_64" {os = "win32" & os-distribution != "cygwinports"} &
    "conf-mingw-w64-glade-x86_64"
      {os = "win32" & os-distribution != "cygwinports"} |

--- a/packages/conf-glade/conf-glade.2/opam
+++ b/packages/conf-glade/conf-glade.2/opam
@@ -5,7 +5,18 @@ homepage: "https://glade.gnome.org/"
 bug-reports: "https://github.com/ocaml/opam-repository/issues"
 license: "LGPL-2.1-or-later"
 build: [
-  [conf-pkg-config:command "libglade-2.0"]
+  # When the version is next bumped, this package can depend on
+  # conf-pkg-config.5 and instead use:
+  # [conf-pkg-config:command "libglade-2.0"]
+  "pkgconf" {os = "win32" & os-distribution != "cygwinports"}
+  "--personality=i686-w64-mingw32"
+    {os = "win32" & os-distribution != "cygwinports" &
+     host-arch-x86_32:installed}
+  "--personality=x86_64-w64-mingw32"
+    {os = "win32" & os-distribution != "cygwinports" &
+     host-arch-x86_64:installed}
+  "pkg-config" {os != "win32" | os-distribution = "cygwinports"}
+  "libglade-2.0"
 ]
 depexts: [
   ["libglade2-dev"] {os-family = "debian" | os-family = "ubuntu"}
@@ -27,7 +38,7 @@ synopsis: "Virtual package relying on a libglade system installation"
 description:
   "This package can only install if libglade2-dev is installed on the system."
 depends: [
-  "conf-pkg-config" {>= "5"}
+  "conf-pkg-config" {build}
   ("host-arch-x86_64" {os = "win32" & os-distribution != "cygwinports"} &
    "conf-mingw-w64-glade-x86_64"
      {os = "win32" & os-distribution != "cygwinports"} |

--- a/packages/conf-gnomecanvas/conf-gnomecanvas.2/opam
+++ b/packages/conf-gnomecanvas/conf-gnomecanvas.2/opam
@@ -4,7 +4,14 @@ homepage: "https://developer.gnome.org/libgnomecanvas/2.30/"
 authors: "The GNOME Project"
 license: "LGPL-2.1-or-later"
 build: [
-  [conf-pkg-config:command "libgnomecanvas-2.0"]
+  # When the version is next bumped, this package can depend on
+  # conf-pkg-config.5 and instead use:
+  # [conf-pkg-config:command "libgnomecanvas-2.0"]
+  ["pkgconf" {os = "win32" & os-distribution != "cygwinports"}
+   "--personality=i686-w64-mingw32" {os = "win32" & os-distribution != "cygwinports" & host-arch-x86_32:installed}
+   "--personality=x86_64-w64-mingw32" {os = "win32" & os-distribution != "cygwinports" & host-arch-x86_64:installed}
+   "pkg-config" {os != "win32" | os-distribution = "cygwinports"}
+   "libgnomecanvas-2.0"]
 ]
 depexts: [
   ["libgnomecanvas2-dev"] {os-family = "debian"}
@@ -31,7 +38,7 @@ description: """
 This package can only install if libgnomecanvas2-dev is installed
 on the system."""
 depends: [
-  "conf-pkg-config" {>= "5"}
+  "conf-pkg-config" {build}
   ("host-arch-x86_64" {os = "win32" & os-distribution != "cygwinports"} & "conf-mingw-w64-gnomecanvas-x86_64" {os = "win32" & os-distribution != "cygwinports"} |
    "host-arch-x86_32" {os = "win32" & os-distribution != "cygwinports"} & "conf-mingw-w64-gnomecanvas-i686" {os = "win32" & os-distribution != "cygwinports"})
 ]

--- a/packages/conf-gnomecanvas/conf-gnomecanvas.2/opam
+++ b/packages/conf-gnomecanvas/conf-gnomecanvas.2/opam
@@ -4,11 +4,7 @@ homepage: "https://developer.gnome.org/libgnomecanvas/2.30/"
 authors: "The GNOME Project"
 license: "LGPL-2.1-or-later"
 build: [
-  ["pkgconf" {os = "win32" & os-distribution != "cygwinports"}
-   "--personality=i686-w64-mingw32" {os = "win32" & os-distribution != "cygwinports" & host-arch-x86_32:installed}
-   "--personality=x86_64-w64-mingw32" {os = "win32" & os-distribution != "cygwinports" & host-arch-x86_64:installed}
-   "pkg-config" {os != "win32" | os-distribution = "cygwinports"}
-   "libgnomecanvas-2.0"]
+  [conf-pkg-config:command "libgnomecanvas-2.0"]
 ]
 depexts: [
   ["libgnomecanvas2-dev"] {os-family = "debian"}
@@ -35,7 +31,7 @@ description: """
 This package can only install if libgnomecanvas2-dev is installed
 on the system."""
 depends: [
-  "conf-pkg-config" {build}
+  "conf-pkg-config" {>= "5"}
   ("host-arch-x86_64" {os = "win32" & os-distribution != "cygwinports"} & "conf-mingw-w64-gnomecanvas-x86_64" {os = "win32" & os-distribution != "cygwinports"} |
    "host-arch-x86_32" {os = "win32" & os-distribution != "cygwinports"} & "conf-mingw-w64-gnomecanvas-i686" {os = "win32" & os-distribution != "cygwinports"})
 ]

--- a/packages/conf-gnomecanvas/conf-gnomecanvas.2/opam
+++ b/packages/conf-gnomecanvas/conf-gnomecanvas.2/opam
@@ -36,8 +36,8 @@ This package can only install if libgnomecanvas2-dev is installed
 on the system."""
 depends: [
   "conf-pkg-config" {build}
-  ("host-arch-x86_32" {os = "win32" & os-distribution != "cygwinports"} & "conf-mingw-w64-gnomecanvas-i686" {os = "win32" & os-distribution != "cygwinports"} |
-   "host-arch-x86_64" {os = "win32" & os-distribution != "cygwinports"} & "conf-mingw-w64-gnomecanvas-x86_64" {os = "win32" & os-distribution != "cygwinports"})
+  ("host-arch-x86_64" {os = "win32" & os-distribution != "cygwinports"} & "conf-mingw-w64-gnomecanvas-x86_64" {os = "win32" & os-distribution != "cygwinports"} |
+   "host-arch-x86_32" {os = "win32" & os-distribution != "cygwinports"} & "conf-mingw-w64-gnomecanvas-i686" {os = "win32" & os-distribution != "cygwinports"})
 ]
 bug-reports: "https://github.com/ocaml/opam-repository/issues"
 flags: conf

--- a/packages/conf-gnutls/conf-gnutls.1/opam
+++ b/packages/conf-gnutls/conf-gnutls.1/opam
@@ -4,10 +4,21 @@ homepage: "https://www.gnutls.org"
 authors: ["Nikos Mavrogiannopoulos" "Simon Josefsson"]
 license: "LGPL-2.1-or-later"
 build: [
-  [conf-pkg-config:command "gnutls" "nettle"]
+  # When the version is next bumped, this package can depend on
+  # conf-pkg-config.5 and instead use:
+  # [conf-pkg-config:command "gnutls" "nettle"]
+  "pkgconf" {os = "win32" & os-distribution != "cygwinports"}
+  "--personality=i686-w64-mingw32"
+    {os = "win32" & os-distribution != "cygwinports" &
+     host-arch-x86_32:installed}
+  "--personality=x86_64-w64-mingw32"
+    {os = "win32" & os-distribution != "cygwinports" &
+     host-arch-x86_64:installed}
+  "pkg-config" {os != "win32" | os-distribution = "cygwinports"}
+  "gnutls" "nettle"
 ]
 depends: [
-  "conf-pkg-config" {>= "5"}
+  "conf-pkg-config" {build}
   ("host-arch-x86_64" {os = "win32" & os-distribution != "cygwinports"} &
    "conf-mingw-w64-nettle-x86_64"
      {os = "win32" & os-distribution != "cygwinports"} &

--- a/packages/conf-gnutls/conf-gnutls.1/opam
+++ b/packages/conf-gnutls/conf-gnutls.1/opam
@@ -4,18 +4,10 @@ homepage: "https://www.gnutls.org"
 authors: ["Nikos Mavrogiannopoulos" "Simon Josefsson"]
 license: "LGPL-2.1-or-later"
 build: [
-  "pkgconf" {os = "win32" & os-distribution != "cygwinports"}
-  "--personality=i686-w64-mingw32"
-    {os = "win32" & os-distribution != "cygwinports" &
-     host-arch-x86_32:installed}
-  "--personality=x86_64-w64-mingw32"
-    {os = "win32" & os-distribution != "cygwinports" &
-     host-arch-x86_64:installed}
-  "pkg-config" {os != "win32" | os-distribution = "cygwinports"}
-  "gnutls" "nettle"
+  [conf-pkg-config:command "gnutls" "nettle"]
 ]
 depends: [
-  "conf-pkg-config" {build}
+  "conf-pkg-config" {>= "5"}
   ("host-arch-x86_64" {os = "win32" & os-distribution != "cygwinports"} &
    "conf-mingw-w64-nettle-x86_64"
      {os = "win32" & os-distribution != "cygwinports"} &

--- a/packages/conf-gnutls/conf-gnutls.1/opam
+++ b/packages/conf-gnutls/conf-gnutls.1/opam
@@ -16,15 +16,15 @@ build: [
 ]
 depends: [
   "conf-pkg-config" {build}
-  ("host-arch-x86_32" {os = "win32" & os-distribution != "cygwinports"} &
-   "conf-mingw-w64-gnutls-i686"
-     {os = "win32" & os-distribution != "cygwinports"} &
-   "conf-mingw-w64-nettle-i686"
-     {os = "win32" & os-distribution != "cygwinports"} |
-   "host-arch-x86_64" {os = "win32" & os-distribution != "cygwinports"} &
+  ("host-arch-x86_64" {os = "win32" & os-distribution != "cygwinports"} &
    "conf-mingw-w64-nettle-x86_64"
      {os = "win32" & os-distribution != "cygwinports"} &
    "conf-mingw-w64-gnutls-x86_64"
+     {os = "win32" & os-distribution != "cygwinports"} |
+   "host-arch-x86_32" {os = "win32" & os-distribution != "cygwinports"} &
+   "conf-mingw-w64-gnutls-i686"
+     {os = "win32" & os-distribution != "cygwinports"} &
+   "conf-mingw-w64-nettle-i686"
      {os = "win32" & os-distribution != "cygwinports"})
 ]
 depexts: [

--- a/packages/conf-gtk2/conf-gtk2.1/opam
+++ b/packages/conf-gtk2/conf-gtk2.1/opam
@@ -5,10 +5,17 @@ bug-reports: "https://github.com/ocaml/opam-repository/issues"
 authors: ["The GNOME Project"]
 license: "LGPL-2.1-or-later"
 build: [
-  [conf-pkg-config:command "--exists" "gtk+-2.0"]
+  # When the version is next bumped, this package can depend on
+  # conf-pkg-config.5 and instead use:
+  # [conf-pkg-config:command "--exists" "gtk+-2.0"]
+  ["pkgconf" {os = "win32" & os-distribution != "cygwinports"}
+      "--personality=i686-w64-mingw32" {os = "win32" & os-distribution != "cygwinports" & host-arch-x86_32:installed}
+      "--personality=x86_64-w64-mingw32" {os = "win32" & os-distribution != "cygwinports" & host-arch-x86_64:installed}
+   "pkg-config" {os != "win32" | os-distribution = "cygwinports"}
+   "--exists" "gtk+-2.0"]
 ]
 depends: [
-  "conf-pkg-config" {>= "5"}
+  "conf-pkg-config" {build}
   ("host-arch-x86_64" {os = "win32" & os-distribution != "cygwinports"} & "conf-mingw-w64-gtk2-x86_64" {os = "win32" & os-distribution != "cygwinports"} |
    "host-arch-x86_32" {os = "win32" & os-distribution != "cygwinports"} & "conf-mingw-w64-gtk2-i686" {os = "win32" & os-distribution != "cygwinports"})
 ]

--- a/packages/conf-gtk2/conf-gtk2.1/opam
+++ b/packages/conf-gtk2/conf-gtk2.1/opam
@@ -5,14 +5,10 @@ bug-reports: "https://github.com/ocaml/opam-repository/issues"
 authors: ["The GNOME Project"]
 license: "LGPL-2.1-or-later"
 build: [
-  ["pkgconf" {os = "win32" & os-distribution != "cygwinports"}
-      "--personality=i686-w64-mingw32" {os = "win32" & os-distribution != "cygwinports" & host-arch-x86_32:installed}
-      "--personality=x86_64-w64-mingw32" {os = "win32" & os-distribution != "cygwinports" & host-arch-x86_64:installed}
-   "pkg-config" {os != "win32" | os-distribution = "cygwinports"}
-   "--exists" "gtk+-2.0"]
+  [conf-pkg-config:command "--exists" "gtk+-2.0"]
 ]
 depends: [
-  "conf-pkg-config" {build}
+  "conf-pkg-config" {>= "5"}
   ("host-arch-x86_64" {os = "win32" & os-distribution != "cygwinports"} & "conf-mingw-w64-gtk2-x86_64" {os = "win32" & os-distribution != "cygwinports"} |
    "host-arch-x86_32" {os = "win32" & os-distribution != "cygwinports"} & "conf-mingw-w64-gtk2-i686" {os = "win32" & os-distribution != "cygwinports"})
 ]

--- a/packages/conf-gtk2/conf-gtk2.1/opam
+++ b/packages/conf-gtk2/conf-gtk2.1/opam
@@ -13,8 +13,8 @@ build: [
 ]
 depends: [
   "conf-pkg-config" {build}
-  ("host-arch-x86_32" {os = "win32" & os-distribution != "cygwinports"} & "conf-mingw-w64-gtk2-i686" {os = "win32" & os-distribution != "cygwinports"} |
-   "host-arch-x86_64" {os = "win32" & os-distribution != "cygwinports"} & "conf-mingw-w64-gtk2-x86_64" {os = "win32" & os-distribution != "cygwinports"})
+  ("host-arch-x86_64" {os = "win32" & os-distribution != "cygwinports"} & "conf-mingw-w64-gtk2-x86_64" {os = "win32" & os-distribution != "cygwinports"} |
+   "host-arch-x86_32" {os = "win32" & os-distribution != "cygwinports"} & "conf-mingw-w64-gtk2-i686" {os = "win32" & os-distribution != "cygwinports"})
 ]
 depexts: [
   ["libgtk2.0-dev" "libexpat1-dev"] {os-family = "debian"}

--- a/packages/conf-gtk3/conf-gtk3.18/opam
+++ b/packages/conf-gtk3/conf-gtk3.18/opam
@@ -11,8 +11,8 @@ build: [
 ]
 depends: [
   "conf-pkg-config" {build}
-  ("host-arch-x86_32" {os = "win32" & os-distribution != "cygwinports"} & "conf-mingw-w64-gtk3-i686" {os = "win32" & os-distribution != "cygwinports"} |
-   "host-arch-x86_64" {os = "win32" & os-distribution != "cygwinports"} & "conf-mingw-w64-gtk3-x86_64" {os = "win32" & os-distribution != "cygwinports"})
+  ("host-arch-x86_64" {os = "win32" & os-distribution != "cygwinports"} & "conf-mingw-w64-gtk3-x86_64" {os = "win32" & os-distribution != "cygwinports"} |
+   "host-arch-x86_32" {os = "win32" & os-distribution != "cygwinports"} & "conf-mingw-w64-gtk3-i686" {os = "win32" & os-distribution != "cygwinports"})
 ]
 depexts: [
   ["libgtk-3-dev" "libexpat1-dev"] {os-family = "debian" | os-family = "ubuntu"}

--- a/packages/conf-gtk3/conf-gtk3.18/opam
+++ b/packages/conf-gtk3/conf-gtk3.18/opam
@@ -5,14 +5,19 @@ license: "LGPL-2.1-or-later"
 homepage: "https://www.gtk.org/"
 bug-reports: "https://github.com/garrigue/lablgtk/issues"
 build: [
-  [conf-pkg-config:command
-     "--short-errors" {os != "win32" | os-distribution = "cygwinports"} "--atleast-version" {os != "win32" | os-distribution = "cygwinports"} "3.18" {os != "win32" | os-distribution = "cygwinports"}
-     "--print-errors" "--exists" {os = "win32" & os-distribution != "cygwinports" & host-arch-x86_64:installed}
-     "gtk+-3.0"
-  ]
+  # When the version is next bumped, this package can depend on
+  # conf-pkg-config.5 and instead use:
+  # [conf-pkg-config:command
+  #    "--short-errors" {os != "win32" | os-distribution = "cygwinports"} "--atleast-version" {os != "win32" | os-distribution = "cygwinports"} "3.18" {os != "win32" | os-distribution = "cygwinports"}
+  #    "--print-errors" "--exists" {os = "win32" & os-distribution != "cygwinports" & host-arch-x86_64:installed}
+  #    "gtk+-3.0"
+  # ]
+  ["pkgconf" "--personality=i686-w64-mingw32" "--print-errors" "--exists" "gtk+-3.0"] {os = "win32" & os-distribution != "cygwinports" & host-arch-x86_32:installed}
+  ["pkgconf" "--personality=x86_64-w64-mingw32" "--print-errors" "--exists" "gtk+-3.0"] {os = "win32" & os-distribution != "cygwinports" & host-arch-x86_64:installed}
+  ["pkg-config" "--short-errors" "--print-errors" "--atleast-version" "3.18" "gtk+-3.0"] {os != "win32" | os-distribution = "cygwinports"}
 ]
 depends: [
-  "conf-pkg-config" {>= "5"}
+  "conf-pkg-config" {build}
   ("host-arch-x86_64" {os = "win32" & os-distribution != "cygwinports"} & "conf-mingw-w64-gtk3-x86_64" {os = "win32" & os-distribution != "cygwinports"} |
    "host-arch-x86_32" {os = "win32" & os-distribution != "cygwinports"} & "conf-mingw-w64-gtk3-i686" {os = "win32" & os-distribution != "cygwinports"})
 ]

--- a/packages/conf-gtk3/conf-gtk3.18/opam
+++ b/packages/conf-gtk3/conf-gtk3.18/opam
@@ -5,12 +5,14 @@ license: "LGPL-2.1-or-later"
 homepage: "https://www.gtk.org/"
 bug-reports: "https://github.com/garrigue/lablgtk/issues"
 build: [
-  ["pkgconf" "--personality=i686-w64-mingw32" "--print-errors" "--exists" "gtk+-3.0"] {os = "win32" & os-distribution != "cygwinports" & host-arch-x86_32:installed}
-  ["pkgconf" "--personality=x86_64-w64-mingw32" "--print-errors" "--exists" "gtk+-3.0"] {os = "win32" & os-distribution != "cygwinports" & host-arch-x86_64:installed}
-  ["pkg-config" "--short-errors" "--print-errors" "--atleast-version" "3.18" "gtk+-3.0"] {os != "win32" | os-distribution = "cygwinports"}
+  [conf-pkg-config:command
+     "--short-errors" {os != "win32" | os-distribution = "cygwinports"} "--atleast-version" {os != "win32" | os-distribution = "cygwinports"} "3.18" {os != "win32" | os-distribution = "cygwinports"}
+     "--print-errors" "--exists" {os = "win32" & os-distribution != "cygwinports" & host-arch-x86_64:installed}
+     "gtk+-3.0"
+  ]
 ]
 depends: [
-  "conf-pkg-config" {build}
+  "conf-pkg-config" {>= "5"}
   ("host-arch-x86_64" {os = "win32" & os-distribution != "cygwinports"} & "conf-mingw-w64-gtk3-x86_64" {os = "win32" & os-distribution != "cygwinports"} |
    "host-arch-x86_32" {os = "win32" & os-distribution != "cygwinports"} & "conf-mingw-w64-gtk3-i686" {os = "win32" & os-distribution != "cygwinports"})
 ]

--- a/packages/conf-gtksourceview3/conf-gtksourceview3.0+2/opam
+++ b/packages/conf-gtksourceview3/conf-gtksourceview3.0+2/opam
@@ -5,10 +5,15 @@ bug-reports: "https://github.com/ocaml/opam-repository/issues"
 homepage: "https://projects.gnome.org/gtksourceview/"
 license: "LGPL-2.1-or-later"
 build: [
-  [conf-pkg-config:command "--short-errors" "--print-errors" "gtksourceview-3.0"]
+  # When the version is next bumped, this package can depend on
+  # conf-pkg-config.5 and instead use:
+  # [conf-pkg-config:command "--short-errors" "--print-errors" "gtksourceview-3.0"]
+  ["pkgconf" "--personality=i686-w64-mingw32" "--short-errors" "--print-errors" "gtksourceview-3.0"] {os = "win32" & os-distribution != "cygwinports" & host-arch-x86_32:installed}
+  ["pkgconf" "--personality=x86_64-w64-mingw32" "--short-errors" "--print-errors" "gtksourceview-3.0"] {os = "win32" & os-distribution != "cygwinports" & host-arch-x86_64:installed}
+  ["pkg-config" "--short-errors" "--print-errors" "gtksourceview-3.0"] {os != "win32" | os-distribution = "cygwinports"}
 ]
 depends: [
-  "conf-pkg-config" {>= "5"}
+  "conf-pkg-config" {build}
   ("host-arch-x86_64" {os = "win32" & os-distribution != "cygwinports"} & "conf-mingw-w64-gtksourceview3-x86_64" {os = "win32" & os-distribution != "cygwinports"} |
    "host-arch-x86_32" {os = "win32" & os-distribution != "cygwinports"} & "conf-mingw-w64-gtksourceview3-i686" {os = "win32" & os-distribution != "cygwinports"})
 ]

--- a/packages/conf-gtksourceview3/conf-gtksourceview3.0+2/opam
+++ b/packages/conf-gtksourceview3/conf-gtksourceview3.0+2/opam
@@ -5,12 +5,10 @@ bug-reports: "https://github.com/ocaml/opam-repository/issues"
 homepage: "https://projects.gnome.org/gtksourceview/"
 license: "LGPL-2.1-or-later"
 build: [
-  ["pkgconf" "--personality=i686-w64-mingw32" "--short-errors" "--print-errors" "gtksourceview-3.0"] {os = "win32" & os-distribution != "cygwinports" & host-arch-x86_32:installed}
-  ["pkgconf" "--personality=x86_64-w64-mingw32" "--short-errors" "--print-errors" "gtksourceview-3.0"] {os = "win32" & os-distribution != "cygwinports" & host-arch-x86_64:installed}
-  ["pkg-config" "--short-errors" "--print-errors" "gtksourceview-3.0"] {os != "win32" | os-distribution = "cygwinports"}
+  [conf-pkg-config:command "--short-errors" "--print-errors" "gtksourceview-3.0"]
 ]
 depends: [
-  "conf-pkg-config" {build}
+  "conf-pkg-config" {>= "5"}
   ("host-arch-x86_64" {os = "win32" & os-distribution != "cygwinports"} & "conf-mingw-w64-gtksourceview3-x86_64" {os = "win32" & os-distribution != "cygwinports"} |
    "host-arch-x86_32" {os = "win32" & os-distribution != "cygwinports"} & "conf-mingw-w64-gtksourceview3-i686" {os = "win32" & os-distribution != "cygwinports"})
 ]

--- a/packages/conf-gtksourceview3/conf-gtksourceview3.0+2/opam
+++ b/packages/conf-gtksourceview3/conf-gtksourceview3.0+2/opam
@@ -11,8 +11,8 @@ build: [
 ]
 depends: [
   "conf-pkg-config" {build}
-  ("host-arch-x86_32" {os = "win32" & os-distribution != "cygwinports"} & "conf-mingw-w64-gtksourceview3-i686" {os = "win32" & os-distribution != "cygwinports"} |
-   "host-arch-x86_64" {os = "win32" & os-distribution != "cygwinports"} & "conf-mingw-w64-gtksourceview3-x86_64" {os = "win32" & os-distribution != "cygwinports"})
+  ("host-arch-x86_64" {os = "win32" & os-distribution != "cygwinports"} & "conf-mingw-w64-gtksourceview3-x86_64" {os = "win32" & os-distribution != "cygwinports"} |
+   "host-arch-x86_32" {os = "win32" & os-distribution != "cygwinports"} & "conf-mingw-w64-gtksourceview3-i686" {os = "win32" & os-distribution != "cygwinports"})
 ]
 depexts: [
   ["gtksourceview-dev"] {os-distribution = "alpine"}

--- a/packages/conf-libcurl/conf-libcurl.2/opam
+++ b/packages/conf-libcurl/conf-libcurl.2/opam
@@ -25,8 +25,8 @@ depexts: [
 ]
 depends: [
   "mingw-w64-shims" {os-distribution = "cygwin" & build}
-  ("host-arch-x86_32" {os = "win32" & os-distribution != "cygwinports"} & "conf-mingw-w64-curl-i686" {os = "win32" & os-distribution != "cygwinports"} |
-   "host-arch-x86_64" {os = "win32" & os-distribution != "cygwinports"} & "conf-mingw-w64-curl-x86_64" {os = "win32" & os-distribution != "cygwinports"})
+  ("host-arch-x86_64" {os = "win32" & os-distribution != "cygwinports"} & "conf-mingw-w64-curl-x86_64" {os = "win32" & os-distribution != "cygwinports"} |
+   "host-arch-x86_32" {os = "win32" & os-distribution != "cygwinports"} & "conf-mingw-w64-curl-i686" {os = "win32" & os-distribution != "cygwinports"})
 ]
 synopsis: "Virtual package relying on a libcurl system installation"
 description:

--- a/packages/conf-libevent/conf-libevent.1/opam
+++ b/packages/conf-libevent/conf-libevent.1/opam
@@ -17,11 +17,11 @@ build: [
 ]
 depends: [
   "conf-pkg-config" {build}
-  ("host-arch-x86_32" {os = "win32" & os-distribution != "cygwinports"} &
-   "conf-mingw-w64-libevent-i686"
-     {os = "win32" & os-distribution != "cygwinports"} |
-   "host-arch-x86_64" {os = "win32" & os-distribution != "cygwinports"} &
+  ("host-arch-x86_64" {os = "win32" & os-distribution != "cygwinports"} &
    "conf-mingw-w64-libevent-x86_64"
+     {os = "win32" & os-distribution != "cygwinports"} |
+   "host-arch-x86_32" {os = "win32" & os-distribution != "cygwinports"} &
+   "conf-mingw-w64-libevent-i686"
      {os = "win32" & os-distribution != "cygwinports"})
 ]
 depexts: [

--- a/packages/conf-libevent/conf-libevent.1/opam
+++ b/packages/conf-libevent/conf-libevent.1/opam
@@ -5,10 +5,21 @@ bug-reports: "https://github.com/ocaml/opam-repository/issues"
 authors: "Libevent dev team"
 license: "BSD-3-clause"
 build: [
-  [conf-pkg-config:command "libevent"]
+  # When the version is next bumped, this package can depend on
+  # conf-pkg-config.5 and instead use:
+  # [conf-pkg-config:command "libevent"]
+  "pkgconf" {os = "win32" & os-distribution != "cygwinports"}
+  "--personality=i686-w64-mingw32"
+    {os = "win32" & os-distribution != "cygwinports" &
+     host-arch-x86_32:installed}
+  "--personality=x86_64-w64-mingw32"
+    {os = "win32" & os-distribution != "cygwinports" &
+     host-arch-x86_64:installed}
+  "pkg-config" {os != "Win32" | os-distribution = "cygwinports"}
+  "libevent"
 ]
 depends: [
-  "conf-pkg-config" {>= "5"}
+  "conf-pkg-config" {build}
   ("host-arch-x86_64" {os = "win32" & os-distribution != "cygwinports"} &
    "conf-mingw-w64-libevent-x86_64"
      {os = "win32" & os-distribution != "cygwinports"} |

--- a/packages/conf-libevent/conf-libevent.1/opam
+++ b/packages/conf-libevent/conf-libevent.1/opam
@@ -5,18 +5,10 @@ bug-reports: "https://github.com/ocaml/opam-repository/issues"
 authors: "Libevent dev team"
 license: "BSD-3-clause"
 build: [
-  "pkgconf" {os = "win32" & os-distribution != "cygwinports"}
-  "--personality=i686-w64-mingw32"
-    {os = "win32" & os-distribution != "cygwinports" &
-     host-arch-x86_32:installed}
-  "--personality=x86_64-w64-mingw32"
-    {os = "win32" & os-distribution != "cygwinports" &
-     host-arch-x86_64:installed}
-  "pkg-config" {os != "Win32" | os-distribution = "cygwinports"}
-  "libevent"
+  [conf-pkg-config:command "libevent"]
 ]
 depends: [
-  "conf-pkg-config" {build}
+  "conf-pkg-config" {>= "5"}
   ("host-arch-x86_64" {os = "win32" & os-distribution != "cygwinports"} &
    "conf-mingw-w64-libevent-x86_64"
      {os = "win32" & os-distribution != "cygwinports"} |

--- a/packages/conf-libffi/conf-libffi.2.0.0/opam
+++ b/packages/conf-libffi/conf-libffi.2.0.0/opam
@@ -4,11 +4,7 @@ authors: ["Anthony Green"]
 homepage: "http://sourceware.org/libffi/"
 license: "MIT"
 build: [
-  "pkgconf" {os = "win32" & os-distribution != "cygwinports"}
-   "--personality=i686-w64-mingw32" {os = "win32" & os-distribution != "cygwinports" & host-arch-x86_32:installed}
-   "--personality=x86_64-w64-mingw32" {os = "win32" & os-distribution != "cygwinports" & host-arch-x86_64:installed}
-   "pkg-config" {os != "win32" | os-distribution = "cygwinports"}
-   "libffi"
+  [conf-pkg-config:command "libffi"]
 ]
 depexts: [
   ["libffi"] {os = "macos" & os-distribution = "homebrew"}
@@ -28,7 +24,7 @@ depexts: [
 synopsis: "Virtual package relying on libffi system installation"
 description: "This package can only install if libffi is installed on the system."
 depends: [
-  "conf-pkg-config" {build}
+  "conf-pkg-config" {>= "5"}
   "mingw-w64-shims" {os-distribution = "cygwin" & build}
   ("host-arch-x86_64" {os = "win32" & os-distribution != "cygwinports"} & "conf-mingw-w64-libffi-x86_64" {os = "win32" & os-distribution != "cygwinports"} |
    "host-arch-x86_32" {os = "win32" & os-distribution != "cygwinports"} & "conf-mingw-w64-libffi-i686" {os = "win32" & os-distribution != "cygwinports"})

--- a/packages/conf-libffi/conf-libffi.2.0.0/opam
+++ b/packages/conf-libffi/conf-libffi.2.0.0/opam
@@ -4,7 +4,14 @@ authors: ["Anthony Green"]
 homepage: "http://sourceware.org/libffi/"
 license: "MIT"
 build: [
-  [conf-pkg-config:command "libffi"]
+  # When the version is next bumped, this package can depend on
+  # conf-pkg-config.5 and instead use:
+  # [conf-pkg-config:command "libffi"]
+  "pkgconf" {os = "win32" & os-distribution != "cygwinports"}
+   "--personality=i686-w64-mingw32" {os = "win32" & os-distribution != "cygwinports" & host-arch-x86_32:installed}
+   "--personality=x86_64-w64-mingw32" {os = "win32" & os-distribution != "cygwinports" & host-arch-x86_64:installed}
+   "pkg-config" {os != "win32" | os-distribution = "cygwinports"}
+   "libffi"
 ]
 depexts: [
   ["libffi"] {os = "macos" & os-distribution = "homebrew"}
@@ -24,7 +31,7 @@ depexts: [
 synopsis: "Virtual package relying on libffi system installation"
 description: "This package can only install if libffi is installed on the system."
 depends: [
-  "conf-pkg-config" {>= "5"}
+  "conf-pkg-config" {build}
   "mingw-w64-shims" {os-distribution = "cygwin" & build}
   ("host-arch-x86_64" {os = "win32" & os-distribution != "cygwinports"} & "conf-mingw-w64-libffi-x86_64" {os = "win32" & os-distribution != "cygwinports"} |
    "host-arch-x86_32" {os = "win32" & os-distribution != "cygwinports"} & "conf-mingw-w64-libffi-i686" {os = "win32" & os-distribution != "cygwinports"})

--- a/packages/conf-libffi/conf-libffi.2.0.0/opam
+++ b/packages/conf-libffi/conf-libffi.2.0.0/opam
@@ -30,8 +30,8 @@ description: "This package can only install if libffi is installed on the system
 depends: [
   "conf-pkg-config" {build}
   "mingw-w64-shims" {os-distribution = "cygwin" & build}
-  ("host-arch-x86_32" {os = "win32" & os-distribution != "cygwinports"} & "conf-mingw-w64-libffi-i686" {os = "win32" & os-distribution != "cygwinports"} |
-   "host-arch-x86_64" {os = "win32" & os-distribution != "cygwinports"} & "conf-mingw-w64-libffi-x86_64" {os = "win32" & os-distribution != "cygwinports"})
+  ("host-arch-x86_64" {os = "win32" & os-distribution != "cygwinports"} & "conf-mingw-w64-libffi-x86_64" {os = "win32" & os-distribution != "cygwinports"} |
+   "host-arch-x86_32" {os = "win32" & os-distribution != "cygwinports"} & "conf-mingw-w64-libffi-i686" {os = "win32" & os-distribution != "cygwinports"})
 ]
 bug-reports: "https://github.com/ocaml/opam-repository/issues"
 flags: conf

--- a/packages/conf-liblz4/conf-liblz4.1/opam
+++ b/packages/conf-liblz4/conf-liblz4.1/opam
@@ -11,8 +11,8 @@ build: [
 ]
 depends: [
   "conf-pkg-config" {build}
-  ("host-arch-x86_32" {os = "win32" & os-distribution != "cygwinports"} & "conf-mingw-w64-liblz4-i686" {os = "win32" & os-distribution != "cygwinports"} |
-   "host-arch-x86_64" {os = "win32" & os-distribution != "cygwinports"} & "conf-mingw-w64-liblz4-x86_64" {os = "win32" & os-distribution != "cygwinports"})
+  ("host-arch-x86_64" {os = "win32" & os-distribution != "cygwinports"} & "conf-mingw-w64-liblz4-x86_64" {os = "win32" & os-distribution != "cygwinports"} |
+   "host-arch-x86_32" {os = "win32" & os-distribution != "cygwinports"} & "conf-mingw-w64-liblz4-i686" {os = "win32" & os-distribution != "cygwinports"})
 ]
 depexts: [
   ["liblz4-dev"] {os-family = "debian"}

--- a/packages/conf-liblz4/conf-liblz4.1/opam
+++ b/packages/conf-liblz4/conf-liblz4.1/opam
@@ -5,12 +5,10 @@ bug-reports: "https://github.com/ocaml/opam-repository/issues"
 authors: ["Yann Collet"]
 license: ["GPL-2.0-only" "BSD-2-Clause"]
 build: [
-  ["pkgconf" "--personality=i686-w64-mingw32" "liblz4"] {os = "win32" & os-distribution != "cygwinports" & host-arch-x86_32:installed}
-  ["pkgconf" "--personality=x86_64-w64-mingw32" "liblz4"] {os = "win32" & os-distribution != "cygwinports" & host-arch-x86_64:installed}
-  ["pkg-config" "liblz4"] {os != "win32" | os-distribution = "cygwinports"}
+  [conf-pkg-config:command "liblz4"]
 ]
 depends: [
-  "conf-pkg-config" {build}
+  "conf-pkg-config" {>= "5"}
   ("host-arch-x86_64" {os = "win32" & os-distribution != "cygwinports"} & "conf-mingw-w64-liblz4-x86_64" {os = "win32" & os-distribution != "cygwinports"} |
    "host-arch-x86_32" {os = "win32" & os-distribution != "cygwinports"} & "conf-mingw-w64-liblz4-i686" {os = "win32" & os-distribution != "cygwinports"})
 ]

--- a/packages/conf-liblz4/conf-liblz4.1/opam
+++ b/packages/conf-liblz4/conf-liblz4.1/opam
@@ -5,10 +5,15 @@ bug-reports: "https://github.com/ocaml/opam-repository/issues"
 authors: ["Yann Collet"]
 license: ["GPL-2.0-only" "BSD-2-Clause"]
 build: [
-  [conf-pkg-config:command "liblz4"]
+  # When the version is next bumped, this package can depend on
+  # conf-pkg-config.5 and instead use:
+  # [conf-pkg-config:command "liblz4"]
+  ["pkgconf" "--personality=i686-w64-mingw32" "liblz4"] {os = "win32" & os-distribution != "cygwinports" & host-arch-x86_32:installed}
+  ["pkgconf" "--personality=x86_64-w64-mingw32" "liblz4"] {os = "win32" & os-distribution != "cygwinports" & host-arch-x86_64:installed}
+  ["pkg-config" "liblz4"] {os != "win32" | os-distribution = "cygwinports"}
 ]
 depends: [
-  "conf-pkg-config" {>= "5"}
+  "conf-pkg-config" {build}
   ("host-arch-x86_64" {os = "win32" & os-distribution != "cygwinports"} & "conf-mingw-w64-liblz4-x86_64" {os = "win32" & os-distribution != "cygwinports"} |
    "host-arch-x86_32" {os = "win32" & os-distribution != "cygwinports"} & "conf-mingw-w64-liblz4-i686" {os = "win32" & os-distribution != "cygwinports"})
 ]

--- a/packages/conf-libpcre/conf-libpcre.2/opam
+++ b/packages/conf-libpcre/conf-libpcre.2/opam
@@ -8,9 +8,16 @@ homepage: "http://www.pcre.org/"
 dev-repo: "git+https://github.com/mmottl/pcre-ocaml.git"
 license: "BSD-3-Clause"
 build:
-  [conf-pkg-config:command "--print-errors" "--exists" "libpcre"]
+  # When the version is next bumped, this package can depend on
+  # conf-pkg-config.5 and instead use:
+  # [conf-pkg-config:command "--print-errors" "--exists" "libpcre"]
+  ["pkgconf" {os = "win32" & os-distribution != "cygwinports"}
+   "--personality=i686-w64-mingw32" {os = "win32" & os-distribution != "cygwinports" & host-arch-x86_32:installed}
+   "--personality=x86_64-w64-mingw32" {os = "win32" & os-distribution != "cygwinports" & host-arch-x86_64:installed}
+   "pkg-config" {os != "win32" | os-distribution = "cygwinports"}
+   "--print-errors" "--exists" "libpcre"]
 depends: [
- "conf-pkg-config" {>= "5"}
+ "conf-pkg-config" {build}
   ("host-arch-x86_64" {os = "win32" & os-distribution != "cygwinports"} & "conf-mingw-w64-pcre-x86_64" {os = "win32" & os-distribution != "cygwinports"} |
    "host-arch-x86_32" {os = "win32" & os-distribution != "cygwinports"} & "conf-mingw-w64-pcre-i686" {os = "win32" & os-distribution != "cygwinports"})
  ]

--- a/packages/conf-libpcre/conf-libpcre.2/opam
+++ b/packages/conf-libpcre/conf-libpcre.2/opam
@@ -8,13 +8,9 @@ homepage: "http://www.pcre.org/"
 dev-repo: "git+https://github.com/mmottl/pcre-ocaml.git"
 license: "BSD-3-Clause"
 build:
-  ["pkgconf" {os = "win32" & os-distribution != "cygwinports"}
-   "--personality=i686-w64-mingw32" {os = "win32" & os-distribution != "cygwinports" & host-arch-x86_32:installed}
-   "--personality=x86_64-w64-mingw32" {os = "win32" & os-distribution != "cygwinports" & host-arch-x86_64:installed}
-   "pkg-config" {os != "win32" | os-distribution = "cygwinports"}
-   "--print-errors" "--exists" "libpcre"]
+  [conf-pkg-config:command "--print-errors" "--exists" "libpcre"]
 depends: [
- "conf-pkg-config" {build}
+ "conf-pkg-config" {>= "5"}
   ("host-arch-x86_64" {os = "win32" & os-distribution != "cygwinports"} & "conf-mingw-w64-pcre-x86_64" {os = "win32" & os-distribution != "cygwinports"} |
    "host-arch-x86_32" {os = "win32" & os-distribution != "cygwinports"} & "conf-mingw-w64-pcre-i686" {os = "win32" & os-distribution != "cygwinports"})
  ]

--- a/packages/conf-libpcre/conf-libpcre.2/opam
+++ b/packages/conf-libpcre/conf-libpcre.2/opam
@@ -15,8 +15,8 @@ build:
    "--print-errors" "--exists" "libpcre"]
 depends: [
  "conf-pkg-config" {build}
-  ("host-arch-x86_32" {os = "win32" & os-distribution != "cygwinports"} & "conf-mingw-w64-pcre-i686" {os = "win32" & os-distribution != "cygwinports"} |
-   "host-arch-x86_64" {os = "win32" & os-distribution != "cygwinports"} & "conf-mingw-w64-pcre-x86_64" {os = "win32" & os-distribution != "cygwinports"})
+  ("host-arch-x86_64" {os = "win32" & os-distribution != "cygwinports"} & "conf-mingw-w64-pcre-x86_64" {os = "win32" & os-distribution != "cygwinports"} |
+   "host-arch-x86_32" {os = "win32" & os-distribution != "cygwinports"} & "conf-mingw-w64-pcre-i686" {os = "win32" & os-distribution != "cygwinports"})
  ]
 bug-reports: "https://github.com/ocaml/opam-repository/issues"
 depexts: [

--- a/packages/conf-libpcre2-8/conf-libpcre2-8.2/opam
+++ b/packages/conf-libpcre2-8/conf-libpcre2-8.2/opam
@@ -8,10 +8,17 @@ homepage: "https://www.pcre.org/"
 dev-repo: "git+https://github.com/PCRE2Project/pcre2.git"
 license: "BSD-3-Clause"
 build: [
-  [conf-pkg-config:command "--print-errors" "--exists" "libpcre2-8"]
-]
+  # When the version is next bumped, this package can depend on
+  # conf-pkg-config.5 and instead use:
+  # [conf-pkg-config:command "--print-errors" "--exists" "libpcre2-8"]
+  ["pkgconf" {os = "win32" & os-distribution != "cygwinports"}
+   "--personality=i686-w64-mingw32" {os = "win32" & os-distribution != "cygwinports" & host-arch-x86_32:installed}
+   "--personality=x86_64-w64-mingw32" {os = "win32" & os-distribution != "cygwinports" & host-arch-x86_64:installed}
+   "pkg-config" {os != "win32" | os-distribution = "cygwinports"}
+   "--print-errors" "--exists" "libpcre2-8"
+  ]]
 depends: [
-  "conf-pkg-config" {>= "5"}
+  "conf-pkg-config" {build}
   ("host-arch-x86_64" {os = "win32" & (os-distribution = "cygwin" | os-distribution = "msys2")}
    & "conf-mingw-w64-pcre2-x86_64" {os = "win32" & (os-distribution = "cygwin" | os-distribution = "msys2")}
    | "host-arch-x86_32" {os = "win32" & (os-distribution = "cygwin" | os-distribution = "msys2")}

--- a/packages/conf-libpcre2-8/conf-libpcre2-8.2/opam
+++ b/packages/conf-libpcre2-8/conf-libpcre2-8.2/opam
@@ -16,10 +16,10 @@ build: [
   ]]
 depends: [
   "conf-pkg-config" {build}
-  ("host-arch-x86_32" {os = "win32" & (os-distribution = "cygwin" | os-distribution = "msys2")}
-   & "conf-mingw-w64-pcre2-i686" {os = "win32" & (os-distribution = "cygwin" | os-distribution = "msys2")}
-   | "host-arch-x86_64" {os = "win32" & (os-distribution = "cygwin" | os-distribution = "msys2")}
-   & "conf-mingw-w64-pcre2-x86_64" {os = "win32" & (os-distribution = "cygwin" | os-distribution = "msys2")})
+  ("host-arch-x86_64" {os = "win32" & (os-distribution = "cygwin" | os-distribution = "msys2")}
+   & "conf-mingw-w64-pcre2-x86_64" {os = "win32" & (os-distribution = "cygwin" | os-distribution = "msys2")}
+   | "host-arch-x86_32" {os = "win32" & (os-distribution = "cygwin" | os-distribution = "msys2")}
+   & "conf-mingw-w64-pcre2-i686" {os = "win32" & (os-distribution = "cygwin" | os-distribution = "msys2")})
   ]
 bug-reports: "https://github.com/ocaml/opam-repository/issues"
 depexts: [

--- a/packages/conf-libpcre2-8/conf-libpcre2-8.2/opam
+++ b/packages/conf-libpcre2-8/conf-libpcre2-8.2/opam
@@ -8,14 +8,10 @@ homepage: "https://www.pcre.org/"
 dev-repo: "git+https://github.com/PCRE2Project/pcre2.git"
 license: "BSD-3-Clause"
 build: [
-  ["pkgconf" {os = "win32" & os-distribution != "cygwinports"}
-   "--personality=i686-w64-mingw32" {os = "win32" & os-distribution != "cygwinports" & host-arch-x86_32:installed}
-   "--personality=x86_64-w64-mingw32" {os = "win32" & os-distribution != "cygwinports" & host-arch-x86_64:installed}
-   "pkg-config" {os != "win32" | os-distribution = "cygwinports"}
-   "--print-errors" "--exists" "libpcre2-8"
-  ]]
+  [conf-pkg-config:command "--print-errors" "--exists" "libpcre2-8"]
+]
 depends: [
-  "conf-pkg-config" {build}
+  "conf-pkg-config" {>= "5"}
   ("host-arch-x86_64" {os = "win32" & (os-distribution = "cygwin" | os-distribution = "msys2")}
    & "conf-mingw-w64-pcre2-x86_64" {os = "win32" & (os-distribution = "cygwin" | os-distribution = "msys2")}
    | "host-arch-x86_32" {os = "win32" & (os-distribution = "cygwin" | os-distribution = "msys2")}

--- a/packages/conf-libssl/conf-libssl.4/opam
+++ b/packages/conf-libssl/conf-libssl.4/opam
@@ -22,8 +22,8 @@ install: [
 ]
 depends: [
   "conf-pkg-config" {build}
-  ("host-arch-x86_32" {os = "win32" & os-distribution != "cygwinports"} & "conf-mingw-w64-openssl-i686" {os = "win32" & os-distribution != "cygwinports"} |
-   "host-arch-x86_64" {os = "win32" & os-distribution != "cygwinports"} & "conf-mingw-w64-openssl-x86_64" {os = "win32" & os-distribution != "cygwinports"})
+  ("host-arch-x86_64" {os = "win32" & os-distribution != "cygwinports"} & "conf-mingw-w64-openssl-x86_64" {os = "win32" & os-distribution != "cygwinports"} |
+   "host-arch-x86_32" {os = "win32" & os-distribution != "cygwinports"} & "conf-mingw-w64-openssl-i686" {os = "win32" & os-distribution != "cygwinports"})
 ]
 depexts: [
   ["libssl-dev"] {os-family = "debian"}

--- a/packages/conf-libssl/conf-libssl.4/opam
+++ b/packages/conf-libssl/conf-libssl.4/opam
@@ -8,11 +8,7 @@ build-env: [
   [HOMEBREW_NO_AUTO_UPDATE = "1"]
 ]
 build: [
-  ["pkgconf" {os = "win32" & os-distribution != "cygwinports"}
-   "--personality=i686-w64-mingw32" {os = "win32" & os-distribution != "cygwinports" & host-arch-x86_32:installed}
-   "--personality=x86_64-w64-mingw32" {os = "win32" & os-distribution != "cygwinports" & host-arch-x86_64:installed}
-   "pkg-config" {os != "win32" | os-distribution = "cygwinports"}
-   "--print-errors" "--exists" "openssl"]
+  [conf-pkg-config:command "--print-errors" "--exists" "openssl"]
     {os != "freebsd" & os != "openbsd" & os != "netbsd" & # libssl is provided by base system on BSDs
      os-distribution != "homebrew"}
   ["sh" "-ex" "./homebrew.sh" "check"] {os-distribution = "homebrew"}
@@ -21,7 +17,7 @@ install: [
   ["sh" "-ex" "./homebrew.sh" "install" lib] {os-distribution = "homebrew"}
 ]
 depends: [
-  "conf-pkg-config" {build}
+  "conf-pkg-config" {>= "5"}
   ("host-arch-x86_64" {os = "win32" & os-distribution != "cygwinports"} & "conf-mingw-w64-openssl-x86_64" {os = "win32" & os-distribution != "cygwinports"} |
    "host-arch-x86_32" {os = "win32" & os-distribution != "cygwinports"} & "conf-mingw-w64-openssl-i686" {os = "win32" & os-distribution != "cygwinports"})
 ]

--- a/packages/conf-libssl/conf-libssl.4/opam
+++ b/packages/conf-libssl/conf-libssl.4/opam
@@ -8,7 +8,14 @@ build-env: [
   [HOMEBREW_NO_AUTO_UPDATE = "1"]
 ]
 build: [
-  [conf-pkg-config:command "--print-errors" "--exists" "openssl"]
+  # When the version is next bumped, this package can depend on
+  # conf-pkg-config.5 and instead use:
+  # [conf-pkg-config:command "--print-errors" "--exists" "openssl"]
+  ["pkgconf" {os = "win32" & os-distribution != "cygwinports"}
+   "--personality=i686-w64-mingw32" {os = "win32" & os-distribution != "cygwinports" & host-arch-x86_32:installed}
+   "--personality=x86_64-w64-mingw32" {os = "win32" & os-distribution != "cygwinports" & host-arch-x86_64:installed}
+   "pkg-config" {os != "win32" | os-distribution = "cygwinports"}
+   "--print-errors" "--exists" "openssl"]
     {os != "freebsd" & os != "openbsd" & os != "netbsd" & # libssl is provided by base system on BSDs
      os-distribution != "homebrew"}
   ["sh" "-ex" "./homebrew.sh" "check"] {os-distribution = "homebrew"}
@@ -17,7 +24,7 @@ install: [
   ["sh" "-ex" "./homebrew.sh" "install" lib] {os-distribution = "homebrew"}
 ]
 depends: [
-  "conf-pkg-config" {>= "5"}
+  "conf-pkg-config" {build}
   ("host-arch-x86_64" {os = "win32" & os-distribution != "cygwinports"} & "conf-mingw-w64-openssl-x86_64" {os = "win32" & os-distribution != "cygwinports"} |
    "host-arch-x86_32" {os = "win32" & os-distribution != "cygwinports"} & "conf-mingw-w64-openssl-i686" {os = "win32" & os-distribution != "cygwinports"})
 ]

--- a/packages/conf-ncurses/conf-ncurses.1/opam
+++ b/packages/conf-ncurses/conf-ncurses.1/opam
@@ -5,19 +5,12 @@ authors: "GNU Project"
 bug-reports: "https://github.com/ocaml/opam-repository/issues"
 license: "MIT"
 build: [
-  "pkgconf" {os = "win32" & os-distribution != "cygwinports"}
-  "--personality=i686-w64-mingw32"
-    {os = "win32" & os-distribution != "cygwinports" &
-     host-arch-x86_32:installed}
-  "--personality=x86_64-w64-mingw32"
-    {os = "win32" & os-distribution != "cygwinports" &
-     host-arch-x86_64:installed}
-  "pkg-config" {os-distribution != "cygwin" & os-distribution != "msys2" & os-distribution != "opensuse" & os != "macos" & os != "freebsd" & os != "netbsd" & os != "openbsd"}
-  "ncurses" {os-distribution != "opensuse" & os != "macos" & os != "freebsd" & os != "netbsd" & os != "openbsd" & os-distribution != "msys2"}
-  "ncursesw" {os-distribution = "msys2"} # MSys2 packages compatible ncursesw https://packages.msys2.org/packages/mingw-w64-x86_64-ncurses
+  # MSys2 packages compatible ncursesw https://packages.msys2.org/packages/mingw-w64-x86_64-ncurses
+  [conf-pkg-config:command "ncurses" {os-distribution != "msys2"} "ncursesw" {os-distribution = "msys2"}]
+    {os-distribution != "opensuse" & os != "macos" & os != "freebsd" & os != "netbsd" & os != "openbsd"}
 ]
 depends: [
-  "conf-pkg-config" {build & os-distribution != "opensuse" & os != "macos" & os != "freebsd" & os != "netbsd" & os != "openbsd"}
+  "conf-pkg-config" {>= "5" & os-distribution != "opensuse" & os != "macos" & os != "freebsd" & os != "netbsd" & os != "openbsd"}
   ("host-arch-x86_64" {os = "win32" & os-distribution != "cygwinports"} &
    "conf-mingw-w64-ncurses-x86_64"
      {os = "win32" & os-distribution != "cygwinports"} |

--- a/packages/conf-ncurses/conf-ncurses.1/opam
+++ b/packages/conf-ncurses/conf-ncurses.1/opam
@@ -18,11 +18,11 @@ build: [
 ]
 depends: [
   "conf-pkg-config" {build & os-distribution != "opensuse" & os != "macos" & os != "freebsd" & os != "netbsd" & os != "openbsd"}
-  ("host-arch-x86_32" {os = "win32" & os-distribution != "cygwinports"} &
-   "conf-mingw-w64-ncurses-i686"
-     {os = "win32" & os-distribution != "cygwinports"} |
-   "host-arch-x86_64" {os = "win32" & os-distribution != "cygwinports"} &
+  ("host-arch-x86_64" {os = "win32" & os-distribution != "cygwinports"} &
    "conf-mingw-w64-ncurses-x86_64"
+     {os = "win32" & os-distribution != "cygwinports"} |
+   "host-arch-x86_32" {os = "win32" & os-distribution != "cygwinports"} &
+   "conf-mingw-w64-ncurses-i686"
      {os = "win32" & os-distribution != "cygwinports"})
 ]
 depexts: [

--- a/packages/conf-ncurses/conf-ncurses.1/opam
+++ b/packages/conf-ncurses/conf-ncurses.1/opam
@@ -5,12 +5,24 @@ authors: "GNU Project"
 bug-reports: "https://github.com/ocaml/opam-repository/issues"
 license: "MIT"
 build: [
-  # MSys2 packages compatible ncursesw https://packages.msys2.org/packages/mingw-w64-x86_64-ncurses
-  [conf-pkg-config:command "ncurses" {os-distribution != "msys2"} "ncursesw" {os-distribution = "msys2"}]
-    {os-distribution != "opensuse" & os != "macos" & os != "freebsd" & os != "netbsd" & os != "openbsd"}
+  # When the version is next bumped, this package can depend on
+  # conf-pkg-config.5 and instead use:
+  # # MSys2 packages compatible ncursesw https://packages.msys2.org/packages/mingw-w64-x86_64-ncurses
+  # [conf-pkg-config:command "ncurses" {os-distribution != "msys2"} "ncursesw" {os-distribution = "msys2"}]
+  #   {os-distribution != "opensuse" & os != "macos" & os != "freebsd" & os != "netbsd" & os != "openbsd"}
+  "pkgconf" {os = "win32" & os-distribution != "cygwinports"}
+  "--personality=i686-w64-mingw32"
+    {os = "win32" & os-distribution != "cygwinports" &
+     host-arch-x86_32:installed}
+  "--personality=x86_64-w64-mingw32"
+    {os = "win32" & os-distribution != "cygwinports" &
+     host-arch-x86_64:installed}
+  "pkg-config" {os-distribution != "cygwin" & os-distribution != "msys2" & os-distribution != "opensuse" & os != "macos" & os != "freebsd" & os != "netbsd" & os != "openbsd"}
+  "ncurses" {os-distribution != "opensuse" & os != "macos" & os != "freebsd" & os != "netbsd" & os != "openbsd" & os-distribution != "msys2"}
+  "ncursesw" {os-distribution = "msys2"} # MSys2 packages compatible ncursesw https://packages.msys2.org/packages/mingw-w64-x86_64-ncurses
 ]
 depends: [
-  "conf-pkg-config" {>= "5" & os-distribution != "opensuse" & os != "macos" & os != "freebsd" & os != "netbsd" & os != "openbsd"}
+  "conf-pkg-config" {build & os-distribution != "opensuse" & os != "macos" & os != "freebsd" & os != "netbsd" & os != "openbsd"}
   ("host-arch-x86_64" {os = "win32" & os-distribution != "cygwinports"} &
    "conf-mingw-w64-ncurses-x86_64"
      {os = "win32" & os-distribution != "cygwinports"} |

--- a/packages/conf-postgresql/conf-postgresql.2/opam
+++ b/packages/conf-postgresql/conf-postgresql.2/opam
@@ -5,14 +5,10 @@ homepage: "https://www.postgresql.org"
 dev-repo: "git+https://github.com/mmottl/postgresql-ocaml.git"
 license: "blessing"
 build: [
-  ["pkgconf" {os = "win32" & os-distribution != "cygwinports"}
-   "--personality=i686-w64-mingw32" {os = "win32" & os-distribution != "cygwinports" & host-arch-x86_32:installed}
-   "--personality=x86_64-w64-mingw32" {os = "win32" & os-distribution != "cygwinports" & host-arch-x86_64:installed}
-   "pkg-config" {os != "win32" | os-distribution = "cygwinports"}
-  "libpq"]
+  [conf-pkg-config:command "libpq"]
 ]
 depends: [
-  "conf-pkg-config" {build}
+  "conf-pkg-config" {>= "5"}
   ("host-arch-x86_64" {os = "win32" & os-distribution != "cygwinports"} & "conf-mingw-w64-postgresql-x86_64" {os = "win32" & os-distribution != "cygwinports"} |
    "host-arch-x86_32" {os = "win32" & os-distribution != "cygwinports"} & "conf-mingw-w64-postgresql-i686" {os = "win32" & os-distribution != "cygwinports"})
 ]

--- a/packages/conf-postgresql/conf-postgresql.2/opam
+++ b/packages/conf-postgresql/conf-postgresql.2/opam
@@ -13,8 +13,8 @@ build: [
 ]
 depends: [
   "conf-pkg-config" {build}
-  ("host-arch-x86_32" {os = "win32" & os-distribution != "cygwinports"} & "conf-mingw-w64-postgresql-i686" {os = "win32" & os-distribution != "cygwinports"} |
-   "host-arch-x86_64" {os = "win32" & os-distribution != "cygwinports"} & "conf-mingw-w64-postgresql-x86_64" {os = "win32" & os-distribution != "cygwinports"})
+  ("host-arch-x86_64" {os = "win32" & os-distribution != "cygwinports"} & "conf-mingw-w64-postgresql-x86_64" {os = "win32" & os-distribution != "cygwinports"} |
+   "host-arch-x86_32" {os = "win32" & os-distribution != "cygwinports"} & "conf-mingw-w64-postgresql-i686" {os = "win32" & os-distribution != "cygwinports"})
 ]
 bug-reports: "https://github.com/ocaml/opam-repository/issues"
 

--- a/packages/conf-postgresql/conf-postgresql.2/opam
+++ b/packages/conf-postgresql/conf-postgresql.2/opam
@@ -5,10 +5,17 @@ homepage: "https://www.postgresql.org"
 dev-repo: "git+https://github.com/mmottl/postgresql-ocaml.git"
 license: "blessing"
 build: [
-  [conf-pkg-config:command "libpq"]
+  # When the version is next bumped, this package can depend on
+  # conf-pkg-config.5 and instead use:
+  # [conf-pkg-config:command "libpq"]
+  ["pkgconf" {os = "win32" & os-distribution != "cygwinports"}
+   "--personality=i686-w64-mingw32" {os = "win32" & os-distribution != "cygwinports" & host-arch-x86_32:installed}
+   "--personality=x86_64-w64-mingw32" {os = "win32" & os-distribution != "cygwinports" & host-arch-x86_64:installed}
+   "pkg-config" {os != "win32" | os-distribution = "cygwinports"}
+  "libpq"]
 ]
 depends: [
-  "conf-pkg-config" {>= "5"}
+  "conf-pkg-config" {build}
   ("host-arch-x86_64" {os = "win32" & os-distribution != "cygwinports"} & "conf-mingw-w64-postgresql-x86_64" {os = "win32" & os-distribution != "cygwinports"} |
    "host-arch-x86_32" {os = "win32" & os-distribution != "cygwinports"} & "conf-mingw-w64-postgresql-i686" {os = "win32" & os-distribution != "cygwinports"})
 ]

--- a/packages/conf-sdl2-image/conf-sdl2-image.1/opam
+++ b/packages/conf-sdl2-image/conf-sdl2-image.1/opam
@@ -28,8 +28,8 @@ description:
   "This package can only install if libsdl2-image is installed on the system."
 depends: [
   "conf-pkg-config" {build}
-  ("host-arch-x86_32" {os = "win32" & os-distribution != "cygwinports"} & "conf-mingw-w64-sdl2-image-i686" {os = "win32" & os-distribution != "cygwinports"} |
-   "host-arch-x86_64" {os = "win32" & os-distribution != "cygwinports"} & "conf-mingw-w64-sdl2-image-x86_64" {os = "win32" & os-distribution != "cygwinports"})
+  ("host-arch-x86_64" {os = "win32" & os-distribution != "cygwinports"} & "conf-mingw-w64-sdl2-image-x86_64" {os = "win32" & os-distribution != "cygwinports"} |
+   "host-arch-x86_32" {os = "win32" & os-distribution != "cygwinports"} & "conf-mingw-w64-sdl2-image-i686" {os = "win32" & os-distribution != "cygwinports"})
 ]
 bug-reports: "https://github.com/ocaml/opam-repository/issues"
 authors: "Sam Lantinga"

--- a/packages/conf-sdl2-image/conf-sdl2-image.1/opam
+++ b/packages/conf-sdl2-image/conf-sdl2-image.1/opam
@@ -3,9 +3,7 @@ maintainer: "https://github.com/ocaml/opam-repository/issues"
 homepage: "http://www.libsdl.org/projects/SDL_image/"
 license: "Zlib"
 build: [
-  ["pkgconf" "--personality=i686-w64-mingw32" "SDL2_image"] {os = "win32" & os-distribution != "cygwinports" & host-arch-x86_32:installed}
-  ["pkgconf" "--personality=x86_64-w64-mingw32" "SDL2_image"] {os = "win32" & os-distribution != "cygwinports" & host-arch-x86_64:installed}
-  ["pkg-config" "SDL2_image"] {os != "win32" | os-distribution = "cygwinports"}
+  [conf-pkg-config:command "SDL2_image"]
 ]
 depexts: [
   ["sdl2_image-dev"] {os-distribution = "alpine"}
@@ -27,7 +25,7 @@ synopsis: "Virtual package relying on a sdl2-image system installation"
 description:
   "This package can only install if libsdl2-image is installed on the system."
 depends: [
-  "conf-pkg-config" {build}
+  "conf-pkg-config" {>= "5"}
   ("host-arch-x86_64" {os = "win32" & os-distribution != "cygwinports"} & "conf-mingw-w64-sdl2-image-x86_64" {os = "win32" & os-distribution != "cygwinports"} |
    "host-arch-x86_32" {os = "win32" & os-distribution != "cygwinports"} & "conf-mingw-w64-sdl2-image-i686" {os = "win32" & os-distribution != "cygwinports"})
 ]

--- a/packages/conf-sdl2-image/conf-sdl2-image.1/opam
+++ b/packages/conf-sdl2-image/conf-sdl2-image.1/opam
@@ -3,7 +3,12 @@ maintainer: "https://github.com/ocaml/opam-repository/issues"
 homepage: "http://www.libsdl.org/projects/SDL_image/"
 license: "Zlib"
 build: [
-  [conf-pkg-config:command "SDL2_image"]
+  # When the version is next bumped, this package can depend on
+  # conf-pkg-config.5 and instead use:
+  # [conf-pkg-config:command "SDL2_image"]
+  ["pkgconf" "--personality=i686-w64-mingw32" "SDL2_image"] {os = "win32" & os-distribution != "cygwinports" & host-arch-x86_32:installed}
+  ["pkgconf" "--personality=x86_64-w64-mingw32" "SDL2_image"] {os = "win32" & os-distribution != "cygwinports" & host-arch-x86_64:installed}
+  ["pkg-config" "SDL2_image"] {os != "win32" | os-distribution = "cygwinports"}
 ]
 depexts: [
   ["sdl2_image-dev"] {os-distribution = "alpine"}
@@ -25,7 +30,7 @@ synopsis: "Virtual package relying on a sdl2-image system installation"
 description:
   "This package can only install if libsdl2-image is installed on the system."
 depends: [
-  "conf-pkg-config" {>= "5"}
+  "conf-pkg-config" {build}
   ("host-arch-x86_64" {os = "win32" & os-distribution != "cygwinports"} & "conf-mingw-w64-sdl2-image-x86_64" {os = "win32" & os-distribution != "cygwinports"} |
    "host-arch-x86_32" {os = "win32" & os-distribution != "cygwinports"} & "conf-mingw-w64-sdl2-image-i686" {os = "win32" & os-distribution != "cygwinports"})
 ]

--- a/packages/conf-sdl2-mixer/conf-sdl2-mixer.1/opam
+++ b/packages/conf-sdl2-mixer/conf-sdl2-mixer.1/opam
@@ -3,9 +3,7 @@ maintainer: "https://github.com/ocaml/opam-repository/issues"
 homepage: "http://www.libsdl.org/projects/SDL_mixer/"
 license: "Zlib"
 build: [
-  ["pkgconf" "--personality=i686-w64-mingw32" "SDL2_mixer"] {os = "win32" & os-distribution != "cygwinports" & host-arch-x86_32:installed}
-  ["pkgconf" "--personality=x86_64-w64-mingw32" "SDL2_mixer"] {os = "win32" & os-distribution != "cygwinports" & host-arch-x86_64:installed}
-  ["pkg-config" "SDL2_mixer"] {os != "win32" | os-distribution = "cygwinports"}
+  [conf-pkg-config:command "SDL2_mixer"]
 ]
 depexts: [
   ["sdl2_mixer-dev"] {os-family = "alpine"}
@@ -26,7 +24,7 @@ synopsis: "Virtual package relying on a sdl2-mixer system installation"
 description:
   "This package can only install if libsdl2-mixer is installed on the system."
 depends: [
-  "conf-pkg-config" {build}
+  "conf-pkg-config" {>= "5"}
   ("host-arch-x86_64" {os = "win32" & os-distribution != "cygwinports"} & "conf-mingw-w64-sdl2-mixer-x86_64" {os = "win32" & os-distribution != "cygwinports"} |
    "host-arch-x86_32" {os = "win32" & os-distribution != "cygwinports"} & "conf-mingw-w64-sdl2-mixer-i686" {os = "win32" & os-distribution != "cygwinports"})
 ]

--- a/packages/conf-sdl2-mixer/conf-sdl2-mixer.1/opam
+++ b/packages/conf-sdl2-mixer/conf-sdl2-mixer.1/opam
@@ -3,7 +3,12 @@ maintainer: "https://github.com/ocaml/opam-repository/issues"
 homepage: "http://www.libsdl.org/projects/SDL_mixer/"
 license: "Zlib"
 build: [
-  [conf-pkg-config:command "SDL2_mixer"]
+  # When the version is next bumped, this package can depend on
+  # conf-pkg-config.5 and instead use:
+  # [conf-pkg-config:command "SDL2_mixer"]
+  ["pkgconf" "--personality=i686-w64-mingw32" "SDL2_mixer"] {os = "win32" & os-distribution != "cygwinports" & host-arch-x86_32:installed}
+  ["pkgconf" "--personality=x86_64-w64-mingw32" "SDL2_mixer"] {os = "win32" & os-distribution != "cygwinports" & host-arch-x86_64:installed}
+  ["pkg-config" "SDL2_mixer"] {os != "win32" | os-distribution = "cygwinports"}
 ]
 depexts: [
   ["sdl2_mixer-dev"] {os-family = "alpine"}
@@ -24,7 +29,7 @@ synopsis: "Virtual package relying on a sdl2-mixer system installation"
 description:
   "This package can only install if libsdl2-mixer is installed on the system."
 depends: [
-  "conf-pkg-config" {>= "5"}
+  "conf-pkg-config" {build}
   ("host-arch-x86_64" {os = "win32" & os-distribution != "cygwinports"} & "conf-mingw-w64-sdl2-mixer-x86_64" {os = "win32" & os-distribution != "cygwinports"} |
    "host-arch-x86_32" {os = "win32" & os-distribution != "cygwinports"} & "conf-mingw-w64-sdl2-mixer-i686" {os = "win32" & os-distribution != "cygwinports"})
 ]

--- a/packages/conf-sdl2-mixer/conf-sdl2-mixer.1/opam
+++ b/packages/conf-sdl2-mixer/conf-sdl2-mixer.1/opam
@@ -27,8 +27,8 @@ description:
   "This package can only install if libsdl2-mixer is installed on the system."
 depends: [
   "conf-pkg-config" {build}
-  ("host-arch-x86_32" {os = "win32" & os-distribution != "cygwinports"} & "conf-mingw-w64-sdl2-mixer-i686" {os = "win32" & os-distribution != "cygwinports"} |
-   "host-arch-x86_64" {os = "win32" & os-distribution != "cygwinports"} & "conf-mingw-w64-sdl2-mixer-x86_64" {os = "win32" & os-distribution != "cygwinports"})
+  ("host-arch-x86_64" {os = "win32" & os-distribution != "cygwinports"} & "conf-mingw-w64-sdl2-mixer-x86_64" {os = "win32" & os-distribution != "cygwinports"} |
+   "host-arch-x86_32" {os = "win32" & os-distribution != "cygwinports"} & "conf-mingw-w64-sdl2-mixer-i686" {os = "win32" & os-distribution != "cygwinports"})
 ]
 bug-reports: "https://github.com/ocaml/opam-repository/issues"
 authors: "Sam Lantinga"

--- a/packages/conf-sdl2-net/conf-sdl2-net.1/opam
+++ b/packages/conf-sdl2-net/conf-sdl2-net.1/opam
@@ -3,9 +3,7 @@ maintainer: "https://github.com/ocaml/opam-repository/issues"
 homepage: "http://www.libsdl.org/projects/SDL_net/"
 license: "Zlib"
 build: [
-  ["pkgconf" "--personality=i686-w64-mingw32" "SDL2_net"] {os = "win32" & os-distribution != "cygwinports" & host-arch-x86_32:installed}
-  ["pkgconf" "--personality=x86_64-w64-mingw32" "SDL2_net"] {os = "win32" & os-distribution != "cygwinports" & host-arch-x86_64:installed}
-  ["pkg-config" "SDL2_net"] {os != "win32" | os-distribution = "cygwinports"}
+  [conf-pkg-config:command "SDL2_net"]
 ]
 depexts: [
   ["sdl2_net"] {os-family = "arch"}
@@ -28,7 +26,7 @@ synopsis: "Virtual package relying on a sdl2-net system installation"
 description:
   "This package can only install if libsdl2-net is installed on the system."
 depends: [
-  "conf-pkg-config" {build}
+  "conf-pkg-config" {>= "5"}
   ("host-arch-x86_64" {os = "win32" & os-distribution != "cygwinports"} & "conf-mingw-w64-sdl2-net-x86_64" {os = "win32" & os-distribution != "cygwinports"} |
    "host-arch-x86_32" {os = "win32" & os-distribution != "cygwinports"} & "conf-mingw-w64-sdl2-net-i686" {os = "win32" & os-distribution != "cygwinports"})
 ]

--- a/packages/conf-sdl2-net/conf-sdl2-net.1/opam
+++ b/packages/conf-sdl2-net/conf-sdl2-net.1/opam
@@ -3,7 +3,12 @@ maintainer: "https://github.com/ocaml/opam-repository/issues"
 homepage: "http://www.libsdl.org/projects/SDL_net/"
 license: "Zlib"
 build: [
-  [conf-pkg-config:command "SDL2_net"]
+  # When the version is next bumped, this package can depend on
+  # conf-pkg-config.5 and instead use:
+  # [conf-pkg-config:command "SDL2_net"]
+  ["pkgconf" "--personality=i686-w64-mingw32" "SDL2_net"] {os = "win32" & os-distribution != "cygwinports" & host-arch-x86_32:installed}
+  ["pkgconf" "--personality=x86_64-w64-mingw32" "SDL2_net"] {os = "win32" & os-distribution != "cygwinports" & host-arch-x86_64:installed}
+  ["pkg-config" "SDL2_net"] {os != "win32" | os-distribution = "cygwinports"}
 ]
 depexts: [
   ["sdl2_net"] {os-family = "arch"}
@@ -26,7 +31,7 @@ synopsis: "Virtual package relying on a sdl2-net system installation"
 description:
   "This package can only install if libsdl2-net is installed on the system."
 depends: [
-  "conf-pkg-config" {>= "5"}
+  "conf-pkg-config" {build}
   ("host-arch-x86_64" {os = "win32" & os-distribution != "cygwinports"} & "conf-mingw-w64-sdl2-net-x86_64" {os = "win32" & os-distribution != "cygwinports"} |
    "host-arch-x86_32" {os = "win32" & os-distribution != "cygwinports"} & "conf-mingw-w64-sdl2-net-i686" {os = "win32" & os-distribution != "cygwinports"})
 ]

--- a/packages/conf-sdl2-net/conf-sdl2-net.1/opam
+++ b/packages/conf-sdl2-net/conf-sdl2-net.1/opam
@@ -29,8 +29,8 @@ description:
   "This package can only install if libsdl2-net is installed on the system."
 depends: [
   "conf-pkg-config" {build}
-  ("host-arch-x86_32" {os = "win32" & os-distribution != "cygwinports"} & "conf-mingw-w64-sdl2-net-i686" {os = "win32" & os-distribution != "cygwinports"} |
-   "host-arch-x86_64" {os = "win32" & os-distribution != "cygwinports"} & "conf-mingw-w64-sdl2-net-x86_64" {os = "win32" & os-distribution != "cygwinports"})
+  ("host-arch-x86_64" {os = "win32" & os-distribution != "cygwinports"} & "conf-mingw-w64-sdl2-net-x86_64" {os = "win32" & os-distribution != "cygwinports"} |
+   "host-arch-x86_32" {os = "win32" & os-distribution != "cygwinports"} & "conf-mingw-w64-sdl2-net-i686" {os = "win32" & os-distribution != "cygwinports"})
 ]
 bug-reports: "https://github.com/ocaml/opam-repository/issues"
 authors: "Sam Lantinga"

--- a/packages/conf-sdl2-ttf/conf-sdl2-ttf.1/opam
+++ b/packages/conf-sdl2-ttf/conf-sdl2-ttf.1/opam
@@ -3,10 +3,15 @@ maintainer: "https://github.com/ocaml/opam-repository/issues"
 homepage: "http://www.libsdl.org/projects/SDL_ttf/"
 license: "Zlib"
 build: [
-  [conf-pkg-config:command "SDL2_ttf"]
+  # When the version is next bumped, this package can depend on
+  # conf-pkg-config.5 and instead use:
+  # [conf-pkg-config:command "SDL2_ttf"]
+  ["pkgconf" "--personality=i686-w64-mingw32" "SDL2_ttf"] {os = "win32" & os-distribution != "cygwinports" & host-arch-x86_32:installed}
+  ["pkgconf" "--personality=x86_64-w64-mingw32" "SDL2_ttf"] {os = "win32" & os-distribution != "cygwinports" & host-arch-x86_64:installed}
+  ["pkg-config" "SDL2_ttf"] {os != "win32" | os-distribution = "cygwinports"}
 ]
 depends: [
-  "conf-pkg-config" {>= "5"}
+  "conf-pkg-config" {build}
   ("host-arch-x86_64" {os = "win32" & os-distribution != "cygwinports"} & "conf-mingw-w64-sdl2-ttf-x86_64" {os = "win32" & os-distribution != "cygwinports"} |
    "host-arch-x86_32" {os = "win32" & os-distribution != "cygwinports"} & "conf-mingw-w64-sdl2-ttf-i686" {os = "win32" & os-distribution != "cygwinports"})
 ]

--- a/packages/conf-sdl2-ttf/conf-sdl2-ttf.1/opam
+++ b/packages/conf-sdl2-ttf/conf-sdl2-ttf.1/opam
@@ -3,12 +3,10 @@ maintainer: "https://github.com/ocaml/opam-repository/issues"
 homepage: "http://www.libsdl.org/projects/SDL_ttf/"
 license: "Zlib"
 build: [
-  ["pkgconf" "--personality=i686-w64-mingw32" "SDL2_ttf"] {os = "win32" & os-distribution != "cygwinports" & host-arch-x86_32:installed}
-  ["pkgconf" "--personality=x86_64-w64-mingw32" "SDL2_ttf"] {os = "win32" & os-distribution != "cygwinports" & host-arch-x86_64:installed}
-  ["pkg-config" "SDL2_ttf"] {os != "win32" | os-distribution = "cygwinports"}
+  [conf-pkg-config:command "SDL2_ttf"]
 ]
 depends: [
-  "conf-pkg-config" {build}
+  "conf-pkg-config" {>= "5"}
   ("host-arch-x86_64" {os = "win32" & os-distribution != "cygwinports"} & "conf-mingw-w64-sdl2-ttf-x86_64" {os = "win32" & os-distribution != "cygwinports"} |
    "host-arch-x86_32" {os = "win32" & os-distribution != "cygwinports"} & "conf-mingw-w64-sdl2-ttf-i686" {os = "win32" & os-distribution != "cygwinports"})
 ]

--- a/packages/conf-sdl2-ttf/conf-sdl2-ttf.1/opam
+++ b/packages/conf-sdl2-ttf/conf-sdl2-ttf.1/opam
@@ -9,8 +9,8 @@ build: [
 ]
 depends: [
   "conf-pkg-config" {build}
-  ("host-arch-x86_32" {os = "win32" & os-distribution != "cygwinports"} & "conf-mingw-w64-sdl2-ttf-i686" {os = "win32" & os-distribution != "cygwinports"} |
-   "host-arch-x86_64" {os = "win32" & os-distribution != "cygwinports"} & "conf-mingw-w64-sdl2-ttf-x86_64" {os = "win32" & os-distribution != "cygwinports"})
+  ("host-arch-x86_64" {os = "win32" & os-distribution != "cygwinports"} & "conf-mingw-w64-sdl2-ttf-x86_64" {os = "win32" & os-distribution != "cygwinports"} |
+   "host-arch-x86_32" {os = "win32" & os-distribution != "cygwinports"} & "conf-mingw-w64-sdl2-ttf-i686" {os = "win32" & os-distribution != "cygwinports"})
 ]
 depexts: [
   ["sdl2_ttf-dev"] {os-family = "alpine"}

--- a/packages/conf-sdl2/conf-sdl2.1/opam
+++ b/packages/conf-sdl2/conf-sdl2.1/opam
@@ -5,7 +5,18 @@ homepage: "http://libsdl.org/"
 bug-reports: "https://github.com/ocaml/opam-repository/issues"
 license: "Zlib"
 build: [
-  [conf-pkg-config:command "sdl2"]
+  # When the version is next bumped, this package can depend on
+  # conf-pkg-config.5 and instead use:
+  # [conf-pkg-config:command "sdl2"]
+  "pkgconf" {os = "win32" & os-distribution != "cygwinports"}
+  "--personality=i686-w64-mingw32"
+    {os = "win32" & os-distribution != "cygwinports" &
+     host-arch-x86_32:installed}
+  "--personality=x86_64-w64-mingw32"
+    {os = "win32" & os-distribution != "cygwinports" &
+     host-arch-x86_64:installed}
+  "pkg-config" {os != "win32" | os-distribution = "cygwinports"}
+  "sdl2"
 ]
 depexts: [
   ["sdl2-dev"] {os-distribution = "alpine"}
@@ -29,7 +40,7 @@ synopsis: "Virtual package relying on a SDL2 system installation"
 description:
   "This package can only install if libSDL2 is installed on the system."
 depends: [
-  "conf-pkg-config" {>= "5"}
+  "conf-pkg-config" {build}
   ("host-arch-x86_64" {os = "win32" & os-distribution != "cygwinports"} &
    "conf-mingw-w64-sdl2-x86_64"
      {os = "win32" & os-distribution != "cygwinports"} |

--- a/packages/conf-sdl2/conf-sdl2.1/opam
+++ b/packages/conf-sdl2/conf-sdl2.1/opam
@@ -5,15 +5,7 @@ homepage: "http://libsdl.org/"
 bug-reports: "https://github.com/ocaml/opam-repository/issues"
 license: "Zlib"
 build: [
-  "pkgconf" {os = "win32" & os-distribution != "cygwinports"}
-  "--personality=i686-w64-mingw32"
-    {os = "win32" & os-distribution != "cygwinports" &
-     host-arch-x86_32:installed}
-  "--personality=x86_64-w64-mingw32"
-    {os = "win32" & os-distribution != "cygwinports" &
-     host-arch-x86_64:installed}
-  "pkg-config" {os != "win32" | os-distribution = "cygwinports"}
-  "sdl2"
+  [conf-pkg-config:command "sdl2"]
 ]
 depexts: [
   ["sdl2-dev"] {os-distribution = "alpine"}
@@ -37,7 +29,7 @@ synopsis: "Virtual package relying on a SDL2 system installation"
 description:
   "This package can only install if libSDL2 is installed on the system."
 depends: [
-  "conf-pkg-config" {build}
+  "conf-pkg-config" {>= "5"}
   ("host-arch-x86_64" {os = "win32" & os-distribution != "cygwinports"} &
    "conf-mingw-w64-sdl2-x86_64"
      {os = "win32" & os-distribution != "cygwinports"} |

--- a/packages/conf-sdl2/conf-sdl2.1/opam
+++ b/packages/conf-sdl2/conf-sdl2.1/opam
@@ -38,11 +38,11 @@ description:
   "This package can only install if libSDL2 is installed on the system."
 depends: [
   "conf-pkg-config" {build}
-  ("host-arch-x86_32" {os = "win32" & os-distribution != "cygwinports"} &
-   "conf-mingw-w64-sdl2-i686"
-     {os = "win32" & os-distribution != "cygwinports"} |
-   "host-arch-x86_64" {os = "win32" & os-distribution != "cygwinports"} &
+  ("host-arch-x86_64" {os = "win32" & os-distribution != "cygwinports"} &
    "conf-mingw-w64-sdl2-x86_64"
+     {os = "win32" & os-distribution != "cygwinports"} |
+   "host-arch-x86_32" {os = "win32" & os-distribution != "cygwinports"} &
+   "conf-mingw-w64-sdl2-i686"
      {os = "win32" & os-distribution != "cygwinports"})
 ]
 flags: conf

--- a/packages/conf-sqlite3/conf-sqlite3.1/opam
+++ b/packages/conf-sqlite3/conf-sqlite3.1/opam
@@ -17,8 +17,8 @@ build: [
 ]
 depends: [
   "conf-pkg-config" {build}
-  ("host-arch-x86_32" {os = "win32" & os-distribution != "cygwinports"} & "conf-mingw-w64-sqlite3-i686" {os = "win32" & os-distribution != "cygwinports"} |
-   "host-arch-x86_64" {os = "win32" & os-distribution != "cygwinports"} & "conf-mingw-w64-sqlite3-x86_64" {os = "win32" & os-distribution != "cygwinports"})
+  ("host-arch-x86_64" {os = "win32" & os-distribution != "cygwinports"} & "conf-mingw-w64-sqlite3-x86_64" {os = "win32" & os-distribution != "cygwinports"} |
+   "host-arch-x86_32" {os = "win32" & os-distribution != "cygwinports"} & "conf-mingw-w64-sqlite3-i686" {os = "win32" & os-distribution != "cygwinports"})
 ]
 bug-reports: "https://github.com/ocaml/opam-repository/issues"
 

--- a/packages/conf-sqlite3/conf-sqlite3.1/opam
+++ b/packages/conf-sqlite3/conf-sqlite3.1/opam
@@ -9,14 +9,10 @@ homepage: "http://www.sqlite3.org"
 dev-repo: "git+https://github.com/mmottl/sqlite3-ocaml.git"
 license: "blessing"
 build: [
-  ["pkgconf" {os = "win32" & os-distribution != "cygwinports"}
-   "--personality=i686-w64-mingw32" {os = "win32" & os-distribution != "cygwinports" & host-arch-x86_32:installed}
-   "--personality=x86_64-w64-mingw32" {os = "win32" & os-distribution != "cygwinports" & host-arch-x86_64:installed}
-   "pkg-config" {os != "win32" | os-distribution = "cygwinports"}
-  "sqlite3"]
+  [conf-pkg-config:command "sqlite3"]
 ]
 depends: [
-  "conf-pkg-config" {build}
+  "conf-pkg-config" {>= "5"}
   ("host-arch-x86_64" {os = "win32" & os-distribution != "cygwinports"} & "conf-mingw-w64-sqlite3-x86_64" {os = "win32" & os-distribution != "cygwinports"} |
    "host-arch-x86_32" {os = "win32" & os-distribution != "cygwinports"} & "conf-mingw-w64-sqlite3-i686" {os = "win32" & os-distribution != "cygwinports"})
 ]

--- a/packages/conf-sqlite3/conf-sqlite3.1/opam
+++ b/packages/conf-sqlite3/conf-sqlite3.1/opam
@@ -9,10 +9,17 @@ homepage: "http://www.sqlite3.org"
 dev-repo: "git+https://github.com/mmottl/sqlite3-ocaml.git"
 license: "blessing"
 build: [
-  [conf-pkg-config:command "sqlite3"]
+  # When the version is next bumped, this package can depend on
+  # conf-pkg-config.5 and instead use:
+  # [conf-pkg-config:command "sqlite3"]
+  ["pkgconf" {os = "win32" & os-distribution != "cygwinports"}
+   "--personality=i686-w64-mingw32" {os = "win32" & os-distribution != "cygwinports" & host-arch-x86_32:installed}
+   "--personality=x86_64-w64-mingw32" {os = "win32" & os-distribution != "cygwinports" & host-arch-x86_64:installed}
+   "pkg-config" {os != "win32" | os-distribution = "cygwinports"}
+  "sqlite3"]
 ]
 depends: [
-  "conf-pkg-config" {>= "5"}
+  "conf-pkg-config" {build}
   ("host-arch-x86_64" {os = "win32" & os-distribution != "cygwinports"} & "conf-mingw-w64-sqlite3-x86_64" {os = "win32" & os-distribution != "cygwinports"} |
    "host-arch-x86_32" {os = "win32" & os-distribution != "cygwinports"} & "conf-mingw-w64-sqlite3-i686" {os = "win32" & os-distribution != "cygwinports"})
 ]

--- a/packages/conf-zlib/conf-zlib.1/opam
+++ b/packages/conf-zlib/conf-zlib.1/opam
@@ -12,8 +12,8 @@ build:
    "zlib"]
 depends: [
   "conf-pkg-config" {build}
-  (("host-arch-x86_32" {os = "win32" & os-distribution != "cygwinports"} & "conf-mingw-w64-zlib-i686" {os = "win32" & os-distribution != "cygwinports"}) |
-   ("host-arch-x86_64" {os = "win32" & os-distribution != "cygwinports"} & "conf-mingw-w64-zlib-x86_64" {os = "win32" & os-distribution != "cygwinports"}))
+  (("host-arch-x86_64" {os = "win32" & os-distribution != "cygwinports"} & "conf-mingw-w64-zlib-x86_64" {os = "win32" & os-distribution != "cygwinports"}) |
+   ("host-arch-x86_32" {os = "win32" & os-distribution != "cygwinports"} & "conf-mingw-w64-zlib-i686" {os = "win32" & os-distribution != "cygwinports"}))
 ]
 depexts: [
   ["zlib-dev"] {os-distribution = "alpine"}

--- a/packages/conf-zlib/conf-zlib.1/opam
+++ b/packages/conf-zlib/conf-zlib.1/opam
@@ -5,13 +5,9 @@ bug-reports: "https://github.com/ocaml/opam-repository/issues"
 authors: ["Jean-loup Gailly" "Mark Adler"]
 license: "zlib"
 build:
-  ["pkgconf" {os = "win32" & os-distribution != "cygwinports"}
-   "pkg-config" {os != "win32" | os-distribution = "cygwinports"}
-   "--personality=i686-w64-mingw32" {os = "win32" & os-distribution != "cygwinports" & host-arch-x86_32:installed}
-   "--personality=x86_64-w64-mingw32" {os = "win32" & os-distribution != "cygwinports" & host-arch-x86_64:installed}
-   "zlib"]
+  [conf-pkg-config:command "zlib"]
 depends: [
-  "conf-pkg-config" {build}
+  "conf-pkg-config" {>= "5"}
   (("host-arch-x86_64" {os = "win32" & os-distribution != "cygwinports"} & "conf-mingw-w64-zlib-x86_64" {os = "win32" & os-distribution != "cygwinports"}) |
    ("host-arch-x86_32" {os = "win32" & os-distribution != "cygwinports"} & "conf-mingw-w64-zlib-i686" {os = "win32" & os-distribution != "cygwinports"}))
 ]

--- a/packages/conf-zlib/conf-zlib.1/opam
+++ b/packages/conf-zlib/conf-zlib.1/opam
@@ -5,9 +5,16 @@ bug-reports: "https://github.com/ocaml/opam-repository/issues"
 authors: ["Jean-loup Gailly" "Mark Adler"]
 license: "zlib"
 build:
-  [conf-pkg-config:command "zlib"]
+  # When the version is next bumped, this package can depend on
+  # conf-pkg-config.5 and instead use:
+  # [conf-pkg-config:command "zlib"]
+  ["pkgconf" {os = "win32" & os-distribution != "cygwinports"}
+   "pkg-config" {os != "win32" | os-distribution = "cygwinports"}
+   "--personality=i686-w64-mingw32" {os = "win32" & os-distribution != "cygwinports" & host-arch-x86_32:installed}
+   "--personality=x86_64-w64-mingw32" {os = "win32" & os-distribution != "cygwinports" & host-arch-x86_64:installed}
+   "zlib"]
 depends: [
-  "conf-pkg-config" {>= "5"}
+  "conf-pkg-config" {build}
   (("host-arch-x86_64" {os = "win32" & os-distribution != "cygwinports"} & "conf-mingw-w64-zlib-x86_64" {os = "win32" & os-distribution != "cygwinports"}) |
    ("host-arch-x86_32" {os = "win32" & os-distribution != "cygwinports"} & "conf-mingw-w64-zlib-i686" {os = "win32" & os-distribution != "cygwinports"}))
 ]

--- a/packages/conf-zstd/conf-zstd.1.3.8/opam
+++ b/packages/conf-zstd/conf-zstd.1.3.8/opam
@@ -5,10 +5,17 @@ bug-reports: "https://github.com/ocaml/opam-repository/issues"
 authors: ["Facebook"]
 license: "BSD-3-Clause"
 build: [
-  [conf-pkg-config:command "--atleast-version=1.3.8" "libzstd"]
+  # When the version is next bumped, this package can depend on
+  # conf-pkg-config.5 and instead use:
+  # [conf-pkg-config:command "--atleast-version=1.3.8" "libzstd"]
+  ["pkgconf" {os = "win32" & os-distribution != "cygwinports"}
+   "--personality=i686-w64-mingw32" {os = "win32" & os-distribution != "cygwinports" & host-arch-x86_32:installed}
+   "--personality=x86_64-w64-mingw32" {os = "win32" & os-distribution != "cygwinports" & host-arch-x86_64:installed}
+   "pkg-config" {os != "win32" | os-distribution = "cygwinports"}
+   "--atleast-version=1.3.8" "libzstd"]
 ]
 depends: [
-  "conf-pkg-config" {>= "5"}
+  "conf-pkg-config" {build}
   (("host-arch-x86_64" {os = "win32" & os-distribution != "cygwinports"} & "conf-mingw-w64-zstd-x86_64" {os = "win32" & os-distribution != "cygwinports"}) |
    ("host-arch-x86_32" {os = "win32" & os-distribution != "cygwinports"} & "conf-mingw-w64-zstd-i686" {os = "win32" & os-distribution != "cygwinports"}))
 ]

--- a/packages/conf-zstd/conf-zstd.1.3.8/opam
+++ b/packages/conf-zstd/conf-zstd.1.3.8/opam
@@ -5,14 +5,10 @@ bug-reports: "https://github.com/ocaml/opam-repository/issues"
 authors: ["Facebook"]
 license: "BSD-3-Clause"
 build: [
-  ["pkgconf" {os = "win32" & os-distribution != "cygwinports"}
-   "--personality=i686-w64-mingw32" {os = "win32" & os-distribution != "cygwinports" & host-arch-x86_32:installed}
-   "--personality=x86_64-w64-mingw32" {os = "win32" & os-distribution != "cygwinports" & host-arch-x86_64:installed}
-   "pkg-config" {os != "win32" | os-distribution = "cygwinports"}
-   "--atleast-version=1.3.8" "libzstd"]
+  [conf-pkg-config:command "--atleast-version=1.3.8" "libzstd"]
 ]
 depends: [
-  "conf-pkg-config" {build}
+  "conf-pkg-config" {>= "5"}
   (("host-arch-x86_64" {os = "win32" & os-distribution != "cygwinports"} & "conf-mingw-w64-zstd-x86_64" {os = "win32" & os-distribution != "cygwinports"}) |
    ("host-arch-x86_32" {os = "win32" & os-distribution != "cygwinports"} & "conf-mingw-w64-zstd-i686" {os = "win32" & os-distribution != "cygwinports"}))
 ]

--- a/packages/conf-zstd/conf-zstd.1.3.8/opam
+++ b/packages/conf-zstd/conf-zstd.1.3.8/opam
@@ -13,8 +13,8 @@ build: [
 ]
 depends: [
   "conf-pkg-config" {build}
-  (("host-arch-x86_32" {os = "win32" & os-distribution != "cygwinports"} & "conf-mingw-w64-zstd-i686" {os = "win32" & os-distribution != "cygwinports"}) |
-   ("host-arch-x86_64" {os = "win32" & os-distribution != "cygwinports"} & "conf-mingw-w64-zstd-x86_64" {os = "win32" & os-distribution != "cygwinports"}))
+  (("host-arch-x86_64" {os = "win32" & os-distribution != "cygwinports"} & "conf-mingw-w64-zstd-x86_64" {os = "win32" & os-distribution != "cygwinports"}) |
+   ("host-arch-x86_32" {os = "win32" & os-distribution != "cygwinports"} & "conf-mingw-w64-zstd-i686" {os = "win32" & os-distribution != "cygwinports"}))
 ]
 depexts: [
   ["libzstd-dev"] {os-family = "debian"}


### PR DESCRIPTION
Using the testing amended in #29998, this restores the 0install-related fixes to conf- packages which addressed part of #29609.

The underlying issue here is how opam translates the request to install packages in a switch to a request to the 0install solver. Something is amiss in the implementation of the translation which is loosely tracked in ocaml/opam#6674.

While these packages are being edited, I've also put in notes about conf-pkg-config.5 which follows in the next PR (these are split into sequence in order to update parts of the CI - these packages need to have been edited here in order that the next PR can revert the overriding of the solver added in #29998).