### PR TITLE
Fix Mazeppa v0.7.2's `checked_oint` dependency

### DIFF
--- a/packages/mazeppa/mazeppa.0.7.2/opam
+++ b/packages/mazeppa/mazeppa.0.7.2/opam
@@ -12,7 +12,7 @@ depends: [
   "ocaml" {>= "4.14"}
   "dune" {>= "3.14"}
   "pprint"
-  "checked_oint" {>= "1.0.1"}
+  "checked_oint" {= "1.0.1"}
   "ppx_deriving"
   "ppx_string_interpolation"
   "ppx_yojson_conv"


### PR DESCRIPTION
Fixes https://github.com/ocaml/opam-repository/pull/30031.