### PR TITLE
[new release] dune (18 packages) (3.24.0)

### DIFF
--- a/packages/chrome-trace/chrome-trace.3.24.0/opam
+++ b/packages/chrome-trace/chrome-trace.3.24.0/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+synopsis: "Chrome trace event generation library"
+description:
+  "This library offers no backwards compatibility guarantees. Use at your own risk."
+maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+license: "MIT"
+homepage: "https://github.com/ocaml/dune"
+doc: "https://dune.readthedocs.io/"
+bug-reports: "https://github.com/ocaml/dune/issues"
+depends: [
+  "dune" {>= "3.24"}
+  "ocaml" {>= "4.14"}
+  "odoc" {with-doc}
+]
+dev-repo: "git+https://github.com/ocaml/dune.git"
+x-maintenance-intent: ["(latest)"]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src:
+    "https://github.com/ocaml/dune/releases/download/3.24.0/dune-3.24.0.tbz"
+  checksum: [
+    "sha256=501f73727a939aa954dc0537e37792a1ba189e61719c81dc367e2594fe016034"
+    "sha512=cd0a366d38ffb65f45c4c92059713190bdd7359c94f0da9c75c08e3acbd505d3852b881b0be1fc060ca2ce70e9425c1447d62560de0cf768b7ec6f9370fa3491"
+  ]
+}
+x-commit-hash: "47f64de764078db6edb2698958b5270a17bffb05"

--- a/packages/dune-action-plugin/dune-action-plugin.3.24.0/opam
+++ b/packages/dune-action-plugin/dune-action-plugin.3.24.0/opam
@@ -1,0 +1,52 @@
+opam-version: "2.0"
+synopsis: "[experimental] API for writing dynamic Dune actions"
+description: """
+
+This library is experimental. No backwards compatibility is implied.
+
+dune-action-plugin provides an API for writing dynamic Dune actions.
+Dynamic dune actions do not need to declare their dependencies
+upfront; they are instead discovered automatically during the
+execution of the action.
+"""
+maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+license: "MIT"
+homepage: "https://github.com/ocaml/dune"
+doc: "https://dune.readthedocs.io/"
+bug-reports: "https://github.com/ocaml/dune/issues"
+depends: [
+  "dune" {>= "3.24"}
+  "dune-glob" {= version}
+  "csexp" {>= "1.5.0"}
+  "ppx_expect" {with-test}
+  "stdune" {= version}
+  "dune-private-libs" {= version}
+  "dune-rpc" {= version}
+  "base-unix"
+  "odoc" {with-doc}
+]
+dev-repo: "git+https://github.com/ocaml/dune.git"
+x-maintenance-intent: ["(latest)"]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src:
+    "https://github.com/ocaml/dune/releases/download/3.24.0/dune-3.24.0.tbz"
+  checksum: [
+    "sha256=501f73727a939aa954dc0537e37792a1ba189e61719c81dc367e2594fe016034"
+    "sha512=cd0a366d38ffb65f45c4c92059713190bdd7359c94f0da9c75c08e3acbd505d3852b881b0be1fc060ca2ce70e9425c1447d62560de0cf768b7ec6f9370fa3491"
+  ]
+}
+x-commit-hash: "47f64de764078db6edb2698958b5270a17bffb05"

--- a/packages/dune-action-trace/dune-action-trace.3.24.0/opam
+++ b/packages/dune-action-trace/dune-action-trace.3.24.0/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+synopsis: "Dune Action Traces"
+description: "Produce trace events from dune actions"
+maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+license: "MIT"
+homepage: "https://github.com/ocaml/dune"
+doc: "https://dune.readthedocs.io/"
+bug-reports: "https://github.com/ocaml/dune/issues"
+depends: [
+  "dune" {>= "3.24"}
+  "csexp" {>= "1.5.0"}
+  "ocaml" {>= "4.14"}
+  "odoc" {with-doc}
+]
+dev-repo: "git+https://github.com/ocaml/dune.git"
+x-maintenance-intent: ["none"]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src:
+    "https://github.com/ocaml/dune/releases/download/3.24.0/dune-3.24.0.tbz"
+  checksum: [
+    "sha256=501f73727a939aa954dc0537e37792a1ba189e61719c81dc367e2594fe016034"
+    "sha512=cd0a366d38ffb65f45c4c92059713190bdd7359c94f0da9c75c08e3acbd505d3852b881b0be1fc060ca2ce70e9425c1447d62560de0cf768b7ec6f9370fa3491"
+  ]
+}
+x-commit-hash: "47f64de764078db6edb2698958b5270a17bffb05"

