### PR TITLE
Bugfix release of OCaml 4.14.4

### DIFF
--- a/packages/ocaml-base-compiler/ocaml-base-compiler.4.14.4/opam
+++ b/packages/ocaml-base-compiler/ocaml-base-compiler.4.14.4/opam
@@ -1,0 +1,82 @@
+opam-version: "2.0"
+# These packages are part of the infrastructure for maintaining the OCaml
+# compiler dependencies in opam. It's not possible to version the metadata
+# itself, because opam's versioning provides no mechanism to ignore the
+# revision (i.e. we don't have a way to have two revisions of ocaml.5.4.1 but
+# where "ocaml" {= "5.4.1"} would always mean to use the latest revision).
+# It is however useful to know which version of the metadata is installed.
+# This number should be bumped whenever a pertinent change is made.
+x-revision: "3"
+synopsis: "Official release 4.14.4"
+maintainer: [
+  "David Allsopp <dra27@dra27.uk>"
+  "Florian Angeletti <florian.angeletti@inria.fr>"
+]
+license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
+authors: "Xavier Leroy and many contributors"
+homepage: "https://ocaml.org"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
+dev-repo: "git+https://github.com/ocaml/ocaml#4.14"
+depends: [
+  # This is OCaml 4.14.4
+  "ocaml" {= "4.14.4" & post}
+
+  # General base- packages
+  "base-unix" {post}
+  "base-bigarray" {post}
+  "base-threads" {post}
+
+  # Port selection (Windows)
+  # amd64 mingw-w64 / MSVC
+  (("arch-x86_64" {os = "win32" & arch = "x86_64"} &
+     ("system-mingw" | "system-msvc")) |
+  # i686 mingw-w64 / MSVC
+   ("arch-x86_32" {os = "win32"} &
+     ("system-mingw" | "system-msvc")) |
+  # Non-Windows systems need to install something to satisfy this formula, so
+  # repeat the base-unix dependency
+   "base-unix" {os != "win32" & post})
+
+  # OCaml with default configuration (no flambda, TSAN, etc.)
+  "ocaml-options-vanilla" {post}
+
+  # Support Packages
+  "flexdll" {>= "0.36" & os = "win32"}
+]
+conflict-class: "ocaml-core-compiler"
+flags: compiler
+build-env: MSYS2_ARG_CONV_EXCL = "*"
+setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
+x-env-path-rewrite: [
+  [CAML_LD_LIBRARY_PATH (";" {os = "win32"} ":" {os != "win32"}) "target"]
+]
+conflicts: "relocatable"
+build: [
+  [
+    "./configure"
+    "--host=x86_64-pc-windows"  {system-msvc:installed & arch-x86_64:installed}
+    "--host=x86_64-w64-mingw32" {os-distribution = "cygwin" & system-mingw:installed & arch-x86_64:installed}
+    "--host=i686-pc-windows"    {system-msvc:installed & arch-x86_32:installed}
+    "--host=i686-w64-mingw32"   {os-distribution = "cygwin" & system-mingw:installed & arch-x86_32:installed}
+    "--prefix=%{prefix}%"
+    "--docdir=%{doc}%/ocaml"
+    "--with-flexdll=%{flexdll:share}%" {os = "win32" & flexdll:installed}
+    "-C"
+    "CC=cc" {os = "openbsd" | os = "macos"}
+    "ASPP=cc -c" {os = "openbsd" | os = "macos"}
+  ]
+  [make "-j%{jobs}%"]
+]
+install: [make "install"]
+url {
+  src: "https://github.com/ocaml/ocaml/releases/download/4.14.4/ocaml_4.14.4.tar.gz"
+  checksum: "sha256=71415c000ebfce604defafaa584ab5ed10ad81ff180897db4e6fea8dac6e4b0d"
+}
+extra-source "ocaml-base-compiler.install" {
+  src:
+    "https://raw.githubusercontent.com/ocaml/ocaml/8c17fd444391392c5f9801241374d749c080c1a8/ocaml-variants.install"
+  checksum: [
+    "sha256=79f2a1a5044a91350a0eb6ce12e261a72a2855c094c425cddf3860e58c486678"
+    "md5=3e969b841df1f51ca448e6e6295cb451"
+  ]
+}

