### PR TITLE
[new release] migra (2.0.0)

### DIFF
--- a/packages/migra/migra.2.0.0/opam
+++ b/packages/migra/migra.2.0.0/opam
@@ -1,0 +1,56 @@
+opam-version: "2.0"
+synopsis:
+  "A database migration tool and library for OCaml supporting PostgreSQL, MariaDB/MySQL, and SQLite"
+description:
+  "A database migration tool and library for OCaml. Migrations are plain SQL with up and down sections, and the database (PostgreSQL, MariaDB/MySQL, or SQLite) is selected from the connection URL. Applied migrations are tracked with checksums, and drift (a modified, missing, or out-of-order migration) is detected before anything runs. It can be used from the command line or embedded as a library to migrate on application startup."
+maintainer: ["David Sinclair <dsincl12@gmail.com>"]
+authors: ["David Sinclair"]
+license: "MIT"
+tags: ["database" "migrations" "postgresql" "mariadb" "mysql" "sqlite"]
+homepage: "https://github.com/dsincl12/migra"
+doc: "https://github.com/dsincl12/migra"
+bug-reports: "https://github.com/dsincl12/migra/issues"
+depends: [
+  "dune" {>= "3.12"}
+  "ocaml" {>= "4.14.0"}
+  "dune-build-info" {>= "3.12"}
+  "lwt" {>= "5.6.0"}
+  "alcotest" {with-test & >= "1.7.0"}
+  "alcotest-lwt" {with-test & >= "1.7.0"}
+  "caqti" {>= "2.0.0"}
+  "caqti-lwt" {>= "2.0.0"}
+  "caqti-dynload" {>= "2.0.0"}
+  "uri" {>= "4.4.0"}
+  "cmdliner" {>= "2.0.0"}
+  "logs" {>= "0.7.0"}
+  "logs-ppx" {>= "0.2.0"}
+  "fmt" {>= "0.9.0"}
+  "odoc" {with-doc}
+]
+depopts: [
+  "caqti-driver-postgresql" "caqti-driver-mariadb" "caqti-driver-sqlite3"
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/dsincl12/migra.git"
+url {
+  src:
+    "https://github.com/dsincl12/migra/releases/download/2.0.0/migra-2.0.0.tbz"
+  checksum: [
+    "sha256=f795152aad57b0ae6fe0894694bbbf8340a3270653cac7f8825d074d3feb366b"
+    "sha512=3afabe27e4ae01b0ca3681b037aaf39d6efc5d568855e2a8bd19885b34496c2f8ce3a631caf15d30bdd77797a08ca711f87c2e48b598b40546060c5e045d6718"
+  ]
+}
+x-commit-hash: "425158968ea272fa2ec6e120373c51b5c37b8396"


### PR DESCRIPTION
A database migration tool and library for OCaml supporting PostgreSQL, MariaDB/MySQL, and SQLite

- Project page: <a href="https://github.com/dsincl12/migra">https://github.com/dsincl12/migra</a>
- Documentation: <a href="https://github.com/dsincl12/migra">https://github.com/dsincl12/migra</a>

##### CHANGES:

### Changed (breaking)
- The engine is no longer shipped as a separate public `migra.engine` library.
  Its modules (runner, SQL parser, dialect, discovery, migration, connection)
  are now private modules of `migra`, so code that reached into `Migra_engine.*`
  must use the public `Migra.*` API. The CLI and the `Migra.Database` /
  `Migra.Migrator` / `Migra.Types` / `Migra.Logging` facades are unchanged.
- `Migra.Migrator.rollback_strategy` is its own type rather than an alias of the
  engine's strategy type.
- Logging is no longer configured as a side effect of loading the library.
  Linking `migra` no longer installs a `Logs` reporter or sets the level; call
  `Migra.Logging.setup ()` to opt in (the CLI does this at startup).
- Removed the unused error variants `FileNotFound`, `DatabaseNotFound`, and
  `TransactionFailed`, and added `WriteError` for migration-file write failures.

### Added
- `generate` honors the `--dir` option (and `Migrator.generate ~migrations_dir`).

### Fixed
- The database lifecycle commands (`init`/`setup`/`drop`/`reset`) accept
  `sqlite3:path` URLs - the documented form, and what `sqlite3://` normalizes
  to - which previously failed with "invalid path format".
- `mysql://` connection URLs are rewritten to the `mariadb://` scheme the Caqti
  driver registers, so they connect instead of reporting a missing driver.
- A connection failure that merely mentions "not found" (a missing host, role,
  or database) is no longer misreported as a missing database driver.
- Migration version stamps are generated in UTC, so they no longer depend on the
  developer's timezone or DST.
- The `DELIMITER` directive is honored only for MySQL/MariaDB, so SQL beginning
  with the word "delimiter" is not misparsed on other dialects.
- The SQL splitter handles digit-led dollar tags (`$1$`), PostgreSQL `E'...'`
  escape strings, and backslash escapes inside MySQL double-quoted strings.
- Each migration file is read once when applied, so the recorded checksum always
  matches the SQL that ran.
- `status` and `migrate --dry-run` are read-only and no longer create the
  migrations-tracking table.
- Conflicting `rollback` selectors (`--all` with `--to` or `--step`) are
  rejected instead of silently ignored.
- A migration-file write failure is reported as a write error (no longer a read
  error) and no longer leaks the file descriptor.
- Removed a doubled blank line from applied/rolled-back migration output.

### Known limitations
- Migration atomicity has per-dialect limits: MySQL/MariaDB DDL implicitly
  commits, a `COMMIT`/`BEGIN` in a migration's own SQL ends Migra's wrapping
  transaction early, and on PostgreSQL a statement that returns rows (e.g.
  `SELECT setval(...)`) is rejected. See the Transactions notes in the README.