--- a/packages/dune-build-info/dune-build-info.3.24.0/opam
+++ b/packages/dune-build-info/dune-build-info.3.24.0/opam
@@ -1,0 +1,45 @@
+opam-version: "2.0"
+synopsis: "Embed build information inside executable"
+description: """
+The build-info library allows to access information about how the
+executable was built, such as the version of the project at which it
+was built or the list of statically linked libraries with their
+versions.  It supports reporting the version from the version control
+system during development to get an precise reference of when the
+executable was built.
+"""
+maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+license: "MIT"
+homepage: "https://github.com/ocaml/dune"
+doc: "https://dune.readthedocs.io/"
+bug-reports: "https://github.com/ocaml/dune/issues"
+depends: [
+  "dune" {>= "3.24"}
+  "ocaml" {>= "4.14"}
+  "odoc" {with-doc}
+]
+dev-repo: "git+https://github.com/ocaml/dune.git"
+x-maintenance-intent: ["(latest)"]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src:
+    "https://github.com/ocaml/dune/releases/download/3.24.0/dune-3.24.0.tbz"
+  checksum: [
+    "sha256=501f73727a939aa954dc0537e37792a1ba189e61719c81dc367e2594fe016034"
+    "sha512=cd0a366d38ffb65f45c4c92059713190bdd7359c94f0da9c75c08e3acbd505d3852b881b0be1fc060ca2ce70e9425c1447d62560de0cf768b7ec6f9370fa3491"
+  ]
+}
+x-commit-hash: "47f64de764078db6edb2698958b5270a17bffb05"

--- a/packages/dune-configurator/dune-configurator.3.24.0/opam
+++ b/packages/dune-configurator/dune-configurator.3.24.0/opam
@@ -1,0 +1,49 @@
+opam-version: "2.0"
+synopsis: "Helper library for gathering system configuration"
+description: """
+dune-configurator is a small library that helps writing OCaml scripts that
+test features available on the system, in order to generate config.h
+files for instance.
+Among other things, dune-configurator allows one to:
+- test if a C program compiles
+- query pkg-config
+- import #define from OCaml header files
+- generate config.h file
+"""
+maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+license: "MIT"
+homepage: "https://github.com/ocaml/dune"
+doc: "https://dune.readthedocs.io/"
+bug-reports: "https://github.com/ocaml/dune/issues"
+depends: [
+  "dune" {>= "3.24"}
+  "ocaml" {>= "4.14"}
+  "base-unix"
+  "csexp" {>= "1.5.0"}
+  "odoc" {with-doc}
+]
+dev-repo: "git+https://github.com/ocaml/dune.git"
+x-maintenance-intent: ["(latest)"]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src:
+    "https://github.com/ocaml/dune/releases/download/3.24.0/dune-3.24.0.tbz"
+  checksum: [
+    "sha256=501f73727a939aa954dc0537e37792a1ba189e61719c81dc367e2594fe016034"
+    "sha512=cd0a366d38ffb65f45c4c92059713190bdd7359c94f0da9c75c08e3acbd505d3852b881b0be1fc060ca2ce70e9425c1447d62560de0cf768b7ec6f9370fa3491"
+  ]
+}
+x-commit-hash: "47f64de764078db6edb2698958b5270a17bffb05"

