### PR TITLE
only run lintcstubs tests if using dune < 3.24

### DIFF
--- a/packages/lintcstubs/lintcstubs.0.4.7/opam
+++ b/packages/lintcstubs/lintcstubs.0.4.7/opam
@@ -30,7 +30,7 @@ build: [
     jobs
     "--promote-install-files=false"
     "@install"
-    "@runtest" {with-test}
+    "@runtest" {with-test & dune:version < "3.24"}
     "@doc" {with-doc}
   ]
   ["dune" "install" "-p" name "--create-install-files" name]


### PR DESCRIPTION
Just as https://github.com/ocaml/opam-repository/pull/29993, a test here depends on internal specifics of dunes install layout, which are changing in 3.24.

An upstream fix for this is submitted at https://github.com/edwintorok/lintcstubs/pull/4