### PR TITLE
Package transom.0.2.0

### DIFF
--- a/packages/transom/transom.0.2.0/opam
+++ b/packages/transom/transom.0.2.0/opam
@@ -1,0 +1,29 @@
+opam-version: "2.0"
+synopsis: "OCaml backend/application logic for desktop WebView apps"
+description: "Transom helps desktop WebView frontends call native OCaml backend/application logic through typed IPC and generated glue."
+maintainer: "funwithcthulhu29@gmail.com"
+authors: ["funwithcthulhu"]
+license: "MIT"
+homepage: "https://github.com/funwithcthulhu/transom"
+bug-reports: "https://github.com/funwithcthulhu/transom/issues"
+dev-repo: "git+https://github.com/funwithcthulhu/transom.git"
+depends: [
+  "ocaml" {>= "5.1"}
+  "dune" {>= "3.11"}
+  "atdgen"
+  "atdgen-runtime"
+  "cmdliner" {>= "1.3.0"}
+  "yojson" {>= "2.0.0"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+url {
+  src:
+    "https://github.com/funwithcthulhu/transom/archive/refs/tags/v0.2.0.tar.gz"
+  checksum: [
+    "md5=4d0b0117994a250dd343bbc03f65acf5"
+    "sha512=629a5e39f3b142ff0391bbcab6a193480d07d04b3a101da85693778dae6539f48b48bc5c36cf24ed4a920da26bab2b9c955d2bb2a5c43fc3dcaec137523a7527"
+  ]
+}


### PR DESCRIPTION
### `transom.0.2.0`
OCaml backend/application logic for desktop WebView apps
Transom helps desktop WebView frontends call native OCaml backend/application logic through typed IPC and generated glue.



---
* Homepage: https://github.com/funwithcthulhu/transom
* Source repo: git+https://github.com/funwithcthulhu/transom.git
* Bug tracker: https://github.com/funwithcthulhu/transom/issues

---
:camel: Pull-request generated by opam-publish v2.6.0