--- a/packages/dune-glob/dune-glob.3.24.0/opam
+++ b/packages/dune-glob/dune-glob.3.24.0/opam
@@ -1,0 +1,42 @@
+opam-version: "2.0"
+synopsis: "Glob string matching language supported by dune"
+description:
+  "dune-glob provides a parser and interpreter for globs as understood by dune language."
+maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+license: "MIT"
+homepage: "https://github.com/ocaml/dune"
+doc: "https://dune.readthedocs.io/"
+bug-reports: "https://github.com/ocaml/dune/issues"
+depends: [
+  "dune" {>= "3.24"}
+  "stdune" {= version}
+  "dyn"
+  "re"
+  "ordering"
+  "odoc" {with-doc}
+]
+dev-repo: "git+https://github.com/ocaml/dune.git"
+x-maintenance-intent: ["(latest)"]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src:
+    "https://github.com/ocaml/dune/releases/download/3.24.0/dune-3.24.0.tbz"
+  checksum: [
+    "sha256=501f73727a939aa954dc0537e37792a1ba189e61719c81dc367e2594fe016034"
+    "sha512=cd0a366d38ffb65f45c4c92059713190bdd7359c94f0da9c75c08e3acbd505d3852b881b0be1fc060ca2ce70e9425c1447d62560de0cf768b7ec6f9370fa3491"
+  ]
+}
+x-commit-hash: "47f64de764078db6edb2698958b5270a17bffb05"

--- a/packages/dune-private-libs/dune-private-libs.3.24.0/opam
+++ b/packages/dune-private-libs/dune-private-libs.3.24.0/opam
@@ -1,0 +1,50 @@
+opam-version: "2.0"
+synopsis: "Private libraries of Dune"
+description: """
+!!!!!!!!!!!!!!!!!!!!!!
+!!!!! DO NOT USE !!!!!
+!!!!!!!!!!!!!!!!!!!!!!
+
+This package contains code that is shared between various dune-xxx
+packages. However, it is not meant for public consumption and provides
+no stability guarantee.
+"""
+maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+license: "MIT"
+homepage: "https://github.com/ocaml/dune"
+doc: "https://dune.readthedocs.io/"
+bug-reports: "https://github.com/ocaml/dune/issues"
+depends: [
+  "dune" {>= "3.24"}
+  "csexp" {>= "1.5.0"}
+  "pp" {>= "1.1.0"}
+  "dyn" {= version}
+  "stdune" {= version}
+  "ocaml" {>= "4.14"}
+  "odoc" {with-doc}
+]
+dev-repo: "git+https://github.com/ocaml/dune.git"
+x-maintenance-intent: ["none"]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src:
+    "https://github.com/ocaml/dune/releases/download/3.24.0/dune-3.24.0.tbz"
+  checksum: [
+    "sha256=501f73727a939aa954dc0537e37792a1ba189e61719c81dc367e2594fe016034"
+    "sha512=cd0a366d38ffb65f45c4c92059713190bdd7359c94f0da9c75c08e3acbd505d3852b881b0be1fc060ca2ce70e9425c1447d62560de0cf768b7ec6f9370fa3491"
+  ]
+}
+x-commit-hash: "47f64de764078db6edb2698958b5270a17bffb05"

--- a/packages/dune-rpc-lwt/dune-rpc-lwt.3.24.0/opam
+++ b/packages/dune-rpc-lwt/dune-rpc-lwt.3.24.0/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+synopsis: "Communicate with dune using rpc and Lwt"
+description: "Specialization of dune-rpc to Lwt"
+maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+license: "MIT"
+homepage: "https://github.com/ocaml/dune"
+doc: "https://dune.readthedocs.io/"
+bug-reports: "https://github.com/ocaml/dune/issues"
+depends: [
+  "dune" {>= "3.24"}
+  "dune-rpc" {= version}
+  "csexp" {>= "1.5.0"}
+  "lwt" {>= "5.6.0"}
+  "base-unix"
+  "odoc" {with-doc}
+]
+dev-repo: "git+https://github.com/ocaml/dune.git"
+x-maintenance-intent: ["(latest)"]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src:
+    "https://github.com/ocaml/dune/releases/download/3.24.0/dune-3.24.0.tbz"
+  checksum: [
+    "sha256=501f73727a939aa954dc0537e37792a1ba189e61719c81dc367e2594fe016034"
+    "sha512=cd0a366d38ffb65f45c4c92059713190bdd7359c94f0da9c75c08e3acbd505d3852b881b0be1fc060ca2ce70e9425c1447d62560de0cf768b7ec6f9370fa3491"
+  ]
+}
+x-commit-hash: "47f64de764078db6edb2698958b5270a17bffb05"

