### PR TITLE
[new release] resource-pooling (1.3)

### DIFF
--- a/packages/resource-pooling/resource-pooling.1.3/opam
+++ b/packages/resource-pooling/resource-pooling.1.3/opam
@@ -1,0 +1,25 @@
+opam-version: "2.0"
+maintainer: "Jan Rochel <jan@besport.com>"
+authors: [ "Jan Rochel (BeSport)" ]
+synopsis: "Library for pooling resources like connections, threads, or similar"
+description: "This package is derived from the module Lwt_pool from the lwt package, which implements resource pooling. With Resource_pool this package provides a modified version with additional features. Also there is a module called Server_pool that manages resource clusters, specifically a cluster of servers each with its own connection pool."
+license: "MIT"
+homepage: "https://github.com/ocsigen/resource-pooling"
+dev-repo: "git+https://github.com/ocsigen/resource-pooling.git"
+bug-reports: "https://github.com/ocsigen/resource-pooling/issues"
+build: [["dune" "build" "-p" name "-j" jobs]]
+depends: [
+  "ocaml" {>= "4.06"}
+  "dune" {>= "1.11"}
+  "lwt" {>= "2.4.7"}
+  "logs"
+]
+url {
+  src:
+    "https://github.com/ocsigen/resource-pooling/releases/download/1.3/resource-pooling-1.3.tbz"
+  checksum: [
+    "sha256=10026abfeaea0a5acc7c15c5e21030bc43fe637692da05c13c6f3ccae222ffef"
+    "sha512=50186ed79db3e9fe5274bcec8bbcc8e83a12f30d9be1dec4e9ad45b9bf01ce60fe76d9e4d95d3599f93572755c536a0e98bd53a38b1d11a422878b317ee7e4ac"
+  ]
+}
+x-commit-hash: "0b73e70048eb0a5c838d7746ab9c0ae6ea202c3c"


### PR DESCRIPTION
Library for pooling resources like connections, threads, or similar

- Project page: <a href="https://github.com/ocsigen/resource-pooling">https://github.com/ocsigen/resource-pooling</a>

##### CHANGES:

* Replace the deprecated `lwt_log` with `logs`/`logs.lwt` for logging
  (`Server_pool.section` is now a `Logs.src` instead of `Lwt_log.section`).
  This removes the `lwt_log` dependency, which capped `lwt < 6.0.0`, and thus
  unblocks builds against Lwt >= 6.
* Depend explicitly on `lwt.unix` (previously pulled transitively via
  `lwt_log`).
