### PR TITLE
Remove pkg config workaround

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -159,7 +159,7 @@ jobs:
       - name: Set-up OCaml
         uses: ocaml/setup-ocaml@v3
         with:
-          ocaml-compiler: "ocaml-base-compiler,conf-pkg-config"
+          ocaml-compiler: "5"
           opam-repositories: |
             default: git+file://${{ github.workspace }}#repo-${{ github.event.pull_request.base.sha }}
           opam-pin: false

--- a/packages/conf-allegro5/conf-allegro5.2/opam
+++ b/packages/conf-allegro5/conf-allegro5.2/opam
@@ -4,7 +4,9 @@ homepage: "https://liballeg.org"
 authors: "The Allegro authors"
 bug-reports: "https://github.com/ocaml/opam-repository/issues"
 license: "Giftware"
-build: ["pkg-config" "allegro-5"]
+build: [
+  [conf-pkg-config:command "allegro-5"]
+]
 depexts: [
   [
     "allegro5-devel"
@@ -34,13 +36,12 @@ depexts: [
   ["allegro5"] {os = "freebsd"}
   ["allegro5"] {os = "netbsd"}
 ]
-available: os != "win32"
 synopsis: "Virtual package relying on Allegro 5 development libraries"
 description:
   "This package can only install if Allegro 5 development libraries are accessible through pkg-config."
 depends: [
-  "conf-pkg-config" {build}
-  ("host-arch-x86_32" {os-distribution = "msys2"} & "conf-mingw-w64-sdl2-i686" {os-distribution = "msys2"} |
-   "host-arch-x86_64" {os-distribution = "msys2"} & "conf-mingw-w64-sdl2-x86_64" {os-distribution = "msys2"})
+  "conf-pkg-config" {>= "5"}
+  ("host-arch-x86_64" {os-distribution = "msys2"} & "conf-mingw-w64-allegro5-x86_64" {os-distribution = "msys2"} |
+   "host-arch-x86_32" {os-distribution = "msys2"} & "conf-mingw-w64-allegro5-i686" {os-distribution = "msys2"})
 ]
 flags: conf


### PR DESCRIPTION
Two temporary commits were added in #29998; one was reverted in #30040 and this PR reverts the other.

By way of demonstration of where we now are, I include a fix for conf-allegro5, which is presently broken on MSYS2 because the dependency is wrong. I've fixed it by introducing a new conf-allegro5.2 package - using the nice new conf-pkg-config.5 - and constraining the old package away from Windows completely. The MSYS2 runner displays what's expected:

```
conf-allegro5.1: base = fail -> PR = skip

Testing conf-allegro5.2
conf-allegro5.2 installed successfully.

Testing conf-allegro5.1
conf-allegro5.1 is not installable. Skip.
```

Also of note:
- The MSYS2 CI _only_ installs the x86_64 depext; it doesn't attempt to install the i686 one as well (#30029 in action)
- Neither workflow rebuilds the compiler as a result of installing conf-pkg-config (#30040 in action)

The Cygwin runner is expected to fail here because there _isn't_ a depext for this library. The fact I haven't (yet) implemented `x-ci-accept-failures` for the Windows CI workflow has nothing to do with Anthropic's export restrictions...