### PR TITLE
diffast-core 0.2 is not compatible with version 0.4

### DIFF
--- a/packages/diffast-core/diffast-core.0.2/opam
+++ b/packages/diffast-core/diffast-core.0.2/opam
@@ -26,7 +26,7 @@ depends: [
   "base64"
   "sedlex"
   "menhir"
-  "diffast-misc"
+  "diffast-misc" {< "0.4"}
   "vlt" {>= "0.2.4"}
   "odoc" {with-doc}
 ]


### PR DESCRIPTION
Seen on https://github.com/ocaml/opam-repository/pull/30013