--- a/packages/dune-rpc/dune-rpc.3.24.0/opam
+++ b/packages/dune-rpc/dune-rpc.3.24.0/opam
@@ -1,0 +1,44 @@
+opam-version: "2.0"
+synopsis: "Communicate with dune using rpc"
+description: "Library to connect and control a running dune instance"
+maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+license: "MIT"
+homepage: "https://github.com/ocaml/dune"
+doc: "https://dune.readthedocs.io/"
+bug-reports: "https://github.com/ocaml/dune/issues"
+depends: [
+  "dune" {>= "3.24"}
+  "ocamlc-loc"
+  "csexp"
+  "ordering"
+  "dyn"
+  "xdg"
+  "stdune" {= version}
+  "pp" {>= "1.1.0"}
+  "odoc" {with-doc}
+]
+dev-repo: "git+https://github.com/ocaml/dune.git"
+x-maintenance-intent: ["(latest)"]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src:
+    "https://github.com/ocaml/dune/releases/download/3.24.0/dune-3.24.0.tbz"
+  checksum: [
+    "sha256=501f73727a939aa954dc0537e37792a1ba189e61719c81dc367e2594fe016034"
+    "sha512=cd0a366d38ffb65f45c4c92059713190bdd7359c94f0da9c75c08e3acbd505d3852b881b0be1fc060ca2ce70e9425c1447d62560de0cf768b7ec6f9370fa3491"
+  ]
+}
+x-commit-hash: "47f64de764078db6edb2698958b5270a17bffb05"

--- a/packages/dune-site/dune-site.3.24.0/opam
+++ b/packages/dune-site/dune-site.3.24.0/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+synopsis: "Embed locations information inside executable and libraries"
+maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+license: "MIT"
+homepage: "https://github.com/ocaml/dune"
+doc: "https://dune.readthedocs.io/"
+bug-reports: "https://github.com/ocaml/dune/issues"
+depends: [
+  "dune" {>= "3.24"}
+  "dune-private-libs" {= version}
+  "odoc" {with-doc}
+]
+dev-repo: "git+https://github.com/ocaml/dune.git"
+x-maintenance-intent: ["(latest)"]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src:
+    "https://github.com/ocaml/dune/releases/download/3.24.0/dune-3.24.0.tbz"
+  checksum: [
+    "sha256=501f73727a939aa954dc0537e37792a1ba189e61719c81dc367e2594fe016034"
+    "sha512=cd0a366d38ffb65f45c4c92059713190bdd7359c94f0da9c75c08e3acbd505d3852b881b0be1fc060ca2ce70e9425c1447d62560de0cf768b7ec6f9370fa3491"
+  ]
+}
+x-commit-hash: "47f64de764078db6edb2698958b5270a17bffb05"