--- a/packages/ocaml-src/ocaml-src.4.14.4/opam
+++ b/packages/ocaml-src/ocaml-src.4.14.4/opam
@@ -1,0 +1,15 @@
+opam-version: "2.0"
+maintainer: "opam-devel@lists.ocaml.org"
+license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
+authors: "OCaml contributors"
+homepage: "http://ocaml.org/"
+build: [ "touch" "META" ]
+install: ["cp" "-r" "." "%{lib}%/ocaml-src"]
+synopsis: "Compiler sources"
+depends: [
+  "ocaml" {= "4.14.4"}
+]
+url {
+  src: "https://github.com/ocaml/ocaml/releases/download/4.14.4/ocaml_4.14.4.tar.gz"
+  checksum: "sha256=71415c000ebfce604defafaa584ab5ed10ad81ff180897db4e6fea8dac6e4b0d"
+}

--- a/packages/ocaml-system/ocaml-system.4.14.4/opam
+++ b/packages/ocaml-system/ocaml-system.4.14.4/opam
@@ -1,0 +1,65 @@
+opam-version: "2.0"
+# These packages are part of the infrastructure for maintaining the OCaml
+# compiler dependencies in opam. It's not possible to version the metadata
+# itself, because opam's versioning provides no mechanism to ignore the
+# revision (i.e. we don't have a way to have two revisions of ocaml.5.4.1 but
+# where "ocaml" {= "5.4.1"} would always mean to use the latest revision).
+# It is however useful to know which version of the metadata is installed.
+# This number should be bumped whenever a pertinent change is made.
+x-revision: "2"
+synopsis: "The OCaml compiler (system version, from outside of opam)"
+maintainer: [
+  "David Allsopp <dra27@dra27.uk>"
+  "Florian Angeletti <florian.angeletti@inria.fr>"
+]
+license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
+authors: "Xavier Leroy and many contributors"
+homepage: "https://ocaml.org"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
+dev-repo: "git+https://github.com/ocaml/ocaml"
+depends: [
+  # This is OCaml 4.14.4
+  "ocaml" {= "4.14.4" & post}
+
+  # General base- packages
+  "base-unix" {post}
+  "base-threads" {post}
+  "base-bigarray" {post}
+
+  # Architecture (Windows-only at present)
+  "host-arch-x86_32" {os = "win32" & ?sys-ocaml-arch & sys-ocaml-arch = "i686" & post}
+  "host-arch-x86_64" {os = "win32" & ?sys-ocaml-arch & sys-ocaml-arch = "x86_64" & post}
+  "host-arch-unknown" {os = "win32" & (!(?sys-ocaml-arch) |
+                       sys-ocaml-arch != "i686" &
+                       sys-ocaml-arch != "x86_64") & post}
+
+  # System (Windows-only at present)
+  "host-system-mingw" {os = "win32" & ?sys-ocaml-arch & sys-ocaml-libc = "msvc" & sys-ocaml-cc = "cc" & post}
+  "host-system-msvc" {os = "win32" & ?sys-ocaml-arch & sys-ocaml-cc = "msvc" & post}
+  "host-system-other" {os = "win32" & ?sys-ocaml-arch & sys-ocaml-libc != "msvc" & post}
+
+  # Environment configuration (Windows-only)
+  # NB There are not "system" distributions of OCaml on Windows; the support
+  # here is intended for binary caching setups, choosing to install a build
+  # of OCaml external to opam, but still using opam to provide the C compiler
+  # configuration.
+  "conf-mingw-w64-gcc-x86_64" {?sys-ocaml-arch & sys-ocaml-arch = "x86_64" & sys-ocaml-libc = "msvc" & sys-ocaml-cc = "cc" & post}
+  "conf-mingw-w64-gcc-i686" {?sys-ocaml-arch & sys-ocaml-arch = "i686" & sys-ocaml-libc = "msvc" & sys-ocaml-cc = "cc" & post}
+  "ocaml-env-mingw32" {?sys-ocaml-arch & sys-ocaml-libc = "msvc" & sys-ocaml-arch = "i686" & sys-ocaml-cc = "cc" & post}
+  "ocaml-env-mingw64" {?sys-ocaml-arch & sys-ocaml-libc = "msvc" & sys-ocaml-arch = "x86_64" & sys-ocaml-cc = "cc" & post}
+  "ocaml-env-msvc32" {?sys-ocaml-arch & sys-ocaml-arch = "i686" & sys-ocaml-cc = "msvc" & post}
+  "ocaml-env-msvc64" {?sys-ocaml-arch & sys-ocaml-arch = "x86_64" & sys-ocaml-cc = "msvc" & post}
+]
+conflict-class: "ocaml-core-compiler"
+available: sys-ocaml-version = "4.14.4" & (os != "win32" | sys-ocaml-libc = "msvc")
+flags: [compiler avoid-version]
+build: ["ocaml" "gen_ocaml_config.ml"]
+substs: "gen_ocaml_config.ml"
+extra-source "gen_ocaml_config.ml.in" {
+  src:
+    "https://raw.githubusercontent.com/ocaml/ocaml/bcb802e851a1391ac6fff957d63b0edbf849225a/tools/opam/gen_ocaml-system_config.ml.in"
+  checksum: [
+    "sha256=71bcd3d35e28cbf71eda81991c8741268f4b87ced71573b2e75f64f136cebfc1"
+    "md5=093e7bec1ec95f9e4c6a313d73c5d840"
+  ]
+}

