### PR TITLE
[new release] tbls (0.4.0)

### DIFF
--- a/packages/tbls/tbls.0.4.0/opam
+++ b/packages/tbls/tbls.0.4.0/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+synopsis: "Pure OCaml library for rendering tabular data"
+description:
+  "Pure OCaml library for rendering tabular data to plain text, Markdown, or HTML. Accepts typed column descriptors or raw string rows, infers integer and float columns, right-aligns numeric values, and returns a string. No runtime dependencies."
+maintainer: ["Sergiy Duras <sergiy@duras.org>"]
+authors: ["Sergiy Duras <sergiy@duras.org>"]
+license: "ISC"
+homepage: "https://codeberg.org/duras/tbls"
+bug-reports: "https://codeberg.org/duras/tbls/issues"
+depends: [
+  "dune" {>= "3.23"}
+  "ocaml" {>= "4.14.0"}
+  "alcotest" {with-test & >= "1.7.0"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/sduras/tbls.git"
+x-maintenance-intent: ["(latest)"]
+url {
+  src:
+    "https://github.com/sduras/tbls/releases/download/0.4.0/tbls-0.4.0.tbz"
+  checksum: [
+    "sha256=9154b258995809c492ebe33b3b070f3a4ec3831f0581ea403824dac1f82e3de0"
+    "sha512=db52c74fecbe987e92915e05c10865b9eb67d057bfd3a03c33d3139a3127a0caaaafbc6ead6a3ac31686c2aa9ee58753142205c563fcd158f0564412ceb7afbc"
+  ]
+}
+x-commit-hash: "64465183996f2e2c3817afda683b24ea1435ca65"


### PR DESCRIPTION
Pure OCaml library for rendering tabular data

- Project page: <a href="https://codeberg.org/duras/tbls">https://codeberg.org/duras/tbls</a>

##### CHANGES:

- Extended East Asian Width table to cover emoji and symbols in the
  U+23xx–U+2Bxx range (✅ U+2705, ⏳ U+23F3, and ~50 related codepoints
  previously misclassified as width 1).
- Added `Width.has_wide_chars`: returns true if a string contains any
  display-width-2 character.
- Added `Width.map_segments`: applies separate transformations to runs of
  wide and narrow characters; used for ANSI coloring that preserves emoji
  native rendering.
- Text renderer: ANSI color applied to header cells (dark orange bold) and
  border characters (dim). Wide-character runs in header cells are excluded
  from foreground coloring so emoji render with their own color.
- Color disabled when `NO_COLOR` is set to any value or `TERM` is `dumb`.
- Markdown separator row now padded to column display width (`:----` for a
  width-5 left-aligned column, not `:---`).
- HTML renderer strips pre-applied cell padding; alignment is expressed via
  the `align` attribute, leaving cell text unpadded.
- CLI utility `tbls(1)`: reads CSV or TSV from files or standard input,
  writes rendered table to standard output.
- CLI flags: `--format text|markdown|html`, `--border ascii|unicode|none`,
  `--delimiter char`, `--no-header`, `--null string`.
- RFC 4180 CSV parser with quoted-field support. Multiline quoted fields
  not supported.
- Exit codes: 0 success, 1 invalid arguments, 2 parse failure, 3 file
  access failure, 4 render failure.
- Man page `tbls(1)`.