--- a/packages/dune/dune.3.24.0/opam
+++ b/packages/dune/dune.3.24.0/opam
@@ -1,0 +1,79 @@
+opam-version: "2.0"
+synopsis: "Fast, portable, and opinionated build system"
+description: """
+
+Dune is a build system that was designed to simplify the release of
+Jane Street packages. It reads metadata from "dune" files following a
+very simple s-expression syntax.
+
+Dune is fast, has very low-overhead, and supports parallel builds on
+all platforms. It has no system dependencies; all you need to build
+dune or packages using dune is OCaml. You don't need make or bash
+as long as the packages themselves don't use bash explicitly.
+
+Dune is composable; supporting multi-package development by simply
+dropping multiple repositories into the same directory.
+
+Dune also supports multi-context builds, such as building against
+several opam roots/switches simultaneously. This helps maintaining
+packages across several versions of OCaml and gives cross-compilation
+for free.
+"""
+maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+license: "MIT"
+homepage: "https://github.com/ocaml/dune"
+doc: "https://dune.readthedocs.io/"
+bug-reports: "https://github.com/ocaml/dune/issues"
+conflicts: [
+  "merlin" {< "3.4.0"}
+  "ocaml-lsp-server" {< "1.3.0"}
+  "dune-configurator" {< "2.3.0"}
+  "odoc" {< "2.0.1"}
+  "dune-release" {< "2.0.0"}
+  "js_of_ocaml-compiler" {< "3.6.0"}
+  "jbuilder" {= "transition"}
+]
+dev-repo: "git+https://github.com/ocaml/dune.git"
+x-maintenance-intent: ["(latest)"]
+build: [
+  ["ocaml" "boot/bootstrap.ml" "-j" jobs]
+  ["./_boot/dune.exe" "build" "dune.install" "--release" "--profile" "dune-bootstrap" "-j" jobs]
+]
+depends: [
+  # Please keep the lower bound in sync with .github/workflows/workflow.yml,
+  # dune-project and min_ocaml_version in bootstrap.ml
+  ("ocaml" {>= "4.14"} | ("ocaml" {>= "4.02" & < "4.14~~"} & "ocamlfind-secondary" & "ocaml-secondary-compiler" {>= "4.14"}))
+  "base-unix"
+  "base-threads"
+  "lwt" { with-dev-setup & os != "win32" }
+  "cinaps" { with-dev-setup }
+  "csexp" { with-dev-setup & >= "1.3.0" }
+  "js_of_ocaml" { with-dev-setup & >= "6.1.0" & os != "win32" }
+  "js_of_ocaml-compiler" { with-dev-setup & >= "6.1.0" & os != "win32" }
+  "mdx" { with-dev-setup & >= "2.3.0" & os != "win32" }
+  "menhir" { with-dev-setup & os != "win32" }
+  "ocamlfind" { with-dev-setup & os != "win32" }
+  "odoc" { with-dev-setup & >= "3.2.0" & os != "win32" }
+  "ppx_expect" { with-dev-setup & >= "v0.17" & os != "win32" }
+  "ppx_optcomp" {with-dev-setup}
+  "spawn" { with-dev-setup }
+  "ppx_inline_test" { with-dev-setup & os != "win32" }
+  "ppxlib" { with-dev-setup & >= "0.37.0" & os != "win32" }
+  "ctypes" { with-dev-setup & os != "win32" }
+  "utop" { with-dev-setup & >= "2.6.0" & os != "win32" }
+  "melange" { with-dev-setup & >= "5.1.0-51" & os != "win32" }
+  "uutf" { with-dev-setup }
+  # the rev store negotiation test launches a git daemon, needs it to be
+  # installed on some distributions
+  "conf-git-daemon" { with-test }
+]
+url {
+  src:
+    "https://github.com/ocaml/dune/releases/download/3.24.0/dune-3.24.0.tbz"
+  checksum: [
+    "sha256=501f73727a939aa954dc0537e37792a1ba189e61719c81dc367e2594fe016034"
+    "sha512=cd0a366d38ffb65f45c4c92059713190bdd7359c94f0da9c75c08e3acbd505d3852b881b0be1fc060ca2ce70e9425c1447d62560de0cf768b7ec6f9370fa3491"
+  ]
+}
+x-commit-hash: "47f64de764078db6edb2698958b5270a17bffb05"

--- a/packages/dyn/dyn.3.24.0/opam
+++ b/packages/dyn/dyn.3.24.0/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+synopsis: "Dynamic type"
+description: "Dynamic type"
+maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+license: "MIT"
+homepage: "https://github.com/ocaml/dune"
+doc: "https://dune.readthedocs.io/"
+bug-reports: "https://github.com/ocaml/dune/issues"
+depends: [
+  "dune" {>= "3.24"}
+  "ocaml" {>= "4.14"}
+  "ordering" {= version}
+  "pp" {>= "1.1.0"}
+  "odoc" {with-doc}
+]
+dev-repo: "git+https://github.com/ocaml/dune.git"
+x-maintenance-intent: ["none"]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src:
+    "https://github.com/ocaml/dune/releases/download/3.24.0/dune-3.24.0.tbz"
+  checksum: [
+    "sha256=501f73727a939aa954dc0537e37792a1ba189e61719c81dc367e2594fe016034"
+    "sha512=cd0a366d38ffb65f45c4c92059713190bdd7359c94f0da9c75c08e3acbd505d3852b881b0be1fc060ca2ce70e9425c1447d62560de0cf768b7ec6f9370fa3491"
+  ]
+}
+x-commit-hash: "47f64de764078db6edb2698958b5270a17bffb05"

