### PR TITLE
[new release] colibri2 (4 packages) (0.6)

### DIFF
--- a/packages/colibri2/colibri2.0.6/opam
+++ b/packages/colibri2/colibri2.0.6/opam
@@ -1,0 +1,72 @@
+opam-version: "2.0"
+synopsis: "A CP solver for smtlib"
+description: "A reimplementation of COLIBRI in OCaml"
+maintainer: ["François Bobot"]
+authors: [
+  "François Bobot"
+  "Bruno Marre"
+  "Guillaume Bury"
+  "Stéphane Graham-Lengrand"
+  "Hichem Rami Ait El Hara"
+]
+license: "LGPL-2.1-only"
+homepage: "https://colibri.frama-c.com"
+bug-reports: "https://git.frama-c.com/pub/colibrics/issues"
+depends: [
+  "base" {>= "v0.16.1"}
+  "flint" {>= "0.4.0"}
+  "cmdliner" {>= "2.0.0"}
+  "colibrilib" {= version}
+  "containers" {>= "3.9"}
+  "dolmen" {= "0.10"}
+  "dolmen_loop" {= "0.10"}
+  "dolmen_type" {= "0.10"}
+  "dune" {>= "3.7" & >= "3.7"}
+  "dune-build-info" {>= "3.7"}
+  "farith"
+  "gen" {>= "1.0"}
+  "gmap"
+  "ocaml" {>= "4.12"}
+  "ocamlgraph" {>= "2.0.0"}
+  "ocplib-simplex" {>= "0.5.1"}
+  "ounit2" {>= "2.2.4" & with-test}
+  "ppx_deriving" {>= "5.2.1"}
+  "ppx_hash" {>= "v0.14.0"}
+  "ppx_here" {>= "v0.14.0"}
+  "ppx_inline_test" {>= "v0.14.1"}
+  "ppx_optcomp" {>= "v0.14.3"}
+  "patricia-tree" {>= "0.14.0"}
+  "qcheck-core" {>= "0.90"}
+  "re" {>= "1.10.3"}
+  "trace" {>= "0.11"}
+  "trace-tef" {>= "0.11"}
+  "zarith" {>= "1.12"}
+  "mlcuddidl"
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+dev-repo: "git+https://git.frama-c.com/pub/colibrics.git"
+url {
+  src:
+    "https://git.frama-c.com/api/v4/projects/879/packages/generic/colibri2/0.6/colibri2-0.6.tbz"
+  checksum: [
+    "sha256=6974bb0397202647ede57771e3294b89d89971c3e0740e4adc8a8bd8264ab4a3"
+    "sha512=870532a98f2c0e8e732277d66baa6fd75c6d42344ed2ec54e1b489456641c13af4d70bae61b4b8b2da1f54781425eca514bac03f72526302e38c1c53fdd667bd"
+  ]
+}
+x-commit-hash: "0380c5965ac3a0596293301bf25e853c45762c46"

--- a/packages/colibrics/colibrics.0.6/opam
+++ b/packages/colibrics/colibrics.0.6/opam
@@ -1,0 +1,49 @@
+opam-version: "2.0"
+synopsis: "A CP solver proved in Why3"
+description: "The core of Colibrics is formally proved using Why3."
+maintainer: ["François Bobot"]
+authors: ["François Bobot"]
+license: "LGPL-2.1-only"
+homepage: "https://colibri.frama-c.com"
+bug-reports: "https://git.frama-c.com/pub/colibrics/issues"
+depends: [
+  "ocaml" {>= "4.12"}
+  "cmdliner" {>= "2.0.0"}
+  "dolmen" {= "0.10"}
+  "dolmen_loop" {= "0.10"}
+  "dolmen_type" {= "0.10"}
+  "dune" {>= "3.7" & >= "3.7"}
+  "jingoo" {>= "1.4.4"}
+  "logs" {>= "0.7.0"}
+  "ppx_deriving_yojson" {>= "3.6.1"}
+  "why3" {>= "1.4.0"}
+  "yojson"
+  "zarith" {>= "1.12"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+dev-repo: "git+https://git.frama-c.com/pub/colibrics.git"
+url {
+  src:
+    "https://git.frama-c.com/api/v4/projects/879/packages/generic/colibri2/0.6/colibri2-0.6.tbz"
+  checksum: [
+    "sha256=6974bb0397202647ede57771e3294b89d89971c3e0740e4adc8a8bd8264ab4a3"
+    "sha512=870532a98f2c0e8e732277d66baa6fd75c6d42344ed2ec54e1b489456641c13af4d70bae61b4b8b2da1f54781425eca514bac03f72526302e38c1c53fdd667bd"
+  ]
+}
+x-commit-hash: "0380c5965ac3a0596293301bf25e853c45762c46"

--- a/packages/colibrilib-why3/colibrilib-why3.0.6/opam
+++ b/packages/colibrilib-why3/colibrilib-why3.0.6/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+synopsis: "A Why3 library of domains and propagators"
+description: "Interval, and union of interval domains defined formally"
+maintainer: ["François Bobot"]
+authors: ["François Bobot"]
+license: "LGPL-2.1-only"
+homepage: "https://colibri.frama-c.com"
+bug-reports: "https://git.frama-c.com/pub/colibrics/issues"
+depends: [
+  "dune" {>= "3.7"}
+  "why3find"
+  "ocaml" {>= "4.12"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+dev-repo: "git+https://git.frama-c.com/pub/colibrics.git"
+url {
+  src:
+    "https://git.frama-c.com/api/v4/projects/879/packages/generic/colibri2/0.6/colibri2-0.6.tbz"
+  checksum: [
+    "sha256=6974bb0397202647ede57771e3294b89d89971c3e0740e4adc8a8bd8264ab4a3"
+    "sha512=870532a98f2c0e8e732277d66baa6fd75c6d42344ed2ec54e1b489456641c13af4d70bae61b4b8b2da1f54781425eca514bac03f72526302e38c1c53fdd667bd"
+  ]
+}
+x-commit-hash: "0380c5965ac3a0596293301bf25e853c45762c46"

--- a/packages/colibrilib/colibrilib.0.6/opam
+++ b/packages/colibrilib/colibrilib.0.6/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+synopsis: "A library of domains and propagators proved in Why3"
+description: "Interval, and union of interval domains defined formally"
+maintainer: ["François Bobot"]
+authors: ["François Bobot"]
+license: "LGPL-2.1-only"
+homepage: "https://colibri.frama-c.com"
+bug-reports: "https://git.frama-c.com/pub/colibrics/issues"
+depends: [
+  "dune" {>= "3.7"}
+  "ocaml" {>= "4.12"}
+  "zarith" {>= "1.12"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+dev-repo: "git+https://git.frama-c.com/pub/colibrics.git"
+url {
+  src:
+    "https://git.frama-c.com/api/v4/projects/879/packages/generic/colibri2/0.6/colibri2-0.6.tbz"
+  checksum: [
+    "sha256=6974bb0397202647ede57771e3294b89d89971c3e0740e4adc8a8bd8264ab4a3"
+    "sha512=870532a98f2c0e8e732277d66baa6fd75c6d42344ed2ec54e1b489456641c13af4d70bae61b4b8b2da1f54781425eca514bac03f72526302e38c1c53fdd667bd"
+  ]
+}
+x-commit-hash: "0380c5965ac3a0596293301bf25e853c45762c46"


### PR DESCRIPTION
A CP solver for smtlib

- Project page: <a href="https://colibri.frama-c.com">https://colibri.frama-c.com</a>

##### CHANGES:

  - Add bv2int, bv2nat, nat2bv, int2bv,
  - produce models that why3 can parse
  - tentatively produce "proof trace" as smtlib2 files
  - --try-disprove-forall-using-domain use domain to disprove universal quantification on floating-points
  - Soundness fix on floating-point linearization
  - Soundness fix on instantiation of real for integer variable
