### PR TITLE
Update pratter 5.0.2

### DIFF
--- a/packages/pratter/pratter.5.0.2/opam
+++ b/packages/pratter/pratter.5.0.2/opam
@@ -1,5 +1,4 @@
 opam-version: "2.0"
-version: "5.0.2"
 synopsis: "A table-driven operator precedence parser"
 description: """
 Pratter is a top-down operator precedence parser that allows to

--- a/packages/pratter/pratter.5.0.2/opam
+++ b/packages/pratter/pratter.5.0.2/opam
@@ -36,5 +36,8 @@ build: [
 dev-repo: "git+https://github.com/Deducteam/pratter"
 url {
   src: "https://codeload.github.com/Deducteam/pratter/tar.gz/refs/tags/5.0.2"
-  checksum: "sha224=d27592a2a31bc29c6563c4a277c8cce8851c5994a553cd1bb6ebea8c"
+  checksum: [
+    "sha256=f690a04270747947277e06116a13a5b163413439d72c1a902a2bff9abe548ad6"
+    "sha512=03a06fe36bad084f9f3730526d0cdf9a410d137256329455df6a4c97421ab0a30b859140f54e72e6e26d86c455a257ff391de007680b8c7bcec013cbd307ad19"
+  ]
 }

--- a/packages/pratter/pratter.5.0.2/opam
+++ b/packages/pratter/pratter.5.0.2/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+version: "5.0.2"
+synopsis: "A table-driven operator precedence parser"
+description: """
+Pratter is a top-down operator precedence parser that allows to
+parse expressions with infix, prefix and postfix operators.
+"""
+maintainer: ["Gabriel Hondet"]
+authors: ["Gabriel Hondet"]
+license: "BSD-3-Clause"
+homepage: "https://github.com/Deducteam/pratter"
+bug-reports: "https://github.com/Deducteam/pratter/issues"
+depends: [
+  "ocaml" {>= "4.10.0"}
+  "dune" {>= "2.7"}
+  # Release 1.5.0 of alcotest fixes interactions with the result library
+  "alcotest" {with-test & >= "1.5.0" & < "2"}
+  "qcheck" {with-test & >= "0.12" }
+  "qcheck-alcotest" {with-test & >= "0.12"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/Deducteam/pratter"
+url {
+  src: "https://codeload.github.com/Deducteam/pratter/tar.gz/refs/tags/5.0.2"
+  checksum: "sha224=d27592a2a31bc29c6563c4a277c8cce8851c5994a553cd1bb6ebea8c"
+}


### PR DESCRIPTION
Update the OCaml library pratter to version 5.0.2. In particular, the project is now hosted at <https://github.com/Deducteam/pratter>.