--- a/packages/fs-io/fs-io.3.24.0/opam
+++ b/packages/fs-io/fs-io.3.24.0/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+synopsis: "File System Operations"
+description: "Misc. Collection of File System Operations"
+maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+license: "MIT"
+homepage: "https://github.com/ocaml/dune"
+doc: "https://dune.readthedocs.io/"
+bug-reports: "https://github.com/ocaml/dune/issues"
+depends: [
+  "dune" {>= "3.24"}
+  "base-unix"
+  "ocaml" {>= "4.14"}
+  "odoc" {with-doc}
+]
+dev-repo: "git+https://github.com/ocaml/dune.git"
+x-maintenance-intent: ["none"]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src:
+    "https://github.com/ocaml/dune/releases/download/3.24.0/dune-3.24.0.tbz"
+  checksum: [
+    "sha256=501f73727a939aa954dc0537e37792a1ba189e61719c81dc367e2594fe016034"
+    "sha512=cd0a366d38ffb65f45c4c92059713190bdd7359c94f0da9c75c08e3acbd505d3852b881b0be1fc060ca2ce70e9425c1447d62560de0cf768b7ec6f9370fa3491"
+  ]
+}
+x-commit-hash: "47f64de764078db6edb2698958b5270a17bffb05"

--- a/packages/ocamlc-loc/ocamlc-loc.3.24.0/opam
+++ b/packages/ocamlc-loc/ocamlc-loc.3.24.0/opam
@@ -1,0 +1,43 @@
+opam-version: "2.0"
+synopsis: "Parse ocaml compiler output into structured form"
+description:
+  "This library offers no backwards compatibility guarantees. Use at your own risk."
+maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+license: "MIT"
+homepage: "https://github.com/ocaml/dune"
+doc: "https://dune.readthedocs.io/"
+bug-reports: "https://github.com/ocaml/dune/issues"
+depends: [
+  "dune" {>= "3.24"}
+  "ocaml" {>= "4.14"}
+  "dyn" {= version}
+  "odoc" {with-doc}
+]
+conflicts: [
+  "ocaml-lsp-server" {< "1.17.0"}
+]
+dev-repo: "git+https://github.com/ocaml/dune.git"
+x-maintenance-intent: ["none"]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src:
+    "https://github.com/ocaml/dune/releases/download/3.24.0/dune-3.24.0.tbz"
+  checksum: [
+    "sha256=501f73727a939aa954dc0537e37792a1ba189e61719c81dc367e2594fe016034"
+    "sha512=cd0a366d38ffb65f45c4c92059713190bdd7359c94f0da9c75c08e3acbd505d3852b881b0be1fc060ca2ce70e9425c1447d62560de0cf768b7ec6f9370fa3491"
+  ]
+}
+x-commit-hash: "47f64de764078db6edb2698958b5270a17bffb05"

--- a/packages/ordering/ordering.3.24.0/opam
+++ b/packages/ordering/ordering.3.24.0/opam
@@ -1,0 +1,38 @@
+opam-version: "2.0"
+synopsis: "Element ordering"
+description: "Element ordering"
+maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+license: "MIT"
+homepage: "https://github.com/ocaml/dune"
+doc: "https://dune.readthedocs.io/"
+bug-reports: "https://github.com/ocaml/dune/issues"
+depends: [
+  "dune" {>= "3.24"}
+  "ocaml" {>= "4.14"}
+  "odoc" {with-doc}
+]
+dev-repo: "git+https://github.com/ocaml/dune.git"
+x-maintenance-intent: ["none"]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src:
+    "https://github.com/ocaml/dune/releases/download/3.24.0/dune-3.24.0.tbz"
+  checksum: [
+    "sha256=501f73727a939aa954dc0537e37792a1ba189e61719c81dc367e2594fe016034"
+    "sha512=cd0a366d38ffb65f45c4c92059713190bdd7359c94f0da9c75c08e3acbd505d3852b881b0be1fc060ca2ce70e9425c1447d62560de0cf768b7ec6f9370fa3491"
+  ]
+}
+x-commit-hash: "47f64de764078db6edb2698958b5270a17bffb05"

