### PR TITLE
Reduce depext-related switch recompilations on Windows without breaking lockfiles

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -171,8 +171,6 @@ jobs:
           Write-Host "# Switch invariant: `e[34m$(opam switch invariant)`e[0m"
           opam list
           opam repo
-        env:
-          OPAMEXTERNALSOLVER: builtin-mccs+glpk
 
       - name: Install packages
         run: |
@@ -303,5 +301,3 @@ jobs:
           if ($failed) {
             throw "One or more packages failed to lint or build"
           }
-        env:
-          OPAMEXTERNALSOLVER: builtin-mccs+glpk

--- a/packages/conf-c++/conf-c++.1.0/opam
+++ b/packages/conf-c++/conf-c++.1.0/opam
@@ -1,14 +1,20 @@
 opam-version: "2.0"
-maintainer: "https://github.com/ocaml/opam-repository/issues"
-authors: "C++ compiler developers"
+maintainer: "David Allsopp <dra27@dra27.uk>"
+authors: "David Allsopp"
 homepage: "https://github.com/ocaml/opam-repository"
 bug-reports: "https://github.com/ocaml/opam-repository/issues"
-license: "GPL-2.0-or-later"
+license: "CC0-1.0+"
 build: [
-  "i686-w64-mingw32-c++" {os = "win32" & host-arch-x86_32:installed}
-  "x86_64-w64-mingw32-c++" {os = "win32" & host-arch-x86_64:installed}
-  "c++" {os != "win32" | (!host-arch-x86_32:installed & !host-arch-x86_64:installed)}
-  "--version"
+  ["touch" "dummy.cpp"]
+  ["i686-w64-mingw32-c++" {os = "win32" & host-arch-x86_32:installed & host-system-mingw:installed}
+   "x86_64-w64-mingw32-c++" {os = "win32" & host-arch-x86_64:installed & host-system-mingw:installed}
+   "cl" {os = "win32" & host-system-msvc:installed}
+   "c++" {os != "win32" | (!host-arch-x86_32:installed & !host-arch-x86_64:installed)}
+     "-c" {!host-system-msvc:installed} "/c" {host-system-msvc:installed} "dummy.cpp"]
+  ["sh" "./write-config.sh" name "-v" "cxx"
+     "c++" {os != "win32" | (os-distribution != "cygwin" & os-distribution != "msys2")}
+     "i686-w64-mingw32-c++" {os = "win32" & (os-distribution = "cygwin" | os-distribution = "msys2") & host-arch-x86_32:installed}
+     "x86_64-w64-mingw32-c++" {os = "win32" & (os-distribution = "cygwin" | os-distribution = "msys2") & host-arch-x86_64:installed}]
 ]
 depexts: [
   ["gcc-c++"] {os-distribution = "centos"}
@@ -21,10 +27,19 @@ depexts: [
   ["gcc"] {os-distribution = "arch"}
   ["gcc-g++"] {os = "win32" & os-distribution = "cygwinports"}
 ]
-depends:
-  (("host-arch-x86_64" {os = "win32" & os-distribution != "cygwinports"} & "conf-mingw-w64-g++-x86_64" {os = "win32" & os-distribution != "cygwinports"}) |
-   ("host-arch-x86_32" {os = "win32" & os-distribution != "cygwinports"} & "conf-mingw-w64-g++-i686" {os = "win32" & os-distribution != "cygwinports"}))
+depends: [
+  (("host-arch-x86_64" {os = "win32" & os-distribution != "cygwinports"} & ("host-system-mingw" {os = "win32" & (os-distribution = "cygwin" | os-distribution = "msys2")} & "conf-mingw-w64-g++-x86_64" {os = "win32" & os-distribution != "cygwinports"} | "host-system-msvc" {os = "win32" & (os-distribution = "cygwin" | os-distribution = "msys2")})) |
+   ("host-arch-x86_32" {os = "win32" & os-distribution != "cygwinports"} & ("host-system-mingw" {os = "win32" & (os-distribution = "cygwin" | os-distribution = "msys2")} & "conf-mingw-w64-g++-i686" {os = "win32" & os-distribution != "cygwinports"} | "host-system-msvc" {os = "win32" & (os-distribution = "cygwin" | os-distribution = "msys2")})))
+  ("ocaml-env-mingw64" {os = "win32"} | "ocaml-env-mingw32" {os = "win32"} |
+   "ocaml-env-msvc64" {os = "win32"} | "ocaml-env-msvc32" {os = "win32"})
+]
 synopsis: "Virtual package relying on the c++ compiler"
 description:
   "This package can only install if the c++ compiler is installed on the system."
-flags: conf
+extra-source "write-config.sh" {
+  src: "https://raw.githubusercontent.com/dra27/mingw-w64-shims/refs/tags/1.0.1/write-config.sh"
+  checksum: [
+    "sha256=b6cc5f98c2cfc23a7bc7774038621a2e7e7b94ed3d3080db40bc455a2575fc7a"
+    "sha512=00c4e7c605e46c8fb4d24c40da0a9317e31e3ec723a7aac59546b1cfb180024cc76dbd27c2aca8d223047ad4b0a4bcd047443fc64a6e218a21931aaa672c3e71"
+  ]
+}

--- a/packages/conf-cc/conf-cc.1/opam
+++ b/packages/conf-cc/conf-cc.1/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+synopsis: "Virtual package for the system's C compiler"
+description: """
+This package can only install if a C compiler is available on the system and
+defines a package variable conf-cc:cc containing the command to run
+"""
+maintainer: "David Allsopp <dra27@dra27.uk>"
+authors: "David Allsopp"
+license: "CC0-1.0+"
+homepage: "https://github.com/ocaml/opam-repository"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
+depends: [
+  ("host-arch-x86_64" {os = "win32"} | "host-arch-x86_32" {os = "win32"})
+  ("host-system-mingw" {os = "win32"} | "host-system-msvc" {os = "win32"})
+  ("ocaml-env-mingw64" {os = "win32"} | "ocaml-env-mingw32" {os = "win32"} |
+   "ocaml-env-msvc64" {os = "win32"} | "ocaml-env-msvc32" {os = "win32"})
+]
+build: [
+  ["touch" "dummy.c"]
+  ["i686-w64-mingw32-gcc" {os = "win32" & host-arch-x86_32:installed & host-system-mingw:installed}
+   "x86_64-w64-mingw32-gcc" {os = "win32" & host-arch-x86_64:installed & host-system-mingw:installed}
+   "cl" {os = "win32" & host-system-msvc:installed}
+   "cc" {os != "win32" | (!host-arch-x86_32:installed & !host-arch-x86_64:installed)}
+     "-c" {!host-system-msvc:installed} "/c" {host-system-msvc:installed} "dummy.c"]
+  ["sh" "./write-config.sh" name "-v" "cc"
+     "cc" {os != "win32" | (os-distribution != "cygwin" & os-distribution != "msys2")}
+     "cl" {os = "win32" & host-system-msvc:installed}
+     "i686-w64-mingw32-gcc" {os = "win32" & host-arch-x86_32:installed & host-system-mingw:installed}
+     "x86_64-w64-mingw32-gcc" {os = "win32" & host-arch-x86_64:installed & host-system-mingw:installed}]
+]
+extra-source "write-config.sh" {
+  src: "https://raw.githubusercontent.com/dra27/mingw-w64-shims/refs/tags/1.0.1/write-config.sh"
+  checksum: [
+    "sha256=b6cc5f98c2cfc23a7bc7774038621a2e7e7b94ed3d3080db40bc455a2575fc7a"
+    "sha512=00c4e7c605e46c8fb4d24c40da0a9317e31e3ec723a7aac59546b1cfb180024cc76dbd27c2aca8d223047ad4b0a4bcd047443fc64a6e218a21931aaa672c3e71"
+  ]
+}

--- a/packages/conf-libcurl/conf-libcurl.1/opam
+++ b/packages/conf-libcurl/conf-libcurl.1/opam
@@ -19,6 +19,7 @@ depexts: [
   ["curl"] {os-distribution = "homebrew" & os = "macos"}
   ["curl"] {os-distribution = "macports" & os = "macos"}
 ]
+available: os != "win32" | os-distribution = "cygwinports"
 synopsis: "Virtual package relying on a libcurl system installation"
 description:
   "This package can only install if the libcurl is installed on the system."

--- a/packages/conf-libcurl/conf-libcurl.2/opam
+++ b/packages/conf-libcurl/conf-libcurl.2/opam
@@ -4,8 +4,7 @@ authors: ["Daniel Stenberg"]
 homepage: "http://curl.haxx.se/"
 license: "BSD-like"
 build: [
-  ["sh" "-exc" "curl-config --libs"] {os = "win32" & os-distribution != "cygwinports"}
-  ["curl-config" "--libs"] {os != "win32" | os-distribution = "cygwinports"}
+  ["sh" {os = "win32" & os-distribution != "cygwinports"} "curl-config" "--libs"]
 ]
 depexts: [
   ["libcurl4-gnutls-dev"] {os-family = "debian"}
@@ -24,8 +23,11 @@ depexts: [
   ["curl"] {os = "freebsd"}
 ]
 depends: [
-  ("host-arch-x86_64" {os = "win32" & os-distribution != "cygwinports"} & "conf-mingw-w64-gcc-x86_64" {os = "win32" & os-distribution = "cygwin"} & "conf-mingw-w64-curl-x86_64" {os = "win32" & os-distribution != "cygwinports"} |
-   "host-arch-x86_32" {os = "win32" & os-distribution != "cygwinports"} & "conf-mingw-w64-gcc-i686" {os = "win32" & os-distribution = "cygwin"} & "conf-mingw-w64-curl-i686" {os = "win32" & os-distribution != "cygwinports"})
+  # curl-config is in the sys-root bin directory, which needs to be in PATH for
+  # the build command above to work; this package therefore depends on the C
+  # compiler as well.
+  ("host-arch-x86_64" {os = "win32" & os-distribution != "cygwinports"} & "conf-mingw-w64-gcc-x86_64" {os = "win32" & os-distribution != "cygwinports"} & "conf-mingw-w64-curl-x86_64" {os = "win32" & os-distribution != "cygwinports"} |
+   "host-arch-x86_32" {os = "win32" & os-distribution != "cygwinports"} & "conf-mingw-w64-gcc-i686" {os = "win32" & os-distribution != "cygwinports"} & "conf-mingw-w64-curl-i686" {os = "win32" & os-distribution != "cygwinports"})
 ]
 depopts: "mingw-w64-shims" {< "1.0.0"}
 synopsis: "Virtual package relying on a libcurl system installation"

--- a/packages/conf-libcurl/conf-libcurl.2/opam
+++ b/packages/conf-libcurl/conf-libcurl.2/opam
@@ -24,10 +24,10 @@ depexts: [
   ["curl"] {os = "freebsd"}
 ]
 depends: [
-  "mingw-w64-shims" {os-distribution = "cygwin" & build}
-  ("host-arch-x86_64" {os = "win32" & os-distribution != "cygwinports"} & "conf-mingw-w64-curl-x86_64" {os = "win32" & os-distribution != "cygwinports"} |
-   "host-arch-x86_32" {os = "win32" & os-distribution != "cygwinports"} & "conf-mingw-w64-curl-i686" {os = "win32" & os-distribution != "cygwinports"})
+  ("host-arch-x86_64" {os = "win32" & os-distribution != "cygwinports"} & "conf-mingw-w64-gcc-x86_64" {os = "win32" & os-distribution = "cygwin"} & "conf-mingw-w64-curl-x86_64" {os = "win32" & os-distribution != "cygwinports"} |
+   "host-arch-x86_32" {os = "win32" & os-distribution != "cygwinports"} & "conf-mingw-w64-gcc-i686" {os = "win32" & os-distribution = "cygwin"} & "conf-mingw-w64-curl-i686" {os = "win32" & os-distribution != "cygwinports"})
 ]
+depopts: "mingw-w64-shims" {< "1.0.0"}
 synopsis: "Virtual package relying on a libcurl system installation"
 description:
   "This package can only install if the libcurl is installed on the system."

--- a/packages/conf-libffi/conf-libffi.2.0.0/opam
+++ b/packages/conf-libffi/conf-libffi.2.0.0/opam
@@ -32,7 +32,6 @@ synopsis: "Virtual package relying on libffi system installation"
 description: "This package can only install if libffi is installed on the system."
 depends: [
   "conf-pkg-config" {build}
-  "mingw-w64-shims" {os-distribution = "cygwin" & build}
   ("host-arch-x86_64" {os = "win32" & os-distribution != "cygwinports"} & "conf-mingw-w64-libffi-x86_64" {os = "win32" & os-distribution != "cygwinports"} |
    "host-arch-x86_32" {os = "win32" & os-distribution != "cygwinports"} & "conf-mingw-w64-libffi-i686" {os = "win32" & os-distribution != "cygwinports"})
 ]

--- a/packages/conf-mingw-w64-g++-i686/conf-mingw-w64-g++-i686.1/opam
+++ b/packages/conf-mingw-w64-g++-i686/conf-mingw-w64-g++-i686.1/opam
@@ -2,18 +2,29 @@ opam-version: "2.0"
 synopsis: "Virtual package for g++ on i686 mingw-w64 (32-bit x86)"
 description: "Ensures the i686 version of g++ for the mingw-w64 project is available"
 maintainer: "David Allsopp <dra27@dra27.uk>"
-authors: "David Allsopp"
+authors: "The GCC Developers"
 license: "GPL-3.0-or-later"
+dev-repo: "git+https://github.com/dra27/mingw-w64-shims.git"
 homepage: "https://www.mingw-w64.org"
 bug-reports: "https://github.com/ocaml/opam-repository/issues"
-flags: conf
 available: os = "win32"
-build: ["i686-w64-mingw32-g++" "--version"]
-depends: [
-  "msys2" {build & os = "win32" & os-distribution = "msys2"}
-  "msys2-mingw32" {os = "win32" & os-distribution = "msys2"}
-  "conf-mingw-w64-gcc-i686" {build}
+build: [
+  ["i686-w64-mingw32-g++" "--version"]
+  ["sh" "./install-shim.sh" name "mingw64-i686-gcc-g++" bin] {os = "win32" & os-distribution = "cygwin" & mingw-w64-shims:installed}
 ]
+depends: [
+  "msys2" {os = "win32" & os-distribution = "msys2"}
+  "msys2-mingw32" {os = "win32" & os-distribution = "msys2"}
+  "conf-mingw-w64-gcc-i686"
+]
+depopts: "mingw-w64-shims" {>= "1.0.0"}
 depexts: [
   ["mingw64-i686-gcc-g++"] {os = "win32" & os-distribution = "cygwin"}
 ]
+extra-source "install-shim.sh" {
+  src: "https://raw.githubusercontent.com/dra27/mingw-w64-shims/refs/tags/1.0.1/install-shim.sh"
+  checksum: [
+    "sha256=9f99322c38b0889f5b1dafbb35ab31dc012ae98c4f98b0f740a89f943142d961"
+    "sha512=0b76a529454b00027b5768fa6ead1b8dda6bc3adab55f4288a702f4cc5d7b280be938cced6841b1556e8cf98f56ecc95b7b22006859d7a91f0ef852aea74e88c"
+  ]
+}

--- a/packages/conf-mingw-w64-g++-x86_64/conf-mingw-w64-g++-x86_64.1/opam
+++ b/packages/conf-mingw-w64-g++-x86_64/conf-mingw-w64-g++-x86_64.1/opam
@@ -2,18 +2,29 @@ opam-version: "2.0"
 synopsis: "Virtual package for g++ on x86_64 mingw-w64 (64-bit x86_64)"
 description: "Ensures the x86_64 version of g++ for the mingw-w64 project is available"
 maintainer: "David Allsopp <dra27@dra27.uk>"
-authors: "David Allsopp"
+authors: "The GCC Developers"
 license: "GPL-3.0-or-later"
+dev-repo: "git+https://github.com/dra27/mingw-w64-shims.git"
 homepage: "https://www.mingw-w64.org"
 bug-reports: "https://github.com/ocaml/opam-repository/issues"
-flags: conf
 available: os = "win32"
-build: ["x86_64-w64-mingw32-g++" "--version"]
-depends: [
-  "msys2" {build & os = "win32" & os-distribution = "msys2"}
-  "msys2-mingw64" {os = "win32" & os-distribution = "msys2"}
-  "conf-mingw-w64-gcc-x86_64" {build}
+build: [
+  ["x86_64-w64-mingw32-g++" "--version"]
+  ["sh" "./install-shim.sh" name "mingw64-x86_64-gcc-g++" bin] {os = "win32" & os-distribution = "cygwin" & mingw-w64-shims:installed}
 ]
+depends: [
+  "msys2" {os = "win32" & os-distribution = "msys2"}
+  "msys2-mingw64" {os = "win32" & os-distribution = "msys2"}
+  "conf-mingw-w64-gcc-x86_64"
+]
+depopts: "mingw-w64-shims" {>= "1.0.0"}
 depexts: [
   ["mingw64-x86_64-gcc-g++"] {os = "win32" & os-distribution = "cygwin"}
 ]
+extra-source "install-shim.sh" {
+  src: "https://raw.githubusercontent.com/dra27/mingw-w64-shims/refs/tags/1.0.1/install-shim.sh"
+  checksum: [
+    "sha256=9f99322c38b0889f5b1dafbb35ab31dc012ae98c4f98b0f740a89f943142d961"
+    "sha512=0b76a529454b00027b5768fa6ead1b8dda6bc3adab55f4288a702f4cc5d7b280be938cced6841b1556e8cf98f56ecc95b7b22006859d7a91f0ef852aea74e88c"
+  ]
+}

--- a/packages/conf-mingw-w64-gcc-i686/conf-mingw-w64-gcc-i686.1/opam
+++ b/packages/conf-mingw-w64-gcc-i686/conf-mingw-w64-gcc-i686.1/opam
@@ -2,18 +2,31 @@ opam-version: "2.0"
 synopsis: "Virtual package for GCC on i686 mingw-w64 (32-bit x86)"
 description: "Ensures the i686 version of GCC for the mingw-w64 project is available"
 maintainer: "David Allsopp <dra27@dra27.uk>"
-authors: "David Allsopp"
+authors: "The GCC Developers"
 license: "GPL-3.0-or-later"
+dev-repo: "git+https://github.com/dra27/mingw-w64-shims.git"
 homepage: "https://www.mingw-w64.org"
 bug-reports: "https://github.com/ocaml/opam-repository/issues"
-flags: conf
 available: os = "win32"
 depends: [
-  "msys2" {build & os = "win32" & os-distribution = "msys2"}
-  "msys2-mingw32" {os = "win32" & os-distribution = "msys2"}
+  "msys2" {os-distribution = "msys2"}
+  "msys2-mingw32" {os-distribution = "msys2"}
+  ("host-arch-x86_64" | "host-arch-x86_32")
 ]
-build: ["i686-w64-mingw32-gcc" "--version"]
+depopts: "mingw-w64-shims" {>= "1.0.0"}
+build: [
+  ["i686-w64-mingw32-gcc" "--version"]
+  ["sh" "./install-shim.sh" name "mingw64-i686-binutils mingw64-i686-gcc-core" bin "i686-w64-mingw32-gcc" "_shim" "cygpath" {host-arch-x86_32:installed}] {os = "win32" & os-distribution = "cygwin" & mingw-w64-shims:installed}
+]
+setenv: PATH += "%{_:runtime}%"
 depexts: [
   ["mingw64-i686-gcc-core"] {os = "win32" & os-distribution = "cygwin"}
   ["mingw-w64-i686-gcc"] {os = "win32" & os-distribution = "msys2"}
 ]
+url {
+  src: "https://github.com/dra27/mingw-w64-shims/archive/refs/tags/1.0.1.tar.gz"
+  checksum: [
+    "sha256=d29e6141f02500f13534b6a0d77c290f2987c534c660a4f90cdb01618be32507"
+    "sha512=892c4b5d7eaab6ce846fe8fe2756f23c61c654605b6c3bf8698db392725b3be81d015536230dc8305e7d17eb451beae5c21f705237523c79cc11e99c17cbed95"
+  ]
+}

--- a/packages/conf-mingw-w64-gcc-x86_64/conf-mingw-w64-gcc-x86_64.1/opam
+++ b/packages/conf-mingw-w64-gcc-x86_64/conf-mingw-w64-gcc-x86_64.1/opam
@@ -2,18 +2,31 @@ opam-version: "2.0"
 synopsis: "Virtual package for GCC on x86_64 mingw-w64 (64-bit x86_64)"
 description: "Ensures the x86_64 version of GCC for the mingw-w64 project is available"
 maintainer: "David Allsopp <dra27@dra27.uk>"
-authors: "David Allsopp"
+authors: "The GCC Developers"
 license: "GPL-3.0-or-later"
+dev-repo: "git+https://github.com/dra27/mingw-w64-shims.git"
 homepage: "https://www.mingw-w64.org"
 bug-reports: "https://github.com/ocaml/opam-repository/issues"
-flags: conf
 available: os = "win32"
 depends: [
-  "msys2" {build & os = "win32" & os-distribution = "msys2"}
-  "msys2-mingw64" {os = "win32" & os-distribution = "msys2"}
+  "msys2" {os-distribution = "msys2"}
+  "msys2-mingw64" {os-distribution = "msys2"}
+  ("host-arch-x86_64" | "host-arch-x86_32")
 ]
-build: ["x86_64-w64-mingw32-gcc" "--version"]
+depopts: "mingw-w64-shims" {>= "1.0.0"}
+build: [
+  ["x86_64-w64-mingw32-gcc" "--version"]
+  ["sh" "./install-shim.sh" name "mingw64-x86_64-binutils mingw64-x86_64-gcc-core" bin "x86_64-w64-mingw32-gcc" "shim" "cygpath" {host-arch-x86_64:installed}] {os = "win32" & os-distribution = "cygwin" & mingw-w64-shims:installed}
+]
+setenv: PATH += "%{_:runtime}%"
 depexts: [
   ["mingw64-x86_64-gcc-core"] {os = "win32" & os-distribution = "cygwin"}
   ["mingw-w64-x86_64-gcc"] {os = "win32" & os-distribution = "msys2"}
 ]
+url {
+  src: "https://github.com/dra27/mingw-w64-shims/archive/refs/tags/1.0.1.tar.gz"
+  checksum: [
+    "sha256=d29e6141f02500f13534b6a0d77c290f2987c534c660a4f90cdb01618be32507"
+    "sha512=892c4b5d7eaab6ce846fe8fe2756f23c61c654605b6c3bf8698db392725b3be81d015536230dc8305e7d17eb451beae5c21f705237523c79cc11e99c17cbed95"
+  ]
+}

--- a/packages/conf-pkg-config/conf-pkg-config.5/opam
+++ b/packages/conf-pkg-config/conf-pkg-config.5/opam
@@ -1,0 +1,62 @@
+opam-version: "2.0"
+maintainer: "David Allsopp <dra27@dra27.uk>"
+authors: ["James Henstridge" "Tim Janik" "Havoc Pennington" "Scott Remnant"]
+homepage: "http://www.freedesktop.org/wiki/Software/pkg-config/"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
+license: "GPL-2.0-or-later"
+dev-repo: "git+https://github.com/dra27/mingw-w64-shims.git"
+depends: [
+  ("host-arch-x86_64" {os = "win32" & (os-distribution = "cygwin" | os-distribution = "msys2")} & "conf-mingw-w64-gcc-x86_64" {os = "win32" & (os-distribution = "cygwin" | os-distribution = "msys2")} & "conf-mingw-w64-pkgconf-x86_64" {os = "win32" & os-distribution = "msys2"} |
+   "host-arch-x86_32" {os = "win32" & (os-distribution = "cygwin" | os-distribution = "msys2")} & "conf-mingw-w64-gcc-i686" {os = "win32" & (os-distribution = "cygwin" | os-distribution = "msys2")} & "conf-mingw-w64-pkgconf-i686" {os = "win32" & os-distribution = "msys2"})
+]
+conflicts: "mingw-w64-shims" {< "1.0.0"}
+build: [
+  ["pkg-config" "--help"] {os != "openbsd" & os != "win32" & !(os = "macos" & os-distribution = "homebrew")}
+  ["pkgconf" "--version"] {os = "openbsd" | (os = "win32" & os-distribution != "msys2") | (os = "macos" & os-distribution = "homebrew")}
+  ["sh" "./write-config.sh" name "-v" "command:list" "EOL"
+     "pkg-config" {os != "openbsd" & os != "win32" & !(os = "macos" & os-distribution = "homebrew")}
+     "pkgconf" {os = "openbsd" | (os = "win32" & os-distribution != "msys2") | (os = "macos" & os-distribution = "homebrew")}
+     "i686-w64-mingw32-pkgconf" {os = "win32" & os-distribution = "msys2" & host-arch-x86_32:installed}
+     "--personality=i686-w64-mingw32" {os = "win32" & os-distribution = "cygwin" & host-arch-x86_32:installed}
+     "x86_64-w64-mingw32-pkgconf" {os = "win32" & os-distribution = "msys2" & host-arch-x86_64:installed}
+     "--personality=x86_64-w64-mingw32" {os = "win32" & os-distribution = "cygwin" & host-arch-x86_64:installed}
+     "EOL"]
+  ["sh" "./install-shim.sh" name "pkgconf" bin] {os = "win32" & os-distribution = "cygwin"}
+]
+depexts: [
+  ["pkg-config"] {os-family = "debian" | os-family = "ubuntu"}
+  ["pkgconf"] {os-distribution = "arch"}
+  ["pkgconf-pkg-config"] {os-family = "fedora"}
+  ["pkgconfig"] {os-distribution = "centos" & os-version <= "7"}
+  ["pkgconf-pkg-config"] {os-distribution = "mageia"}
+  ["pkgconfig"] {os-distribution = "rhel" & os-version <= "7"}
+  ["pkgconfig"] {os-distribution = "ol" & os-version <= "7"}
+  ["pkgconf"] {os-distribution = "alpine"}
+  ["pkg-config"] {os-distribution = "nixos"}
+  ["pkgconf"] {os = "macos" & os-distribution = "homebrew"}
+  ["pkgconfig"] {os = "macos" & os-distribution = "macports"}
+  ["pkgconf"] {os = "freebsd"}
+  ["pkgconf-pkg-config"] {os-distribution = "rhel" & os-version >= "8"}
+  ["pkgconf-pkg-config"] {os-distribution = "centos" & os-version >= "8"}
+  ["pkgconf-pkg-config"] {os-distribution = "ol" & os-version >= "8"}
+  ["system:pkgconf"] {os = "win32" & os-distribution = "cygwinports"}
+  ["pkgconf"] {os-distribution = "cygwin"}
+]
+synopsis: "Check if pkg-config is installed and create an opam switch local pkgconfig folder"
+description: """
+This package can only install if the pkg-config package is installed
+on the system."""
+extra-source "install-shim.sh" {
+  src: "https://raw.githubusercontent.com/dra27/mingw-w64-shims/refs/tags/1.0.1/install-shim.sh"
+  checksum: [
+    "sha256=9f99322c38b0889f5b1dafbb35ab31dc012ae98c4f98b0f740a89f943142d961"
+    "sha512=0b76a529454b00027b5768fa6ead1b8dda6bc3adab55f4288a702f4cc5d7b280be938cced6841b1556e8cf98f56ecc95b7b22006859d7a91f0ef852aea74e88c"
+  ]
+}
+extra-source "write-config.sh" {
+  src: "https://raw.githubusercontent.com/dra27/mingw-w64-shims/refs/tags/1.0.1/write-config.sh"
+  checksum: [
+    "sha256=b6cc5f98c2cfc23a7bc7774038621a2e7e7b94ed3d3080db40bc455a2575fc7a"
+    "sha512=00c4e7c605e46c8fb4d24c40da0a9317e31e3ec723a7aac59546b1cfb180024cc76dbd27c2aca8d223047ad4b0a4bcd047443fc64a6e218a21931aaa672c3e71"
+  ]
+}

--- a/packages/mingw-w64-shims/mingw-w64-shims.0.1.0/opam
+++ b/packages/mingw-w64-shims/mingw-w64-shims.0.1.0/opam
@@ -11,7 +11,8 @@ Secondly, for opam's internally managed Cygwin installation, it installs shim
 executables to provide the cygpath utility along with all tool-prefixed
 programs from the -gcc-core, -gcc-g++ and -binutils packages from the
 mingw64-i686 and mingw64-x86_64 package sets."""
-maintainer: "David Allsopp <david@tarides.com>"
+maintainer: "David Allsopp <dra27@dra27.uk>"
+x-maintenance-intent: ["(latest)"]
 authors: "David Allsopp"
 license: "CC0-1.0+"
 homepage: "https://opam.ocaml.org"

--- a/packages/mingw-w64-shims/mingw-w64-shims.0.2.0/opam
+++ b/packages/mingw-w64-shims/mingw-w64-shims.0.2.0/opam
@@ -11,7 +11,8 @@ Secondly, for opam's internally managed Cygwin installation, it installs shim
 executables to provide the cygpath utility along with all tool-prefixed
 programs from the -gcc-core, -gcc-g++ and -binutils packages from the
 mingw64-i686 and mingw64-x86_64 package sets."""
-maintainer: "David Allsopp <david@tarides.com>"
+maintainer: "David Allsopp <dra27@dra27.uk>"
+x-maintenance-intent: ["(latest)"]
 authors: "David Allsopp"
 license: "CC0-1.0+"
 homepage: "https://opam.ocaml.org"

--- a/packages/mingw-w64-shims/mingw-w64-shims.1.0.1/opam
+++ b/packages/mingw-w64-shims/mingw-w64-shims.1.0.1/opam
@@ -1,0 +1,28 @@
+opam-version: "2.0"
+synopsis: "Configuration for the mingw-w64 Cygwin packages in opam"
+description: """
+The mingw-w64 ports of OCaml require access to GCC, the assembler and binutils.
+This set of packages performs two tasks. Firstly, it ensures that the directory
+containing the runtime DLLS are added to PATH. A typical Cygwin installation
+requires C:\\cygwin64\\usr\\x86_64-w64-mingw32\\sys-root\\mingw\\bin to be added
+to PATH, for example.
+
+Secondly, for opam's internally managed Cygwin installation, they install shim
+executables to provide the cygpath utility along with all tool-prefixed
+programs from the -gcc-core, -gcc-g++ and -binutils packages from the
+mingw64-i686 and mingw64-x86_64 package sets.
+
+In earlier versions of mingw-w64-shims, the mingw-w64-shims package formed part
+of this set. Installing mingw-w64-shims is no longer necessary."""
+maintainer: "David Allsopp <dra27@dra27.uk>"
+x-maintenance-intent: ["(latest)"]
+authors: "David Allsopp"
+license: "CC0-1.0+"
+homepage: "https://opam.ocaml.org"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
+available: os = "win32" & os-distribution = "cygwin"
+dev-repo: "git+https://github.com/dra27/mingw-w64-shims.git"
+depends:
+  "host-arch-x86_32" & "conf-mingw-w64-gcc-i686" {post} |
+  "host-arch-x86_64" & "conf-mingw-w64-gcc-x86_64" {post}
+flags: conf


### PR DESCRIPTION
This resurrects the crux of #29976.

In CI, the "Testing edited package" steps are only interesting inasmuch as they confirm nothing breaks this time. The interesting part is the sequence of installations:
- `conf-cc.1` (which is new): recompiles the switch (keeping mingw-w64-shims 0.2.0)
- `conf-pkg-config.5` (which is new): upgrades mingw-w64-shims to 1.0.1, and therefore rebuilds the compiler
- `conf-c++.1`: unlike the _editing_ test, this just installs the required conf package _and doesn't rebuild the compiler_ (that's the fix)
- `conf-mingw-w64-g++-i686.1`, etc: these likewise no longer rebuild the compiler
- `mingw-w64-shims.0.1.0` and `mingw-w64-shims.0.2.0`: usefully, because `conf-libcurl.2` is installed, this demonstrates that downgrading to the older versions still preserved the required paths and so forth for these packages to work.

Note that this is all done with the 0install solver, and each of the jobs can be seen only selecting the required depext this time (instead of pulling in 32bit versions with the 64bit ones).

🤞