### PR TITLE
OCaml 4.14.4: remove avoid-version

### DIFF
--- a/packages/ocaml/ocaml.4.14.4/opam
+++ b/packages/ocaml/ocaml.4.14.4/opam
@@ -45,4 +45,4 @@ authors: [
   "Didier Rémy"
   "Jérôme Vouillon"
 ]
-flags: [conf avoid-version]
+flags: [conf]


### PR DESCRIPTION
/cc @Octachron 