--- a/packages/stdune/stdune.3.24.0/opam
+++ b/packages/stdune/stdune.3.24.0/opam
@@ -1,0 +1,46 @@
+opam-version: "2.0"
+synopsis: "Dune's unstable standard library"
+description:
+  "This library offers no backwards compatibility guarantees. Use at your own risk."
+maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+license: "MIT"
+homepage: "https://github.com/ocaml/dune"
+doc: "https://dune.readthedocs.io/"
+bug-reports: "https://github.com/ocaml/dune/issues"
+depends: [
+  "dune" {>= "3.24"}
+  "ocaml" {>= "4.14"}
+  "base-unix"
+  "csexp" {>= "1.5.0"}
+  "dyn" {= version}
+  "fs-io" {= version}
+  "ordering" {= version}
+  "pp" {>= "2.0.0"}
+  "top-closure" {= version}
+  "odoc" {with-doc}
+]
+dev-repo: "git+https://github.com/ocaml/dune.git"
+x-maintenance-intent: ["none"]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src:
+    "https://github.com/ocaml/dune/releases/download/3.24.0/dune-3.24.0.tbz"
+  checksum: [
+    "sha256=501f73727a939aa954dc0537e37792a1ba189e61719c81dc367e2594fe016034"
+    "sha512=cd0a366d38ffb65f45c4c92059713190bdd7359c94f0da9c75c08e3acbd505d3852b881b0be1fc060ca2ce70e9425c1447d62560de0cf768b7ec6f9370fa3491"
+  ]
+}
+x-commit-hash: "47f64de764078db6edb2698958b5270a17bffb05"

--- a/packages/top-closure/top-closure.3.24.0/opam
+++ b/packages/top-closure/top-closure.3.24.0/opam
@@ -1,0 +1,38 @@
+opam-version: "2.0"
+synopsis: "Topological Closure"
+description: "Generic Topological Closure"
+maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+license: "MIT"
+homepage: "https://github.com/ocaml/dune"
+doc: "https://dune.readthedocs.io/"
+bug-reports: "https://github.com/ocaml/dune/issues"
+depends: [
+  "dune" {>= "3.24"}
+  "ocaml" {>= "4.14"}
+  "odoc" {with-doc}
+]
+dev-repo: "git+https://github.com/ocaml/dune.git"
+x-maintenance-intent: ["none"]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src:
+    "https://github.com/ocaml/dune/releases/download/3.24.0/dune-3.24.0.tbz"
+  checksum: [
+    "sha256=501f73727a939aa954dc0537e37792a1ba189e61719c81dc367e2594fe016034"
+    "sha512=cd0a366d38ffb65f45c4c92059713190bdd7359c94f0da9c75c08e3acbd505d3852b881b0be1fc060ca2ce70e9425c1447d62560de0cf768b7ec6f9370fa3491"
+  ]
+}
+x-commit-hash: "47f64de764078db6edb2698958b5270a17bffb05"

--- a/packages/xdg/xdg.3.24.0/opam
+++ b/packages/xdg/xdg.3.24.0/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+synopsis: "XDG Base Directory Specification"
+description:
+  "https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html"
+maintainer: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+license: "MIT"
+homepage: "https://github.com/ocaml/dune"
+doc: "https://dune.readthedocs.io/"
+bug-reports: "https://github.com/ocaml/dune/issues"
+depends: [
+  "dune" {>= "3.24"}
+  "ocaml" {>= "4.14"}
+  "odoc" {with-doc}
+]
+dev-repo: "git+https://github.com/ocaml/dune.git"
+x-maintenance-intent: ["(latest)"]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src:
+    "https://github.com/ocaml/dune/releases/download/3.24.0/dune-3.24.0.tbz"
+  checksum: [
+    "sha256=501f73727a939aa954dc0537e37792a1ba189e61719c81dc367e2594fe016034"
+    "sha512=cd0a366d38ffb65f45c4c92059713190bdd7359c94f0da9c75c08e3acbd505d3852b881b0be1fc060ca2ce70e9425c1447d62560de0cf768b7ec6f9370fa3491"
+  ]
+}
+x-commit-hash: "47f64de764078db6edb2698958b5270a17bffb05"


### PR DESCRIPTION
Fast, portable, and opinionated build system

- Project page: <a href="https://github.com/ocaml/dune">https://github.com/ocaml/dune</a>
- Documentation: <a href="https://dune.readthedocs.io/">https://dune.readthedocs.io/</a>

##### CHANGES:

### Fixed

