### PR TITLE
ocsipersist-{dbm,sqlite,pgs} are not compatible with new release

### DIFF
--- a/packages/ocsipersist-dbm/ocsipersist-dbm.2.0.0/opam
+++ b/packages/ocsipersist-dbm/ocsipersist-dbm.2.0.0/opam
@@ -16,6 +16,7 @@ depends: [
   "lwt" {>= "4.2.0"}
   "lwt_log"
   "ocsipersist" {>= "2.0.0" & < "2.1.0"}
+  "ocsipersist-lib" {>= "2.0.0" & < "2.1.0"}
   "dbm"
 ]
 url {

--- a/packages/ocsipersist-pgsql/ocsipersist-pgsql.2.0.0/opam
+++ b/packages/ocsipersist-pgsql/ocsipersist-pgsql.2.0.0/opam
@@ -16,6 +16,7 @@ depends: [
   "lwt" {>= "4.2.0"}
   "lwt_log"
   "ocsipersist" {>= "2.0.0" & < "2.1.0"}
+  "ocsipersist-lib" {>= "2.0.0" & < "2.1.0"}
   "pgocaml"
 ]
 url {

--- a/packages/ocsipersist-sqlite/ocsipersist-sqlite.2.0.0/opam
+++ b/packages/ocsipersist-sqlite/ocsipersist-sqlite.2.0.0/opam
@@ -15,6 +15,7 @@ depends: [
   "lwt" {>= "4.2.0"}
   "lwt_log"
   "ocsipersist" {>= "2.0.0" & < "2.1.0"}
+  "ocsipersist-lib" {>= "2.0.0" & < "2.1.0"}
   "sqlite3"
 ]
 url {


### PR DESCRIPTION
Should fix the revdeps of https://github.com/ocaml/opam-repository/pull/30046