### PR TITLE
ez_file: drop constraints on `dune` version

### DIFF
--- a/packages/ez_file/ez_file.0.4.0/opam
+++ b/packages/ez_file/ez_file.0.4.0/opam
@@ -43,7 +43,6 @@ depends: [
   "ppx_expect" {with-test}
   "odoc" {with-doc}
   "ocamlformat" {with-test}
-  "dune" {>= "2.6.0" & < "3.0.0"}
 ]
 url {
   src: "https://github.com/OCamlPro/ez_file/archive/refs/tags/v0.4.0.tar.gz"


### PR DESCRIPTION
Note the removed constraint is actually a duplicate for `dune` (there is `"dune" {>= "2.8.0"}` above in the diff).