--- a/packages/ocaml-variants/ocaml-variants.4.14.4+options/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.14.4+options/opam
@@ -1,0 +1,114 @@
+opam-version: "2.0"
+# These packages are part of the infrastructure for maintaining the OCaml
+# compiler dependencies in opam. It's not possible to version the metadata
+# itself, because opam's versioning provides no mechanism to ignore the
+# revision (i.e. we don't have a way to have two revisions of ocaml.5.4.1 but
+# where "ocaml" {= "5.4.1"} would always mean to use the latest revision).
+# It is however useful to know which version of the metadata is installed.
+# This number should be bumped whenever a pertinent change is made.
+x-revision: "3"
+license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
+synopsis: "Official release of OCaml 4.14.4"
+maintainer: [
+  "David Allsopp <dra27@dra27.uk>"
+  "Florian Angeletti <florian.angeletti@inria.fr>"
+]
+authors: ["Xavier Leroy" "Damien Doligez" "Alain Frisch" "Jacques Garrigue" "Didier Rémy" "Jérôme Vouillon"]
+homepage: "https://ocaml.org"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
+dev-repo: "git+https://github.com/ocaml/ocaml.git#4.14"
+depends: [
+  # This is OCaml 4.14.4
+  "ocaml" {= "4.14.4" & post}
+
+  # General base- packages
+  "base-unix" {post}
+  "base-bigarray" {post}
+  "base-threads" {post}
+
+  # Port selection (Windows)
+  # amd64 mingw-w64 / MSVC
+  (("arch-x86_64" {os = "win32" & arch = "x86_64"} &
+     ("system-mingw" | "system-msvc")) |
+  # i686 mingw-w64 / MSVC
+   ("arch-x86_32" {os = "win32"} &
+     ("system-mingw" | "system-msvc")) |
+  # Non-Windows systems need to install something to satisfy this formula, so
+  # repeat the base-unix dependency
+   "base-unix" {os != "win32" & post})
+
+  # Support Packages
+  "flexdll" {>= "0.36" & os = "win32"}
+]
+conflict-class: "ocaml-core-compiler"
+flags: compiler
+build-env: MSYS2_ARG_CONV_EXCL = "*"
+setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
+x-env-path-rewrite: [
+  [CAML_LD_LIBRARY_PATH (";" {os = "win32"} ":" {os != "win32"}) "target"]
+]
+conflicts: "relocatable"
+build: [
+  [
+    "./configure"
+    "--host=x86_64-pc-windows"  {system-msvc:installed & arch-x86_64:installed}
+    "--host=x86_64-w64-mingw32" {os-distribution = "cygwin" & system-mingw:installed & arch-x86_64:installed}
+    "--host=i686-pc-windows"    {system-msvc:installed & arch-x86_32:installed}
+    "--host=i686-w64-mingw32"   {os-distribution = "cygwin" & system-mingw:installed & arch-x86_32:installed}
+    "--prefix=%{prefix}%"
+    "--docdir=%{doc}%/ocaml"
+    "--with-flexdll=%{flexdll:share}%" {os = "win32" & flexdll:installed}
+    "-C"
+    "--with-afl" {ocaml-option-afl:installed}
+    "--disable-native-compiler" {ocaml-option-bytecode-only:installed}
+    "--disable-force-safe-string" {ocaml-option-default-unsafe-string:installed}
+    "DEFAULT_STRING=unsafe" {ocaml-option-default-unsafe-string:installed}
+    "--disable-flat-float-array" {ocaml-option-no-flat-float-array:installed}
+    "--enable-flambda" {ocaml-option-flambda:installed}
+    "--enable-frame-pointers" {ocaml-option-fp:installed}
+    "--disable-naked-pointers" {ocaml-option-nnp:installed}
+    "--enable-naked-pointers-checker" {ocaml-option-nnpchecker:installed}
+    "CC=cc" {!ocaml-option-32bit:installed & !ocaml-option-musl:installed & (os="openbsd"|os="macos")}
+    "CC=musl-gcc" {ocaml-option-musl:installed & os-distribution!="alpine"}
+    "CFLAGS=-Os" {ocaml-option-musl:installed}
+    "CC=gcc -m32" {ocaml-option-32bit:installed & os="linux"}
+    "CC=gcc -Wl,-read_only_relocs,suppress -arch i386 -m32" {ocaml-option-32bit:installed & os="macos"}
+    "ASPP=cc -c" {!ocaml-option-32bit:installed & !ocaml-option-musl:installed & (os="openbsd"|os="macos")}
+    "ASPP=musl-gcc -c" {ocaml-option-musl:installed & os-distribution!="alpine"}
+    "ASPP=gcc -m32 -c" {ocaml-option-32bit:installed & os="linux"}
+    "ASPP=gcc -arch i386 -m32 -c" {ocaml-option-32bit:installed & os="macos"}
+    "AS=as --32" {ocaml-option-32bit:installed & os="linux"}
+    "AS=as -arch i386" {ocaml-option-32bit:installed & os="macos"}
+    "--host=i386-linux" {ocaml-option-32bit:installed & os="linux"}
+    "--host=i386-apple-darwin13.2.0" {ocaml-option-32bit:installed & os="macos"}
+    "PARTIALLD=ld -r -melf_i386" {ocaml-option-32bit:installed & os="linux"}
+    "LIBS=-static" {ocaml-option-static:installed}
+  ]
+  [make "-j%{jobs}%"]
+]
+install: [make "install"]
+url {
+  src: "https://github.com/ocaml/ocaml/releases/download/4.14.4/ocaml_4.14.4.tar.gz"
+  checksum: "sha256=71415c000ebfce604defafaa584ab5ed10ad81ff180897db4e6fea8dac6e4b0d"
+}
+depopts: [
+  "ocaml-option-32bit"
+  "ocaml-option-afl"
+  "ocaml-option-bytecode-only"
+  "ocaml-option-default-unsafe-string"
+  "ocaml-option-no-flat-float-array"
+  "ocaml-option-flambda"
+  "ocaml-option-fp"
+  "ocaml-option-musl"
+  "ocaml-option-static"
+  "ocaml-option-nnp"
+  "ocaml-option-nnpchecker"
+]
+extra-source "ocaml-variants.install" {
+  src:
+    "https://raw.githubusercontent.com/ocaml/ocaml/8c17fd444391392c5f9801241374d749c080c1a8/ocaml-variants.install"
+  checksum: [
+    "sha256=79f2a1a5044a91350a0eb6ce12e261a72a2855c094c425cddf3860e58c486678"
+    "md5=3e969b841df1f51ca448e6e6295cb451"
+  ]
+}

