### PR TITLE
OCaml 5.5.0 manual

### DIFF
--- a/packages/ocaml-manual/ocaml-manual.5.5.0/opam
+++ b/packages/ocaml-manual/ocaml-manual.5.5.0/opam
@@ -1,0 +1,22 @@
+opam-version: "2.0"
+maintainer: "Daniel Bünzli <daniel.buenzl i@erratique.ch>"
+authors: [ "Xavier Leroy"
+           "Damien Doligez"
+           "Alain Frisch"
+           "Jacques Garrigue"
+           "Didier Rémy"
+           "Jérôme Vouillon" ]
+homepage: "http://ocaml.org/"
+doc: "https://ocaml.org/manual/"
+license: "CC-BY-SA-4.0"
+dev-repo: "git+https://github.com/ocaml/ocaml.git"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
+install: ["cp" "-R" "." _:doc]
+synopsis: "The OCaml system manual"
+depends: [
+  "ocaml" {= version}
+]
+url {
+  src: "http://caml.inria.fr/distrib/ocaml-5.5/ocaml-5.5-refman-html.tar.gz"
+  checksum: "sha256=c202d1668a680567a5ada7e7ad6bc4a97e701082077af54c2b37c9f8d5088f61"
+}


### PR DESCRIPTION
This PR adds the opam package for the OCaml 5.5.0 version of the reference manual.