### PR TITLE
[new release] goblint (2.8.0)

### DIFF
--- a/packages/goblint/goblint.2.8.0/opam
+++ b/packages/goblint/goblint.2.8.0/opam
@@ -1,0 +1,133 @@
+opam-version: "2.0"
+synopsis: "Static analysis framework for C"
+description: """
+Goblint is a sound static analysis framework for C programs using abstract interpretation.
+It specializes in thread-modular verification of multi-threaded programs, especially regarding data races.
+Goblint includes analyses for assertions, overflows, deadlocks, etc and can be extended with new analyses.
+"""
+maintainer: [
+  "Simmo Saan <simmo.saan@gmail.com>"
+  "Michael Schwarz <michael.schwarz93@gmail.com>"
+  "Karoliine Holter <karoliine.holter@ut.ee>"
+]
+authors: [
+  "Simmo Saan"
+  "Michael Schwarz"
+  "Julian Erhard"
+  "Sarah Tilscher"
+  "Karoliine Holter"
+  "Michael Petter"
+  "Ali Rasim Kocal"
+  "Ralf Vogler"
+  "Kalmer Apinis"
+  "Vesal Vojdani"
+]
+license: "MIT"
+tags: [
+  "program analysis"
+  "program verification"
+  "static analysis"
+  "abstract interpretation"
+  "C"
+  "data race analysis"
+  "concurrency"
+]
+homepage: "https://goblint.in.tum.de"
+doc: "https://goblint.readthedocs.io/en/latest/"
+bug-reports: "https://github.com/goblint/analyzer/issues"
+depends: [
+  "dune" {>= "3.20"}
+  "ocaml" {>= "4.14"}
+  "goblint-cil" {>= "2.1.0"}
+  "batteries" {>= "3.9.0"}
+  "patricia-tree" {>= "0.14.0"}
+  "zarith" {>= "1.12"}
+  "yojson" {>= "2.0.0" & < "3"}
+  "qcheck-core" {>= "0.19"}
+  "ppx_deriving" {>= "6.0.2"}
+  "ppx_deriving_hash" {>= "0.1.2"}
+  "ppx_deriving_yojson" {>= "3.7.0"}
+  "ppx_blob" {>= "0.8.0"}
+  "ppxlib" {>= "0.30.0"}
+  "ounit2" {with-test}
+  "qcheck-ounit" {with-test}
+  "odoc" {with-doc}
+  "fpath"
+  "dune-site"
+  "dune-build-info"
+  "json-data-encoding"
+  "jsonrpc" {>= "1.12"}
+  "sha" {>= "1.12"}
+  "fileutils" {>= "0.6.4"}
+  "cpu"
+  "arg-complete" {>= "0.2.1"}
+  "yaml" {>= "3.0.0"}
+  "uuidm"
+  "catapult"
+  "catapult-file"
+  "conf-gmp" {>= "3"}
+  "conf-ruby" {with-test}
+  "benchmark" {with-test}
+  "conf-gcc"
+  "domain-local-await"
+  "domain_shims"
+  "ocaml-lsp-server" {with-dev-setup}
+  "ocp-indent" {with-dev-setup}
+]
+depopts: ["apron" "z3" "domainslib" "memtrace"]
+conflicts: [
+  "dune" {>= "3.22.0"}
+  "result" {< "1.5"}
+  "apron" {< "v0.9.15"}
+  "camlidl" {< "1.13"}
+  "ez-conf-lib" {= "1"}
+  "mlgmpidl" {< "1.3.0"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+dev-repo: "git+https://github.com/goblint/analyzer.git"
+x-maintenance-intent: ["(latest)" "(latest).(latest-1)"]
+# on `dune build` goblint.opam will be generated from goblint.opam.template and dune-project
+# also remember to generate/adjust goblint.opam.locked!
+available: os-family != "bsd" & os-distribution != "alpine" & (arch != "arm64" | os = "macos")
+# pin-depends: [
+  # published goblint-cil 2.1.0 is currently up-to-date, so no pin needed
+  # [ "goblint-cil.2.1.0" "git+https://github.com/goblint/cil.git#76083d655d56e4c7791d457db57f0dd6461faf71" ]
+  # pinned for performance (https://github.com/ocaml-batteries-team/batteries-included/pull/1149) via fork, remove after new batteries release (and then bump the batteries lower-bound accordingly)
+  # [ "batteries.3.11.0" "git+https://github.com/sim642/batteries-included.git#3920bdf614e4a12120fabfa2c97ee913cc246b13" ]
+  # pinned for stability (https://github.com/goblint/analyzer/issues/1520), remove after new apron release
+  # [ "apron.v0.9.15" "git+https://github.com/antoinemine/apron.git#418a217c7a70dae3f422678f3aaba38ae374d91a" ]
+# ]
+depexts: [
+  ["libgraph-easy-perl"] {os-distribution = "ubuntu" & with-test} # doesn't work (https://github.com/ocaml/opam/issues/5836)
+]
+post-messages: [
+  "Do not benchmark Goblint on OCaml 5 (https://goblint.readthedocs.io/en/latest/user-guide/benchmarking/)." {ocaml:version >= "5.0.0"}
+]
+x-ci-accept-failures: [
+  "macos-homebrew" # newer MacOS headers cannot be parsed (https://github.com/ocaml/opam-repository/pull/26307#issuecomment-2258080206)
+  "opensuse-tumbleweed" # not GNU diff, so some cram tests fail (https://discuss.ocaml.org/t/opensuse-and-opam-tests/14641/2)
+]
+url {
+  src:
+    "https://github.com/goblint/analyzer/releases/download/v2.8.0/goblint-2.8.0.tbz"
+  checksum: [
+    "sha256=9175eec0143102243964e34a0786584fd590c60422009259c705a89a27f88de4"
+    "sha512=9d760007dd8d003cf596516444ed7acc7370fc3d446e75ac71b0176522c3baae090410762f9035e7aae4f6b0e394bf28bb5b1c08ca0476920b94aa919ef04f42"
+  ]
+}
+x-commit-hash: "1931b4d513dda298e05283d3476645fe1bda706f"


### PR DESCRIPTION
Static analysis framework for C

- Project page: <a href="https://goblint.in.tum.de">https://goblint.in.tum.de</a>
- Documentation: <a href="https://goblint.readthedocs.io/en/latest/">https://goblint.readthedocs.io/en/latest/</a>

##### CHANGES:

* Add new may-happen-in-parallel analyses (goblint/analyzer#1805, goblint/analyzer#1865, goblint/analyzer#1913, goblint/analyzer#1928).
* Add Open Verification Dashboard checks output (goblint/analyzer#1838, goblint/analyzer#1929).
* Add negative bitwise shift warnings (goblint/analyzer#1637, goblint/analyzer#1989).
* Add missing function declaration warnings (goblint/analyzer#1911).
* Improve overflow warnings (goblint/analyzer#1894, goblint/analyzer#1895, goblint/analyzer#1896, goblint/analyzer#1905).
* Fix spurious overflow checks (goblint/analyzer#1767, goblint/analyzer#1909, goblint/analyzer#1910, goblint/analyzer#1932, goblint/analyzer#2022).
* Fix missing overflow and out-of-bounds checks (goblint/analyzer#1935, goblint/analyzer#2017, goblint/analyzer#2029).
* Optimize base analysis domain using Patricia trees (goblint/analyzer#2002, goblint/analyzer#2015).
* Optimize field offset calculations (goblint/analyzer#1964, goblint/analyzer#1973, goblint/analyzer#1974).
* Optimize non-incremental top-down solver (goblint/analyzer#1566, goblint/analyzer#1972).
* Add OCaml 5.5 support (goblint/analyzer#2006, goblint/analyzer#2010).