--- a/packages/ocaml-variants/ocaml-variants.4.14.5+trunk/opam
+++ b/packages/ocaml-variants/ocaml-variants.4.14.5+trunk/opam
@@ -25,8 +25,8 @@ homepage: "https://ocaml.org"
 bug-reports: "https://github.com/ocaml/opam-repository/issues"
 dev-repo: "git+https://github.com/ocaml/ocaml.git#4.14"
 depends: [
-  # This is OCaml 4.14.3
-  "ocaml" {= "4.14.3" & post}
+  # This is OCaml 4.14.5
+  "ocaml" {= "4.14.5" & post}
 
   # General base- packages
   "base-unix" {post}

--- a/packages/ocaml/ocaml.4.14.5/opam
+++ b/packages/ocaml/ocaml.4.14.5/opam
@@ -1,0 +1,48 @@
+opam-version: "2.0"
+# These packages are part of the infrastructure for maintaining the OCaml
+# compiler dependencies in opam. It's not possible to version the metadata
+# itself, because opam's versioning provides no mechanism to ignore the
+# revision (i.e. we don't have a way to have two revisions of ocaml.5.4.1 but
+# where "ocaml" {= "5.4.1"} would always mean to use the latest revision).
+# It is however useful to know which version of the metadata is installed.
+# This number should be bumped whenever a pertinent change is made.
+x-revision: "2"
+license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
+synopsis: "The OCaml compiler (virtual package)"
+description: """
+This package requires a matching implementation of OCaml,
+and polls it to initialise specific variables like `ocaml:native-dynlink`"""
+maintainer: "David Allsopp <dra27@dra27.uk>"
+depends: [
+  "ocaml-config" {>= "2"}
+  "ocaml-base-compiler" {>= "4.14.5~" & < "4.14.6~"} |
+  "ocaml-variants" {>= "4.14.5~" & < "4.14.6~"} |
+  "ocaml-system" {>= "4.14.5" & < "4.14.6~"} |
+  "dkml-base-compiler" {>= "4.14.5~" & < "4.14.6~"}
+  ("ocaml-env-mingw64" {os = "win32"} | "ocaml-env-mingw32" {os = "win32"} |
+   "ocaml-env-msvc64" {os = "win32"} | "ocaml-env-msvc32" {os = "win32"})
+]
+setenv: [
+  [OCAMLTOP_INCLUDE_PATH += "%{toplevel}%"]
+  [CAML_LD_LIBRARY_PATH = "%{_:stubsdir}%"]
+  [CAML_LD_LIBRARY_PATH += "%{lib}%/stublibs"]
+  # Legacy opam variable
+  [OCAML_TOPLEVEL_PATH = "%{toplevel}%"]
+]
+x-env-path-rewrite: [
+  [CAML_LD_LIBRARY_PATH (";" {os = "win32"} ":" {os != "win32"}) "target"]
+  [OCAMLTOP_INCLUDE_PATH (";" {os = "win32"} ":" {os != "win32"}) "target"]
+]
+build: ["ocaml" "%{ocaml-config:share}%/gen_ocaml_config.ml" _:version _:name]
+build-env: CAML_LD_LIBRARY_PATH = ""
+homepage: "https://ocaml.org"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
+authors: [
+  "Xavier Leroy"
+  "Damien Doligez"
+  "Alain Frisch"
+  "Jacques Garrigue"
+  "Didier Rémy"
+  "Jérôme Vouillon"
+]
+flags: [conf avoid-version]


### PR DESCRIPTION
This is a bug fix release of the OCaml 4 branch which contains two security fixes in the standard library, one ARM64 compilation fix, and various configuration and build fixes.

As usual this PR contains the 3 main package 

- ocaml-base-compiler.4.14.4
- ocaml-system.4.14.4
- ocaml-variants.4.14.4+options

the source file package

- ocaml-source.4.14.4

but also the `ocaml.4.14.5` metapackage and it moves the ocaml 4 + trunk package from `ocaml-variants.4.14.4+trunk` to `ocaml-variants.4.14.5+trunk`.