### PR TITLE
only run crunch.4.0.0 tests if using dune < 3.24

### DIFF
--- a/packages/crunch/crunch.4.0.0/opam
+++ b/packages/crunch/crunch.4.0.0/opam
@@ -32,7 +32,7 @@ build: [
     "-j"
     jobs
     "@install"
-    "@runtest" {with-test}
+    "@runtest" {with-test & dune:version < "3.24"}
     "@doc" {with-doc}
   ]
 ]


### PR DESCRIPTION
Just as in https://github.com/ocaml/opam-repository/pull/29993, a test here depends on internal specifics of dune's install layout, which are changing in 3.24.

An upstream fix for future versions is proposed at https://github.com/mirage/ocaml-crunch/pull/69