### PR TITLE
[new release] lstar-rocq (2 packages) (2.0)

### DIFF
--- a/packages/lstar-rocq/lstar-rocq.2.0/opam
+++ b/packages/lstar-rocq/lstar-rocq.2.0/opam
@@ -1,0 +1,43 @@
+opam-version: "2.0"
+synopsis: "Formally-verified automata learning in Rocq"
+description:
+  "Formally-verified implementations of L* and similar algorithms in Rocq"
+maintainer: ["Charles Averill <charlesaverill20@gmail.com>"]
+authors: ["Charles Averill <charlesaverill20@gmail.com>"]
+license: "MIT"
+homepage: "https://github.com/CharlesAverill/lstar-rocq"
+doc: "https://github.com/CharlesAverill/lstar-rocq"
+bug-reports: "https://github.com/CharlesAverill/lstar-rocq/issues"
+depends: [
+  "dune" {>= "3.21"}
+  "rocq-core" {>= "9.1.0"}
+  "rocq-prover"
+  "rocq-stdlib"
+  "rocq-runtime"
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/CharlesAverill/lstar-rocq.git"
+x-maintenance-intent: ["(latest)"]
+url {
+  src:
+    "https://github.com/CharlesAverill/lstar-rocq/releases/download/v2.0/lstar-rocq-2.0.tbz"
+  checksum: [
+    "sha256=c0e054fc161cd19cbe5926074527d11be7d05f2ba2a642f4f17ec9451740d9d9"
+    "sha512=9ea8383a8632fc12a6e3993d91a8f696ea3daf704628037250c8af7e315112a9557608348332f194122b62711ed2a554c5500abe57b49e174ebf4d9974786dac"
+  ]
+}
+x-commit-hash: "533a502347dc1c998fb7063ac725fc8b65a5a4fd"

--- a/packages/lstar/lstar.2.0/opam
+++ b/packages/lstar/lstar.2.0/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+synopsis: "Automata learning with from lstar-rocq"
+description: "Formally-verified implementations of L* and similar algorithms"
+maintainer: ["Charles Averill <charlesaverill20@gmail.com>"]
+authors: ["Charles Averill <charlesaverill20@gmail.com>"]
+license: "MIT"
+homepage: "https://github.com/CharlesAverill/lstar-rocq"
+doc: "https://github.com/CharlesAverill/lstar-rocq"
+bug-reports: "https://github.com/CharlesAverill/lstar-rocq/issues"
+depends: [
+  "dune" {>= "3.21"}
+  "rocq-core" {>= "9.1.0"}
+  "rocq-prover"
+  "rocq-stdlib"
+  "rocq-runtime"
+  "lstar-rocq" {= version}
+  "odoc" {with-doc}
+]
+dev-repo: "git+https://github.com/CharlesAverill/lstar-rocq.git"
+x-maintenance-intent: ["(latest)"]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src:
+    "https://github.com/CharlesAverill/lstar-rocq/releases/download/v2.0/lstar-rocq-2.0.tbz"
+  checksum: [
+    "sha256=c0e054fc161cd19cbe5926074527d11be7d05f2ba2a642f4f17ec9451740d9d9"
+    "sha512=9ea8383a8632fc12a6e3993d91a8f696ea3daf704628037250c8af7e315112a9557608348332f194122b62711ed2a554c5500abe57b49e174ebf4d9974786dac"
+  ]
+}
+x-commit-hash: "533a502347dc1c998fb7063ac725fc8b65a5a4fd"


### PR DESCRIPTION
Formally-verified automata learning in Rocq

- Project page: <a href="https://github.com/CharlesAverill/lstar-rocq">https://github.com/CharlesAverill/lstar-rocq</a>
- Documentation: <a href="https://github.com/CharlesAverill/lstar-rocq">https://github.com/CharlesAverill/lstar-rocq</a>

##### CHANGES:

Breaking changes.
Both L* and KV signatures have changed, requiring passing fuel in via the `Teacher`
module rather than upon calling the learner loop.
This arises from new guarantees about termination and minimality for both algorithms.
