### PR TITLE
Run affected merlin tests only on supported dune versions (< 3.24)

### DIFF
--- a/packages/merlin/merlin.5.6-504/opam
+++ b/packages/merlin/merlin.5.6-504/opam
@@ -9,7 +9,7 @@ x-maintenance-intent: ["(latest)"]
 build: [
   ["dune" "subst"] {dev}
   ["dune" "build" "-p" name "-j" jobs]
-  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test & dune:version < "3.24"}
 ]
 depends: [
   "dune" {>= "3.0.0"}

--- a/packages/merlin/merlin.5.6.1-504/opam
+++ b/packages/merlin/merlin.5.6.1-504/opam
@@ -9,7 +9,7 @@ x-maintenance-intent: ["(latest)"]
 build: [
   ["dune" "subst"] {dev}
   ["dune" "build" "-p" name "-j" jobs]
-  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test & dune:version < "3.24"}
 ]
 depends: [
   "dune" {>= "3.0.0"}

--- a/packages/merlin/merlin.5.7.0-504/opam
+++ b/packages/merlin/merlin.5.7.0-504/opam
@@ -9,7 +9,7 @@ x-maintenance-intent: ["(latest)"]
 build: [
   ["dune" "subst"] {dev}
   ["dune" "build" "-p" name "-j" jobs]
-  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test & dune:version < "3.24"}
 ]
 depends: [
   "dune" {>= "3.0.0"}

--- a/packages/merlin/merlin.5.7.1-504/opam
+++ b/packages/merlin/merlin.5.7.1-504/opam
@@ -9,7 +9,7 @@ x-maintenance-intent: ["(latest)"]
 build: [
   ["dune" "subst"] {dev}
   ["dune" "build" "-p" name "-j" jobs]
-  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test & dune:version < "3.24"}
 ]
 depends: [
   "dune" {>= "3.0.0"}


### PR DESCRIPTION
Just as in ocaml#29993, a test here depends on internal specifics of dune's install layout, which are changing in 3.24.

An upstream fix is proposed at https://github.com/ocaml/merlin/pull/2078

The need for this filter was detected in the revdeps tests here https://github.com/ocaml/opam-repository/pull/29996#issuecomment-4651407043