### PR TITLE
[new release] js_of_ocaml (8 packages) (6.4.0)

### DIFF
--- a/packages/eliom/eliom.12.0.0/opam
+++ b/packages/eliom/eliom.12.0.0/opam
@@ -21,14 +21,14 @@ depends: [
   "ocamlfind"
   "ppx_deriving"
   "ppxlib" {>= "0.37"}
-  "js_of_ocaml-compiler" {>= "6.3.2"}
-  "wasm_of_ocaml-compiler" {>= "6.3.2"}
-  "js_of_ocaml" {>= "6.3.2"}
-  "js_of_ocaml-lwt" {>= "6.3.2"}
+  "js_of_ocaml-compiler" {>= "6.3.2" & < "6.4.0"}
+  "wasm_of_ocaml-compiler" {>= "6.3.2" & < "6.4.0"}
+  "js_of_ocaml" {>= "6.3.2" & < "6.4.0"}
+  "js_of_ocaml-lwt" {>= "6.3.2" & < "6.4.0"}
   "js_of_ocaml-ocamlbuild" {build}
-  "js_of_ocaml-ppx" {>= "6.3.2"}
-  "js_of_ocaml-ppx_deriving_json" {>= "6.3.2"}
-  "js_of_ocaml-tyxml" {>= "6.3.2"}
+  "js_of_ocaml-ppx" {>= "6.3.2" & < "6.4.0"}
+  "js_of_ocaml-ppx_deriving_json" {>= "6.3.2" & < "6.4.0"}
+  "js_of_ocaml-tyxml" {>= "6.3.2" & < "6.4.0"}
   "logs"
   "tyxml" {>= "4.6" & < "4.7"}
   "ocsigenserver" {>= "7.0" & < "8.0"}

--- a/packages/eliom/eliom.12.0.1/opam
+++ b/packages/eliom/eliom.12.0.1/opam
@@ -21,14 +21,14 @@ depends: [
   "ocamlfind"
   "ppx_deriving"
   "ppxlib" {>= "0.37"}
-  "js_of_ocaml-compiler" {>= "6.3.2"}
-  "wasm_of_ocaml-compiler" {>= "6.3.2"}
-  "js_of_ocaml" {>= "6.3.2"}
-  "js_of_ocaml-lwt" {>= "6.3.2"}
+  "js_of_ocaml-compiler" {>= "6.3.2" & < "6.4.0"}
+  "wasm_of_ocaml-compiler" {>= "6.3.2" & < "6.4.0"}
+  "js_of_ocaml" {>= "6.3.2" & < "6.4.0"}
+  "js_of_ocaml-lwt" {>= "6.3.2" & < "6.4.0"}
   "js_of_ocaml-ocamlbuild" {build}
-  "js_of_ocaml-ppx" {>= "6.3.2"}
-  "js_of_ocaml-ppx_deriving_json" {>= "6.3.2"}
-  "js_of_ocaml-tyxml" {>= "6.3.2"}
+  "js_of_ocaml-ppx" {>= "6.3.2" & < "6.4.0"}
+  "js_of_ocaml-ppx_deriving_json" {>= "6.3.2" & < "6.4.0"}
+  "js_of_ocaml-tyxml" {>= "6.3.2" & < "6.4.0"}
   "logs"
   "tyxml" {>= "4.6" & < "4.7"}
   "ocsigenserver" {>= "7.0" & < "8.0"}

--- a/packages/js_of_ocaml-compiler/js_of_ocaml-compiler.6.0.1/opam
+++ b/packages/js_of_ocaml-compiler/js_of_ocaml-compiler.6.0.1/opam
@@ -12,7 +12,7 @@ doc: "https://ocsigen.org/js_of_ocaml/latest/manual/overview"
 bug-reports: "https://github.com/ocsigen/js_of_ocaml/issues"
 depends: [
   "dune" {>= "3.17"}
-  "ocaml" {>= "4.08" & < "5.4"}
+  "ocaml" {(>= "4.08" & < "4.14.3") | (>= "5.0" & < "5.4")}
   "num" {with-test}
   "ppx_expect" {>= "v0.16.1" & with-test}
   "ppxlib" {>= "0.15.0" & < "0.36.0"}

--- a/packages/js_of_ocaml-compiler/js_of_ocaml-compiler.6.4.0/opam
+++ b/packages/js_of_ocaml-compiler/js_of_ocaml-compiler.6.4.0/opam
@@ -1,0 +1,67 @@
+opam-version: "2.0"
+synopsis: "Compiler from OCaml bytecode to JavaScript"
+description:
+  "Js_of_ocaml is a compiler from OCaml bytecode to JavaScript. It makes it possible to run pure OCaml programs in JavaScript environment like browsers and Node.js"
+maintainer: ["Ocsigen team <dev@ocsigen.org>"]
+authors: ["Ocsigen team <dev@ocsigen.org>"]
+license: [
+  "GPL-2.0-or-later" "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
+]
+homepage: "https://ocsigen.org/js_of_ocaml/latest/js_of_ocaml/overview.html"
+doc: "https://ocsigen.org/js_of_ocaml/latest/js_of_ocaml/overview.html"
+bug-reports: "https://github.com/ocsigen/js_of_ocaml/issues"
+depends: [
+  "dune" {>= "3.20"}
+  "ocaml" {>= "4.13" & < "5.6"}
+  "num" {with-test}
+  "ppx_expect" {>= "v0.16.1" & with-test}
+  "ppxlib" {>= "0.33"}
+  "ocaml-compiler-libs" {>= "v0.12.4"}
+  "re" {with-test}
+  "cmdliner" {>= "2.0"}
+  "sedlex" {>= "3.3"}
+  "qcheck" {with-test}
+  "menhir" {>= "20180523"}
+  "menhirLib"
+  "menhirSdk"
+  "yojson" {>= "2.1"}
+  "odoc" {with-doc}
+]
+depopts: ["ocamlfind"]
+conflicts: [
+  "ocamlfind" {< "1.5.1"}
+  "js_of_ocaml" {< "3.0"}
+]
+dev-repo: "git+https://github.com/ocsigen/js_of_ocaml.git"
+x-maintenance-intent: ["(latest)"]
+build: [
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+  ["cmdliner" "install" "tool-support"
+              "--update-opam-install=%{_:name}%.install"
+              "_build/install/default/bin/js_of_ocaml" {os-family != "windows"}
+              "_build/install/default/bin/js_of_ocaml.exe:js_of_ocaml" {os-family = "windows"}
+              "_build/cmdliner-install"]
+  ["cmdliner" "install" "tool-support"
+              "--update-opam-install=%{_:name}%.install"
+              "_build/install/default/bin/jsoo_minify" {os-family != "windows"}
+              "_build/install/default/bin/jsoo_minify.exe:jsoo_minify" {os-family = "windows"}
+              "_build/cmdliner-install"]
+]
+url {
+  src:
+    "https://github.com/ocsigen/js_of_ocaml/releases/download/6.4.0/js_of_ocaml-6.4.0.tbz"
+  checksum: [
+    "sha256=7ae22a7e5a6c6aa14a8e2695fa62c66f32cb20db17f1b45dc21e97009342151f"
+    "sha512=6cea398d61d4be8e38e912ba7e4bad4f7b81b10d946cdf29026274b5a4b2cc2709fb75e23f7cbe2db335cc65679c262a8aa1b9148effc987d6e79665a7538286"
+  ]
+}
+x-commit-hash: "e4d950bc1cbcb0f8fc61cce06b0c6a2c55f94581"

--- a/packages/js_of_ocaml-lwt/js_of_ocaml-lwt.6.4.0/opam
+++ b/packages/js_of_ocaml-lwt/js_of_ocaml-lwt.6.4.0/opam
@@ -1,0 +1,47 @@
+opam-version: "2.0"
+synopsis: "Compiler from OCaml bytecode to JavaScript"
+description:
+  "Js_of_ocaml is a compiler from OCaml bytecode to JavaScript. It makes it possible to run pure OCaml programs in JavaScript environment like browsers and Node.js"
+maintainer: ["Ocsigen team <dev@ocsigen.org>"]
+authors: ["Ocsigen team <dev@ocsigen.org>"]
+license: [
+  "GPL-2.0-or-later" "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
+]
+homepage: "https://ocsigen.org/js_of_ocaml/latest/js_of_ocaml/overview.html"
+doc: "https://ocsigen.org/js_of_ocaml/latest/js_of_ocaml/overview.html"
+bug-reports: "https://github.com/ocsigen/js_of_ocaml/issues"
+depends: [
+  "dune" {>= "3.20"}
+  "ocaml" {>= "4.13"}
+  "js_of_ocaml" {= version}
+  "js_of_ocaml-ppx" {= version}
+  "lwt" {>= "2.4.4" & != "5.9.2"}
+  "num" {with-test}
+  "ppx_expect" {>= "v0.14.2" & with-test}
+  "re" {>= "1.9.0" & with-test}
+  "odoc" {with-doc}
+]
+depopts: ["graphics" "lwt_log"]
+dev-repo: "git+https://github.com/ocsigen/js_of_ocaml.git"
+x-maintenance-intent: ["(latest)"]
+build: [
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src:
+    "https://github.com/ocsigen/js_of_ocaml/releases/download/6.4.0/js_of_ocaml-6.4.0.tbz"
+  checksum: [
+    "sha256=7ae22a7e5a6c6aa14a8e2695fa62c66f32cb20db17f1b45dc21e97009342151f"
+    "sha512=6cea398d61d4be8e38e912ba7e4bad4f7b81b10d946cdf29026274b5a4b2cc2709fb75e23f7cbe2db335cc65679c262a8aa1b9148effc987d6e79665a7538286"
+  ]
+}
+x-commit-hash: "e4d950bc1cbcb0f8fc61cce06b0c6a2c55f94581"

--- a/packages/js_of_ocaml-ppx/js_of_ocaml-ppx.6.4.0/opam
+++ b/packages/js_of_ocaml-ppx/js_of_ocaml-ppx.6.4.0/opam
@@ -1,0 +1,45 @@
+opam-version: "2.0"
+synopsis: "Compiler from OCaml bytecode to JavaScript"
+description:
+  "Js_of_ocaml is a compiler from OCaml bytecode to JavaScript. It makes it possible to run pure OCaml programs in JavaScript environment like browsers and Node.js"
+maintainer: ["Ocsigen team <dev@ocsigen.org>"]
+authors: ["Ocsigen team <dev@ocsigen.org>"]
+license: [
+  "GPL-2.0-or-later" "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
+]
+homepage: "https://ocsigen.org/js_of_ocaml/latest/js_of_ocaml/overview.html"
+doc: "https://ocsigen.org/js_of_ocaml/latest/js_of_ocaml/overview.html"
+bug-reports: "https://github.com/ocsigen/js_of_ocaml/issues"
+depends: [
+  "dune" {>= "3.20"}
+  "ocaml" {>= "4.13"}
+  "js_of_ocaml" {= version}
+  "ppxlib" {>= "0.33"}
+  "num" {with-test}
+  "ppx_expect" {>= "v0.14.2" & with-test}
+  "re" {>= "1.9.0" & with-test}
+  "odoc" {with-doc}
+]
+dev-repo: "git+https://github.com/ocsigen/js_of_ocaml.git"
+x-maintenance-intent: ["(latest)"]
+build: [
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src:
+    "https://github.com/ocsigen/js_of_ocaml/releases/download/6.4.0/js_of_ocaml-6.4.0.tbz"
+  checksum: [
+    "sha256=7ae22a7e5a6c6aa14a8e2695fa62c66f32cb20db17f1b45dc21e97009342151f"
+    "sha512=6cea398d61d4be8e38e912ba7e4bad4f7b81b10d946cdf29026274b5a4b2cc2709fb75e23f7cbe2db335cc65679c262a8aa1b9148effc987d6e79665a7538286"
+  ]
+}
+x-commit-hash: "e4d950bc1cbcb0f8fc61cce06b0c6a2c55f94581"

--- a/packages/js_of_ocaml-ppx_deriving_json/js_of_ocaml-ppx_deriving_json.6.4.0/opam
+++ b/packages/js_of_ocaml-ppx_deriving_json/js_of_ocaml-ppx_deriving_json.6.4.0/opam
@@ -1,0 +1,45 @@
+opam-version: "2.0"
+synopsis: "Compiler from OCaml bytecode to JavaScript"
+description:
+  "Js_of_ocaml is a compiler from OCaml bytecode to JavaScript. It makes it possible to run pure OCaml programs in JavaScript environment like browsers and Node.js"
+maintainer: ["Ocsigen team <dev@ocsigen.org>"]
+authors: ["Ocsigen team <dev@ocsigen.org>"]
+license: [
+  "GPL-2.0-or-later" "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
+]
+homepage: "https://ocsigen.org/js_of_ocaml/latest/js_of_ocaml/overview.html"
+doc: "https://ocsigen.org/js_of_ocaml/latest/js_of_ocaml/overview.html"
+bug-reports: "https://github.com/ocsigen/js_of_ocaml/issues"
+depends: [
+  "dune" {>= "3.20"}
+  "ocaml" {>= "4.13"}
+  "js_of_ocaml" {= version}
+  "ppxlib" {>= "0.33"}
+  "num" {with-test}
+  "ppx_expect" {>= "v0.14.2" & with-test}
+  "re" {>= "1.9.0" & with-test}
+  "odoc" {with-doc}
+]
+dev-repo: "git+https://github.com/ocsigen/js_of_ocaml.git"
+x-maintenance-intent: ["(latest)"]
+build: [
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src:
+    "https://github.com/ocsigen/js_of_ocaml/releases/download/6.4.0/js_of_ocaml-6.4.0.tbz"
+  checksum: [
+    "sha256=7ae22a7e5a6c6aa14a8e2695fa62c66f32cb20db17f1b45dc21e97009342151f"
+    "sha512=6cea398d61d4be8e38e912ba7e4bad4f7b81b10d946cdf29026274b5a4b2cc2709fb75e23f7cbe2db335cc65679c262a8aa1b9148effc987d6e79665a7538286"
+  ]
+}
+x-commit-hash: "e4d950bc1cbcb0f8fc61cce06b0c6a2c55f94581"

--- a/packages/js_of_ocaml-toplevel/js_of_ocaml-toplevel.6.4.0/opam
+++ b/packages/js_of_ocaml-toplevel/js_of_ocaml-toplevel.6.4.0/opam
@@ -1,0 +1,47 @@
+opam-version: "2.0"
+synopsis: "Compiler from OCaml bytecode to JavaScript"
+description:
+  "Js_of_ocaml is a compiler from OCaml bytecode to JavaScript. It makes it possible to run pure OCaml programs in JavaScript environment like browsers and Node.js"
+maintainer: ["Ocsigen team <dev@ocsigen.org>"]
+authors: ["Ocsigen team <dev@ocsigen.org>"]
+license: [
+  "GPL-2.0-or-later" "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
+]
+homepage: "https://ocsigen.org/js_of_ocaml/latest/js_of_ocaml/overview.html"
+doc: "https://ocsigen.org/js_of_ocaml/latest/js_of_ocaml/overview.html"
+bug-reports: "https://github.com/ocsigen/js_of_ocaml/issues"
+depends: [
+  "dune" {>= "3.20"}
+  "ocaml" {>= "4.13"}
+  "js_of_ocaml-compiler" {= version}
+  "ocamlfind" {>= "1.5.1"}
+  "graphics" {with-test}
+  "num" {with-test}
+  "ppx_expect" {>= "v0.14.2" & with-test}
+  "ppxlib" {>= "0.33"}
+  "re" {>= "1.9.0" & with-test}
+  "odoc" {with-doc}
+]
+dev-repo: "git+https://github.com/ocsigen/js_of_ocaml.git"
+x-maintenance-intent: ["(latest)"]
+build: [
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src:
+    "https://github.com/ocsigen/js_of_ocaml/releases/download/6.4.0/js_of_ocaml-6.4.0.tbz"
+  checksum: [
+    "sha256=7ae22a7e5a6c6aa14a8e2695fa62c66f32cb20db17f1b45dc21e97009342151f"
+    "sha512=6cea398d61d4be8e38e912ba7e4bad4f7b81b10d946cdf29026274b5a4b2cc2709fb75e23f7cbe2db335cc65679c262a8aa1b9148effc987d6e79665a7538286"
+  ]
+}
+x-commit-hash: "e4d950bc1cbcb0f8fc61cce06b0c6a2c55f94581"

--- a/packages/js_of_ocaml-tyxml/js_of_ocaml-tyxml.6.4.0/opam
+++ b/packages/js_of_ocaml-tyxml/js_of_ocaml-tyxml.6.4.0/opam
@@ -1,0 +1,48 @@
+opam-version: "2.0"
+synopsis: "Compiler from OCaml bytecode to JavaScript"
+description:
+  "Js_of_ocaml is a compiler from OCaml bytecode to JavaScript. It makes it possible to run pure OCaml programs in JavaScript environment like browsers and Node.js"
+maintainer: ["Ocsigen team <dev@ocsigen.org>"]
+authors: ["Ocsigen team <dev@ocsigen.org>"]
+license: [
+  "GPL-2.0-or-later" "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
+]
+homepage: "https://ocsigen.org/js_of_ocaml/latest/js_of_ocaml/overview.html"
+doc: "https://ocsigen.org/js_of_ocaml/latest/js_of_ocaml/overview.html"
+bug-reports: "https://github.com/ocsigen/js_of_ocaml/issues"
+depends: [
+  "dune" {>= "3.20"}
+  "ocaml" {>= "4.13"}
+  "js_of_ocaml" {= version}
+  "js_of_ocaml-ppx" {= version}
+  "react" {>= "1.2.2"}
+  "reactiveData" {>= "0.2"}
+  "tyxml" {>= "4.6"}
+  "num" {with-test}
+  "ppx_expect" {>= "v0.14.2" & with-test}
+  "re" {>= "1.9.0" & with-test}
+  "odoc" {with-doc}
+]
+dev-repo: "git+https://github.com/ocsigen/js_of_ocaml.git"
+x-maintenance-intent: ["(latest)"]
+build: [
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src:
+    "https://github.com/ocsigen/js_of_ocaml/releases/download/6.4.0/js_of_ocaml-6.4.0.tbz"
+  checksum: [
+    "sha256=7ae22a7e5a6c6aa14a8e2695fa62c66f32cb20db17f1b45dc21e97009342151f"
+    "sha512=6cea398d61d4be8e38e912ba7e4bad4f7b81b10d946cdf29026274b5a4b2cc2709fb75e23f7cbe2db335cc65679c262a8aa1b9148effc987d6e79665a7538286"
+  ]
+}
+x-commit-hash: "e4d950bc1cbcb0f8fc61cce06b0c6a2c55f94581"

--- a/packages/js_of_ocaml/js_of_ocaml.6.4.0/opam
+++ b/packages/js_of_ocaml/js_of_ocaml.6.4.0/opam
@@ -1,0 +1,45 @@
+opam-version: "2.0"
+synopsis: "Compiler from OCaml bytecode to JavaScript"
+description:
+  "Js_of_ocaml is a compiler from OCaml bytecode to JavaScript. It makes it possible to run pure OCaml programs in JavaScript environment like browsers and Node.js"
+maintainer: ["Ocsigen team <dev@ocsigen.org>"]
+authors: ["Ocsigen team <dev@ocsigen.org>"]
+license: [
+  "GPL-2.0-or-later" "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
+]
+homepage: "https://ocsigen.org/js_of_ocaml/latest/js_of_ocaml/overview.html"
+doc: "https://ocsigen.org/js_of_ocaml/latest/js_of_ocaml/overview.html"
+bug-reports: "https://github.com/ocsigen/js_of_ocaml/issues"
+depends: [
+  "dune" {>= "3.20"}
+  "ocaml" {>= "4.13"}
+  "js_of_ocaml-compiler" {= version}
+  "num" {with-test}
+  "ppx_expect" {>= "v0.14.2" & with-test}
+  "ppxlib" {>= "0.33"}
+  "re" {>= "1.9.0" & with-test}
+  "odoc" {with-doc}
+]
+dev-repo: "git+https://github.com/ocsigen/js_of_ocaml.git"
+x-maintenance-intent: ["(latest)"]
+build: [
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src:
+    "https://github.com/ocsigen/js_of_ocaml/releases/download/6.4.0/js_of_ocaml-6.4.0.tbz"
+  checksum: [
+    "sha256=7ae22a7e5a6c6aa14a8e2695fa62c66f32cb20db17f1b45dc21e97009342151f"
+    "sha512=6cea398d61d4be8e38e912ba7e4bad4f7b81b10d946cdf29026274b5a4b2cc2709fb75e23f7cbe2db335cc65679c262a8aa1b9148effc987d6e79665a7538286"
+  ]
+}
+x-commit-hash: "e4d950bc1cbcb0f8fc61cce06b0c6a2c55f94581"

--- a/packages/promise_jsoo/promise_jsoo.0.1.0/opam
+++ b/packages/promise_jsoo/promise_jsoo.0.1.0/opam
@@ -8,8 +8,8 @@ bug-reports: "https://github.com/mnxn/promise_jsoo/issues"
 depends: [
   "ocaml" {>= "4.08"}
   "dune" {>= "2.7"}
-  "js_of_ocaml"
-  "js_of_ocaml-ppx"
+  "js_of_ocaml" {< "6.4.0"}
+  "js_of_ocaml-ppx" {< "6.4.0"}
   "gen_js_api"
   "webtest" {with-test}
   "webtest-js" {with-test}

--- a/packages/promise_jsoo/promise_jsoo.0.2.0/opam
+++ b/packages/promise_jsoo/promise_jsoo.0.2.0/opam
@@ -8,8 +8,8 @@ bug-reports: "https://github.com/mnxn/promise_jsoo/issues"
 depends: [
   "dune" {>= "2.7"}
   "ocaml" {>= "4.08"}
-  "js_of_ocaml"
-  "js_of_ocaml-ppx"
+  "js_of_ocaml" {< "6.4.0"}
+  "js_of_ocaml-ppx" {< "6.4.0"}
   "gen_js_api"
   "webtest" {with-test}
   "webtest-js" {with-test}

--- a/packages/promise_jsoo/promise_jsoo.0.3.0/opam
+++ b/packages/promise_jsoo/promise_jsoo.0.3.0/opam
@@ -8,8 +8,8 @@ bug-reports: "https://github.com/mnxn/promise_jsoo/issues"
 depends: [
   "dune" {>= "2.7"}
   "ocaml" {>= "4.08"}
-  "js_of_ocaml"
-  "js_of_ocaml-ppx"
+  "js_of_ocaml" {< "6.4.0"}
+  "js_of_ocaml-ppx" {< "6.4.0"}
   "gen_js_api"
   "webtest" {with-test}
   "webtest-js" {with-test}

--- a/packages/promise_jsoo/promise_jsoo.0.3.1/opam
+++ b/packages/promise_jsoo/promise_jsoo.0.3.1/opam
@@ -8,8 +8,8 @@ bug-reports: "https://github.com/mnxn/promise_jsoo/issues"
 depends: [
   "dune" {>= "2.7"}
   "ocaml" {>= "4.08"}
-  "js_of_ocaml"
-  "js_of_ocaml-ppx"
+  "js_of_ocaml" {< "6.4.0"}
+  "js_of_ocaml-ppx" {< "6.4.0"}
   "gen_js_api"
   "webtest" {with-test}
   "webtest-js" {with-test}

--- a/packages/promise_jsoo_lwt/promise_jsoo_lwt.0.4.2/opam
+++ b/packages/promise_jsoo_lwt/promise_jsoo_lwt.0.4.2/opam
@@ -9,7 +9,7 @@ bug-reports: "https://github.com/mnxn/promise_jsoo/issues"
 depends: [
   "dune" {>= "2.7"}
   "ocaml" {>= "4.08"}
-  "promise_jsoo"
+  "promise_jsoo" {>= "0.4.0"}
   "lwt"
   "gen_js_api" {>= "1.0.8"}
   "webtest" {with-test}

--- a/packages/promise_jsoo_lwt/promise_jsoo_lwt.0.4.3/opam
+++ b/packages/promise_jsoo_lwt/promise_jsoo_lwt.0.4.3/opam
@@ -9,7 +9,7 @@ bug-reports: "https://github.com/mnxn/promise_jsoo/issues"
 depends: [
   "dune" {>= "2.7"}
   "ocaml" {>= "4.08"}
-  "promise_jsoo"
+  "promise_jsoo" {>= "0.4.0"}
   "lwt"
   "gen_js_api" {>= "1.0.8"}
   "webtest" {with-test}

--- a/packages/wasm_of_ocaml-compiler/wasm_of_ocaml-compiler.6.4.0/opam
+++ b/packages/wasm_of_ocaml-compiler/wasm_of_ocaml-compiler.6.4.0/opam
@@ -1,0 +1,63 @@
+opam-version: "2.0"
+synopsis: "Compiler from OCaml bytecode to WebAssembly"
+description:
+  "Wasm_of_ocaml is a compiler from OCaml bytecode to WebAssembly. It makes it possible to run pure OCaml programs in JavaScript environment like browsers and Node.js"
+maintainer: ["Ocsigen team <dev@ocsigen.org>"]
+authors: ["Ocsigen team <dev@ocsigen.org>"]
+license: [
+  "GPL-2.0-or-later" "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
+]
+homepage: "https://ocsigen.org/js_of_ocaml/latest/js_of_ocaml/overview.html"
+doc: "https://ocsigen.org/js_of_ocaml/latest/js_of_ocaml/overview.html"
+bug-reports: "https://github.com/ocsigen/js_of_ocaml/issues"
+depends: [
+  "dune" {>= "3.20"}
+  "ocaml" {>= "4.14"}
+  "js_of_ocaml" {= version}
+  "num" {with-test}
+  "ppx_expect" {>= "v0.14.2" & with-test}
+  "ppxlib" {>= "0.33"}
+  "re" {with-test}
+  "cmdliner" {>= "2.0"}
+  "opam-format" {with-test}
+  "sedlex" {>= "2.3"}
+  "menhir" {>= "20180523"}
+  "menhirLib"
+  "menhirSdk"
+  "yojson" {>= "2.1"}
+  "conf-binaryen"
+  "odoc" {with-doc}
+]
+depopts: ["ocamlfind"]
+conflicts: [
+  "ocamlfind" {< "1.5.1"}
+  "js_of_ocaml" {< "3.0"}
+]
+dev-repo: "git+https://github.com/ocsigen/js_of_ocaml.git"
+x-maintenance-intent: ["(latest)"]
+build: [
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+  ["cmdliner" "install" "tool-support"
+              "--update-opam-install=%{_:name}%.install"
+              "_build/install/default/bin/wasm_of_ocaml" {os-family != "windows"}
+              "_build/install/default/bin/wasm_of_ocaml.exe:wasm_of_ocaml" {os-family = "windows"}
+              "_build/cmdliner-install"]
+]
+url {
+  src:
+    "https://github.com/ocsigen/js_of_ocaml/releases/download/6.4.0/js_of_ocaml-6.4.0.tbz"
+  checksum: [
+    "sha256=7ae22a7e5a6c6aa14a8e2695fa62c66f32cb20db17f1b45dc21e97009342151f"
+    "sha512=6cea398d61d4be8e38e912ba7e4bad4f7b81b10d946cdf29026274b5a4b2cc2709fb75e23f7cbe2db335cc65679c262a8aa1b9148effc987d6e79665a7538286"
+  ]
+}
+x-commit-hash: "e4d950bc1cbcb0f8fc61cce06b0c6a2c55f94581"


### PR DESCRIPTION
Compiler from OCaml bytecode to JavaScript

- Project page: <a href="https://ocsigen.org/js_of_ocaml/latest/js_of_ocaml/overview.html">https://ocsigen.org/js_of_ocaml/latest/js_of_ocaml/overview.html</a>
- Documentation: <a href="https://ocsigen.org/js_of_ocaml/latest/js_of_ocaml/overview.html">https://ocsigen.org/js_of_ocaml/latest/js_of_ocaml/overview.html</a>

##### CHANGES:

## Features/Changes
* Compiler: initial support for OCaml 5.5.0 (ocsigen/js_of_ocaml#2197, ocsigen/js_of_ocaml#2220)
* Compiler: OxCaml support (ocsigen/js_of_ocaml#2105, ocsigen/js_of_ocaml#2225)
* Compiler: new variable coalescing pass, plus faster variable-naming,
  free-variable and shape-computation passes (ocsigen/js_of_ocaml#2166, ocsigen/js_of_ocaml#2321, ocsigen/js_of_ocaml#2198)
* Compiler: add the `--build-config` and `--apply-build-config` flags (ocsigen/js_of_ocaml#2177)
* Compiler: put more values into global variables (ocsigen/js_of_ocaml#2211)
* Compiler: cosmetic minification in compact mode — `!0`/`!1` booleans,
  drop the leading `0` in `0.x` fractions, normalise exponents
  (`1e+05` → `1e5`), and pick backtick strings when they reduce escapes;
  `--pretty` output is unchanged (ocsigen/js_of_ocaml#1117)
* Wasm: dynlink and toplevel support (ocsigen/js_of_ocaml#2186)
* Compiler/wasm: WASI 0.1 support (ocsigen/js_of_ocaml#1831)
* Wasm_of_ocaml: alternative effect implementation based on the Stack
  Switching proposal (ocsigen/js_of_ocaml#2189)
* Runtime/wasm: implement the legacy `num` library `nat` primitives
  (previously no-op stubs), so arbitrary-precision integers and rationals
  now work as on the JavaScript runtime (ocsigen/js_of_ocaml#2263)
* Runtime/wasm: faster string↔ArrayBuffer copies, faster small-string
  conversions, and optimized bigstring primitives (ocsigen/js_of_ocaml#2124, ocsigen/js_of_ocaml#2144)
* Runtime/wasm: pure-Wasm zstd and BLAKE2b implementations; the runtime
  no longer relies on the JavaScript zstd/BLAKE2 shims to unmarshal
  compressed values or compute Digest.BLAKE512/256/128. This also makes
  both available under the WASI target, which has no JavaScript (ocsigen/js_of_ocaml#2249)
* Runtime: initial support for quickjs-ng (ocsigen/js_of_ocaml#2229)
* Lib: add `Promise` — type-safe bindings to JavaScript promises (even for
  `'a Promise.t Promise.t`), with Lwt interop in `Js_of_ocaml_lwt.Promise`
  (`to_lwt`/`of_lwt`) and Promise-typed `Dom_html` bindings
  (`requestFullscreen`, `requestPointerLock`, `exitFullscreen`,
  `mediaElement.play`, `imageElement.decode`, `Animation.{finished,ready}`).
  Breaking: `mediaElement.play` now returns `unit Promise.t` (ocsigen/js_of_ocaml#2031)
* Lib: add `Fetch` and `Abort` — Fetch API binding with a typed
  `AbortController`/`AbortSignal` primitive for cancellation (ocsigen/js_of_ocaml#596)
* Lib: many additional `Dom_html` bindings and a new `Performance` module
  (ocsigen/js_of_ocaml#2221, ocsigen/js_of_ocaml#2248)
* Lib: add `Console` bindings for `table`, `count`, `countReset` and
  `timeLog` (ocsigen/js_of_ocaml#2350)
* Lib: align `Dom_svg` with SVG 2 — new `graphicsElement`/`geometryElement`
  parents, `style`/`className`/`dataset` merged into `element`, SVG 2
  members, `markerElement` and the full `SVGFE*` filter-primitive family,
  every SVG element is now an event target (ocsigen/js_of_ocaml#519), and `prop`/`readonly_prop`
  fixes. Breaking: drops the SVG 1.1-only `getTransformToElement`;
  `nearestViewportElement`/`farthestViewportElement` are now typed `optdef`
* Lib: implement the popover API (ocsigen/js_of_ocaml#1734)
* Lib: add `Intl.RelativeTimeFormat` (ocsigen/js_of_ocaml#2070)
* Lib: remove dead legacy-browser code from the DOM bindings (IE
  `attachEvent`/`createElement`/`cancelBubble` fallbacks, prefixed
  `requestAnimationFrame`, the Firefox 3.x `File.fileName` property).
  Breaking: drops the obsolete Gecko `MouseScrollEvent`/`_DOMMouseScroll`
  bindings — the `mouseScrollEvent` type, the `MouseScrollEvent`
  `taggedEvent` variant, `CoerceTo.mouseScrollEvent` and
  `Event._DOMMouseScroll` (ocsigen/js_of_ocaml#2350)

## Bug fixes
* Compiler: don't rewrite `x = e + x` into `x += e` for `+` (not
  commutative on strings), which reversed `Filename.concat` operands and
  broke `Filename.temp_file` in whole-program builds (ocsigen/js_of_ocaml#2228)
* Compiler: fix the dead `require()` guard in share_constant (it matched
  "requires"), which could replace `require` string arguments and confuse
  bundlers (ocsigen/js_of_ocaml#2284)
* Compiler: parenthesize `in` in conditional else-branches, arrow concise
  bodies and `for`-initializer yields when re-printing parsed JavaScript,
  which previously emitted output that did not parse (ocsigen/js_of_ocaml#2282)
* Compiler: emit a flat dispatch loop instead of deeply nested labelled
  blocks for many sibling merge targets, avoiding parser "too much
  recursion" overflows (ocsigen/js_of_ocaml#2122)
* Compiler: avoid JS stack overflow on deep mutually-recursive direct-style
  calls under `--effects=double-translation` (ocsigen/js_of_ocaml#2243)
* Compiler: fix reference unboxing (ocsigen/js_of_ocaml#2210), a missing conditional
  simplification (ocsigen/js_of_ocaml#2217), `Js_assign.simpl` (ocsigen/js_of_ocaml#2218), and UGEINT lowering
* Compiler/wasm: fix the int-division return type (ocsigen/js_of_ocaml#2197), preserve the
  physical identity of empty closures (ocsigen/js_of_ocaml#2207), and fix a crash on some
  function calls (ocsigen/js_of_ocaml#2208)
* Runtime: hashing is now consistent across backends — JS strings with code
  points above U+00FF mix two 16-bit units per word, `Hashtbl.hash` of float
  arrays, bigarray tail zero-extension and `float32_hash` normalize like
  native; ASCII/Latin-1 strings are unchanged (ocsigen/js_of_ocaml#2263, ocsigen/js_of_ocaml#2270, ocsigen/js_of_ocaml#2332)
* Runtime/wasm: bring many primitives in line with the JavaScript runtime —
  `caml_wrap_exception` only wraps real `Error`s, `caml_js_meth_call`
  decodes method names as UTF-8, the exception formatter grows its buffer,
  `Sys.is_directory`/`file_exists` follow symlinks, `isatty` returns false
  in browsers, `caml_seek_in` validates the destination, `Array.make`/
  `Obj.new_block` build proper float arrays, `caml_unregister_named_value`
  handles non-head bucket entries, the lexer only moves position memory on
  memory-action transitions, the bytecode-section accessors raise without
  `--toplevel`, format-string `#`/`%+f`/`% f` corner cases, and
  `Condition.wait` is a no-op with each condition variable having a distinct
  identity (ocsigen/js_of_ocaml#2263)
* Runtime: marshalling fixes on both backends — `Marshal.to_buffer` returns
  the byte count; float arrays use `CODE_DOUBLE_ARRAY` (readable by native
  and Wasm); BLOCK32 sizes are decoded with an unsigned shift (≥ 2^21 fields
  no longer truncated) and a block with ≥ 2^22 fields raises instead of
  truncating; `input_value` on a bad object raises `Failure`; bigarray
  deserialization rejects bad dimensions; big-endian double arrays are
  registered in the object table (ocsigen/js_of_ocaml#2263, ocsigen/js_of_ocaml#2270)
* Runtime: filesystem fixes (ocsigen/js_of_ocaml#2270) — the fake device no longer destroys a
  directory renamed into its own subtree, refuses to unlink directories,
  honors `Open_append` (which now implies write access), reports proper Unix
  error codes/syscalls/paths, no longer matches mount points as regexes,
  raises `Sys_error` on cross-device renames, keeps file sizes 64-bit on the
  node backend, and no longer deletes a file renamed onto itself; `flush` on
  a closed channel no longer raises
* Runtime: `O_APPEND`/`Open_append` matches native on both backends — the
  file offset starts at 0 (so `lseek`/`pos_out` report 0 right after opening)
  and every write goes to the end of the file, even after seeking backwards
  (ocsigen/js_of_ocaml#2306)
* Runtime: an empty path raises `ENOENT` on the JavaScript backend like
  native (and the Wasm runtime), so `Unix.stat ""`, `Unix.opendir ""`, etc.
  raise instead of operating on the cwd, and `Sys.file_exists ""` is false
  (ocsigen/js_of_ocaml#2354)
* Runtime: Unix fixes — `Unix.localtime` computes `tm_yday` from the date
  (was off by one during DST) and reaches `Intl` safely; `Unix.close` frees
  the fd-table slot; `Unix.error_message` no longer crashes on unknown codes
  or node < 22; `chmod` raises `Unix_error`; `readdir` includes "." and
  "..", and add `Unix.getegid` / fix the `Unix.getgrgid` export (ocsigen/js_of_ocaml#2263,
  ocsigen/js_of_ocaml#2270, ocsigen/js_of_ocaml#2303, ocsigen/js_of_ocaml#2304)
* Runtime: channel fixes — `in_channel_of_descr`/`out_channel_of_descr`
  allocate fresh channels (they used to share a record and loop on reads);
  refill-hook channels grow their buffer and keep `pos_in`/`pos_out`
  correct; `Sys.command` returns the child exit status; `Sys.getenv` raises
  on prototype names; `Sys.isatty` consults the channel's file (ocsigen/js_of_ocaml#2270, ocsigen/js_of_ocaml#2330)
* Runtime: Str engine fixes — SIMPLEOPT/STAR/PLUS no longer read past the
  end of the string (a trailing negated class could loop forever),
  instruction arguments are no longer masked to 8 bits (regexps with > 256
  pool entries mis-indexed), and a `Str.replace` backreference one past the
  last group raises instead of trapping (ocsigen/js_of_ocaml#2263, ocsigen/js_of_ocaml#2270)
* Runtime: ephemeron/weak fixes — `blit_key`, `blit_data`, `get_data`,
  `get_copy` and `get_data_copy` corrected (no clobbering, copy bytes and
  float arrays, no traps on JS-valued data); data is weakly keyed on the key
  object so key↔data cycles can be collected; `Gc.finalise_last` runs under
  `--effects=cps`; `Gc.counters` returns a plain tuple (ocsigen/js_of_ocaml#2263, ocsigen/js_of_ocaml#2270, ocsigen/js_of_ocaml#2274,
  ocsigen/js_of_ocaml#2279)
* Runtime: numeric fixes — `Digest`/MD5 correct for inputs ≥ 2 GiB;
  `Int64.shift_right` for negatives with shift counts 41–47;
  `Int64.of_string` (ocsigen/js_of_ocaml#2223); `Printf "%#x" 0` prints `0`; float16 bigarray
  NaN comparison; comparing an immediate against a custom block no longer
  throws and orders correctly; `Float.Array.sub`/`append`/`concat` return
  tag-254 arrays; `caml_bigstring_blit_*` treat positions as raw offsets;
  `compare_nat` reads only the common digit length (ocsigen/js_of_ocaml#2263, ocsigen/js_of_ocaml#2270)
* Runtime: float formatting and parsing — the exact decimal expansion is
  printed beyond `toFixed`/`toExponential`'s limits (`%.150e`, `%f` of values
  ≥ 1e21); hex-float literals parse with correct rounding, saturate huge
  exponents instead of wrapping, and reject non-decimal/JavaScript literals;
  `ldexp` rounds once into the subnormal range; and `float_of_string` skips
  all leading whitespace (ocsigen/js_of_ocaml#2263, ocsigen/js_of_ocaml#2270)
* Runtime: `caml_float16_of_double` rounds through `float32` like native, so
  `float16` tie values agree across the js, wasm and native backends; and
  `Unix.getuid`/`geteuid`/`getgid`/`getegid` return the real ids on Node (the
  WASI build keeps `1`) (ocsigen/js_of_ocaml#2280)
* Runtime: Graphics backend fixes (ocsigen/js_of_ocaml#2270) — consistent bottom-left pixel
  origin across all primitives, correct `draw_arc` quadrant, synchronous
  first `draw_image`, `fill_rect` paints the far edges, pie-slice `fill_arc`,
  half-pixel-centred strokes/fills for crisp lines, and round caps/joins,
  matching the native X11 backend
* Runtime: `Domain.spawn` of a raising body now succeeds and `Domain.join`
  re-raises (with the `Finished` payload layout expected per OCaml version),
  instead of corrupting the domain id and termination mutex (ocsigen/js_of_ocaml#2263, ocsigen/js_of_ocaml#2270,
  ocsigen/js_of_ocaml#2302)
* Runtime: `caml_dynlink_open_lib` drops the `mode` argument on OCaml ≥ 5.1
  and returns the filled library-slot index (ocsigen/js_of_ocaml#2270)
* Runtime: misc runtime-review fixes — `Runtime_events.User.register`
  orders `typ`/`tag` correctly and the cursor primitives are renamed
  `caml_ml_runtime_events_*`; `jsoo_effect_not_supported` is provided only
  when effects are disabled; `Blake2.create` truncates an over-long key;
  `OCAMLRUNPARAM` backtrace parsing is last-wins; fix `caml_oo_cache_id`
  (ocsigen/js_of_ocaml#2224) and JS→OCaml string conversion (ocsigen/js_of_ocaml#2230) (ocsigen/js_of_ocaml#2263, ocsigen/js_of_ocaml#2270)
* Lib: binding fixes (ocsigen/js_of_ocaml#2350) — `CSS.Angle` parses integer angles such as
  `"45deg"`; `CSS.Color` rejects empty channels (`"rgb(,,)"`);
  `IntersectionObserver.takeRecords` is wrapped in `Js.t`; `EventSource`
  `onopen`/`onerror` receive a plain `Dom.event`; `Intl.Collator.compare`
  returns `Js.number_t`; `Dom.attr.ownerElement` is typed `element t opt
  readonly_prop`; `Regexp.replace_first` preserves all flags except `g`
  (adds a `flags` accessor)
* Lib: fix method-name mangling — `Typed_array._BYTES_PER_ELEMENT_`,
  `WebGL._MAX_RENDERBUFFER_SIZE_` and `canvasElement.toDataURL_compression`
  resolved to the wrong JavaScript identifiers (ocsigen/js_of_ocaml#2239)
* Lib: defer `Intl.{Collator,DateTimeFormat,...}` member lookups so the
  module no longer throws at load time when `globalThis.Intl` is undefined
  (ocsigen/js_of_ocaml#2229)
* Lib: fix `onbeforeunload` breaking navigation (ocsigen/js_of_ocaml#1436) — the
  `event_listener` return type is now `bool t optdef` (`undefined` means "no
  opinion"), with new `Dom.listener`/`full_listener` and a typed
  `beforeUnloadEvent`
* Lib: fix several `Dom_html` bindings (ocsigen/js_of_ocaml#2221)
* Lib: `Deriving_Json` now round-trips non-finite floats — the writer emits
  `NaN`/`Infinity`/`-Infinity` (matching the reader) instead of OCaml's
  `nan`/`inf`/`-inf`, which the reader rejected (ocsigen/js_of_ocaml#2365)
* Lib: drop a stray `console.log` fired on every event in
  `Lwt_js_events.mousewheel` (ocsigen/js_of_ocaml#2365)
* Lib: `Lwt_file` read functions now fail the thread with an exception on a
  read error or abort instead of raising `assert false` (ocsigen/js_of_ocaml#2365)
* Lib: `Lwt_xmlHttpRequest` frame `content_xml` returns `None` for non-default
  response types (text/json/blob/arraybuffer/document) instead of raising
  `assert false` (ocsigen/js_of_ocaml#2365)
* Lib: `Lwt_js_events.request_animation_frame` is now cancellable — cancelling
  the thread cancels the pending animation-frame callback (ocsigen/js_of_ocaml#2365)