- Fix promotion failure when a target changes from a directory to a file
  between builds, causing "Is a directory" errors.
  (ocaml/dune#14371, fixes ocaml/dune#5647, fixes ocaml/dune#6575, @Alizter)

- Make `dune build @doc` pick up an odoc installed via `dune tools install
  odoc` even without `DUNE_CONFIG__LOCK_DEV_TOOL=enabled`, mirroring how
  `dune fmt` consumes a locked ocamlformat (ocaml/dune#14426, fixes ocaml/dune#14235, @mt-caret)

- Reject `(package ...)` inside a named dependency binding
  (`(deps (:name (package foo)))`). Previously this was silently accepted but
  `%{name}` would resolve to an empty path list. (ocaml/dune#14499, @Alizter)

- Fix incorrect dependency in the `.cmxs` build for libraries with
  mode-dependent foreign stubs: the rule depended on the byte stubs archive
  instead of the native one, so parallel builds could fail to find
  `-l<lib>_stubs_native`. (ocaml/dune#14500, fixes ocaml/dune#12964, @Alizter)

- Fix `dune build` failing with "No rule found" when `lock_dir` paths in
  `dune-workspace` contain a subdirectory (e.g. `(path sub/dune.lock)`).
  (ocaml/dune#14524, fixes ocaml/dune#14523, @Alizter)

- Artifact substitution repairs executable bit if it's not set correctly in the workspace
  (ocaml/dune#14556, @rgrinberg)

- Ignore `EINVAL` when accepting sockets on MacOS (ocaml/dune#14612, fixes ocaml/dune#12660, @rgrinberg)

- Validate profile names. Profile names must be non-empty and can only contain
  letters, digits, `_` and `-`. The name `_` is reserved as a wildcard in
  `(env ...)` stanzas. (ocaml/dune#14657, fixes ocaml/dune#14630, @rlepigre)

### Added

- Add `%{pkg:<package>:<section>:<path>}` pform for resolving package install
  files. Works with workspace packages, lock-file packages, and installed
  packages. (ocaml/dune#14200, fixes ocaml/dune#14193, fixes ocaml/dune#3378, @Alizter)

- Enable the relocatable compiler by default for package management (ocaml/dune#14357,
  fixes ocaml/dune#14012, @Alizter)

- Add changed source files to the `build-start` trace event for watch-mode
  restarts, showing the paths that triggered the rebuild (ocaml/dune#14396, @rgrinberg)

- Add dune's rusage information in start/finish build trace events (ocaml/dune#14402, @rgrinberg)

- Add a status message for RPC clients that manage to connect (ocaml/dune#14424, @rgrinberg)

- Allow blang expressions in the `runtest_alias` field in the `cram` stanza (ocaml/dune#14425, @rgrinberg)

- Extend the stat based cache to cache the contents of directories and not just
  source files (ocaml/dune#14469, @rgrinberg).

- Show the number of connected RPC clients in the watch mode status line
  (ocaml/dune#14489, @rgrinberg)

- Promote directory targets from experimental to generally available in 3.24
  (ocaml/dune#14579, @rgrinberg)

### Changed

- Use `/` as directory separator when appending local paths to external paths,
  making path construction consistent across platforms. (ocaml/dune#14278, @Alizter)
- On Windows, normalise process paths to `\` before passing them to
  `CreateProcessW` so that programs which scan `argv[0]` (notably `cmd.exe`)
  do not misparse mixed separators. (ocaml/dune#14278, @Alizter)

- `%{bin:NAME}` now resolves to the build artifact path rather than
  the install staging path. Rules with `%{bin:NAME}` deps additionally
  get a per-rule `.binaries` directory prepended to the action's
  `PATH`, containing correctly-named symlinks for each declared bin
  pform dep. (ocaml/dune#14432, fixes ocaml/dune#3324, @Alizter)

- Replace the Rocq language field `(stdlib ...)` with the presence-only field
  `(no_corelib)` in Rocq language 0.14. (ocaml/dune#14452, fixes ocaml/dune#14358, @Durbatuluk1701)

- Throttle sandbox creation to 250 concurrent sandboxes. (ocaml/dune#14464, @rgrinberg)

- The package solver now uses cached revision store lookups for improved
  performance. (ocaml/dune#14494, fixes ocaml/dune#12637, @Alizter, @rgrinberg)

- Remove the deprecated `(lang coq)` Coq Build Language. Use the
  Rocq Build Language (`(using rocq <version>)`) instead. Projects that
  still declare `(using coq <version>)` now get an error pointing them
  at Rocq. (ocaml/dune#14525, fixes ocaml/dune#12788, @Alizter)
