### PR TITLE
Add missing constraints to async_websocket.v0.13.0

### DIFF
--- a/packages/async_websocket/async_websocket.v0.13.0/opam
+++ b/packages/async_websocket/async_websocket.v0.13.0/opam
@@ -11,6 +11,10 @@ build: [
 ]
 depends: [
   "ocaml" {>= "4.07.0"}
+  "async" {>= "v0.13" & < "v0.14"}
+  "core_kernel" {>= "v0.13" & < "v0.14"}
+  "ppx_jane" {>= "v0.13" & < "v0.14"}
+  "cryptokit"
   "dune"  {>= "1.5.1"}
 ]
 synopsis: "A library that implements the websocket protocol on top of Async"


### PR DESCRIPTION
These constraints are present in async_websocket.v0.13.1 (and later).

These constraints stop OxCaml switches accidentally trying to wander on to this package - I think it was also be reasonable just to add `available: false`