### PR TITLE
[new release] tbls (0.4.0)

### DIFF
--- a/packages/tbls/tbls.0.4.0/opam
+++ b/packages/tbls/tbls.0.4.0/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+synopsis: "Pure OCaml library for rendering tabular data"
+description:
+  "Pure OCaml library for rendering tabular data to plain text, Markdown, or HTML. Accepts typed column descriptors or raw string rows, infers integer and float columns, right-aligns numeric values, and returns a string. No runtime dependencies."
+maintainer: ["Sergiy Duras <sergiy@duras.org>"]
+authors: ["Sergiy Duras <sergiy@duras.org>"]
+license: "ISC"
+homepage: "https://codeberg.org/duras/tbls"
+bug-reports: "https://codeberg.org/duras/tbls/issues"
+depends: [
+  "dune" {>= "3.23"}
+  "ocaml" {>= "4.14.0"}
+  "alcotest" {with-test & >= "1.7.0"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/sduras/tbls.git"
+x-maintenance-intent: ["(latest)"]
+url {
+  src:
+    "https://github.com/sduras/tbls/releases/download/0.4.0/tbls-0.4.0.tbz"
+  checksum: [
+    "sha256=27152327074676748020d11ce3cc91cc8c37cd343db64591b1f7af0ff5b62c1d"
+    "sha512=f440832e1716c9faf5893f24ce54501fbe373d92889b8612e0661d279c1b92ed2f040ea8f14c031bb00bd7b381950ab23a027cac530eb53834ef3d4c730c6c11"
+  ]
+}
+x-commit-hash: "b4ef3b6ebad98102a839d417bf6a430dcccea4ca"


### PR DESCRIPTION
Pure OCaml library for rendering tabular data

- Project page: <a href="https://codeberg.org/duras/tbls">https://codeberg.org/duras/tbls</a>

##### CHANGES:

- Fixed display-width calculation for emoji and symbols in the U+23xx–U+2Bxx range.
- Added `Width.has_wide_chars`.
- Added `Width.map_segments`.
- Improved ANSI-colored text output while preserving native emoji colors.
- Disable color when `NO_COLOR` is set or `TERM=dumb`.
- Markdown separator rows now match column display width.
- Simplified HTML output by removing pre-applied cell padding.
- Added `tbls(1)` CLI for rendering CSV/TSV as text, Markdown, or HTML tables.
- Added RFC 4180 CSV parsing with quoted-field support (multiline fields not supported).
- Added standard exit codes and `tbls(1)` manual page.
