### PR TITLE
[new release] msts (0.1.0)

### DIFF
--- a/packages/msts/msts.0.1.0/opam
+++ b/packages/msts/msts.0.1.0/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+synopsis: "Geocentric lunar ephemeris library"
+description: """
+Dependency-free OCaml library that computes the Moon's geocentric ecliptic
+   position and phase information from a Unix timestamp. Implements the
+   Schlyter Keplerian algorithm with empirical perturbation corrections.
+   Valid over 1900-01-01 through 2100-12-31."""
+maintainer: ["Sergiy Duras <sergiy@duras.org>"]
+authors: ["Sergiy Duras <sergiy@duras.org>"]
+license: "ISC"
+homepage: "https://codeberg.org/duras/msts"
+bug-reports: "https://codeberg.org/duras/msts/issues"
+depends: [
+  "dune" {>= "3.17"}
+  "ocaml" {>= "4.14"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/sduras/msts.git"
+url {
+  src:
+    "https://github.com/sduras/msts/releases/download/v0.1.0/msts-0.1.0.tbz"
+  checksum: [
+    "sha256=b41551c4d48ec1ddffcf9127e6ea95abe813e3c844bb9da11f0d3cedf1a6f021"
+    "sha512=c2754d94314a7f0517ceb51308493ef799123b988eda3c8b29ac070a669183460d7376ae15c97b25a7380a6e472e5e4d0549655659303f20fac0342afe108e1c"
+  ]
+}
+x-commit-hash: "6e4c9ea5b97bb21cb326962aed4a456a2c469c87"


### PR DESCRIPTION
Geocentric lunar ephemeris library

- Project page: <a href="https://codeberg.org/duras/msts">https://codeberg.org/duras/msts</a>

##### CHANGES:

- Initial release.
- `compute`: geocentric ecliptic position and phase from a Unix timestamp.
- `phase_name_to_string`: English name for all eight phase constructors.
- Validated against JPL Horizons (DE441) at six reference dates over
  1900-01-01 through 2100-12-31.
