### PR TITLE
Package ocaml-version.4.1.3

### DIFF
--- a/packages/ocaml-version/ocaml-version.4.1.3/opam
+++ b/packages/ocaml-version/ocaml-version.4.1.3/opam
@@ -1,0 +1,54 @@
+opam-version: "2.0"
+synopsis: "Manipulate, parse and generate OCaml compiler version strings"
+description: """\
+This library provides facilities to parse version numbers of the OCaml compiler, and enumerates the various official OCaml releases and configuration variants.
+
+OCaml version numbers are of the form `major.minor.patch+extra`, where the `patch` and `extra` fields are optional.  This library offers the following functionality:
+
+- Functions to parse and serialise OCaml compiler version numbers.
+- Enumeration of official OCaml compiler version releases.
+- Test compiler versions for a particular feature (e.g. the `bytes` type)
+- [opam](https://opam.ocaml.org) compiler switch enumeration.
+
+### Further information
+
+- **Discussion:** Post on <https://discuss.ocaml.org/> with the `ocaml` tag under the Ecosystem category.
+- **Bugs:** <https://github.com/ocurrent/ocaml-version/issues>
+- **Docs:** <http://docs.mirage.io/ocaml-version>"""
+maintainer: "Anil Madhavapeddy <anil@recoil.org>"
+authors: "Anil Madhavapeddy <anil@recoil.org>"
+license: "ISC"
+tags: "org:ocamllabs"
+homepage: "https://github.com/ocurrent/ocaml-version"
+doc: "https://ocurrent.github.io/ocaml-version/doc"
+bug-reports: "https://github.com/ocurrent/ocaml-version/issues"
+depends: [
+  "dune" {>= "3.6"}
+  "ocaml" {>= "4.07.0"}
+  "alcotest" {with-test}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/ocurrent/ocaml-version.git"
+url {
+  src:
+    "https://github.com/ocurrent/ocaml-version/releases/download/v4.1.3/ocaml-version-4.1.3.tbz"
+  checksum: [
+    "md5=867c6b0abd51a8a04781a495db97f2ea"
+    "sha512=654c76169f8bccfa370a782684f5df753d5bfb37e23cb2f011e2591ea0b6bda1544d8454e9c6c2a74695892bb5a9155466e5d546763c0b07e18a61b3c061130c"
+  ]
+}
+x-maintenance-intent: ["(latest)"]


### PR DESCRIPTION
### `ocaml-version.4.1.3`
Manipulate, parse and generate OCaml compiler version strings
This library provides facilities to parse version numbers of the OCaml compiler, and enumerates the various official OCaml releases and configuration variants.

OCaml version numbers are of the form `major.minor.patch+extra`, where the `patch` and `extra` fields are optional.  This library offers the following functionality:

- Functions to parse and serialise OCaml compiler version numbers.
- Enumeration of official OCaml compiler version releases.
- Test compiler versions for a particular feature (e.g. the `bytes` type)
- [opam](https://opam.ocaml.org) compiler switch enumeration.

### Further information

- **Discussion:** Post on <https://discuss.ocaml.org/> with the `ocaml` tag under the Ecosystem category.
- **Bugs:** <https://github.com/ocurrent/ocaml-version/issues>
- **Docs:** <http://docs.mirage.io/ocaml-version>



---
* Homepage: https://github.com/ocurrent/ocaml-version
* Source repo: git+https://github.com/ocurrent/ocaml-version.git
* Bug tracker: https://github.com/ocurrent/ocaml-version/issues

---
## What's Changed
* Add OCaml 5.5.0 release by @Octachron in https://github.com/ocurrent/ocaml-version/pull/92


**Full Changelog**: https://github.com/ocurrent/ocaml-version/compare/v4.1.2...v4.1.3


---
:camel: Pull-request generated by opam-publish v2.5.1
