### PR TITLE
[new release] sail (13 packages) (0.20.2)

### DIFF
--- a/packages/libsail/libsail.0.20.2/opam
+++ b/packages/libsail/libsail.0.20.2/opam
@@ -1,0 +1,69 @@
+opam-version: "2.0"
+synopsis:
+  "Sail is a language for describing the instruction semantics of processors"
+description: """
+Sail is a language for describing the instruction-set
+architecture (ISA) semantics of processors. Sail aims to provide a
+engineer-friendly, vendor-pseudocode-like language for describing
+instruction semantics. It is essentially a first-order imperative
+language, but with lightweight dependent typing for numeric types and
+bitvector lengths, which are automatically checked using Z3. It has
+been used for several papers, available from
+http://www.cl.cam.ac.uk/~pes20/sail/.
+"""
+maintainer: ["Sail Devs <cl-sail-dev@lists.cam.ac.uk>"]
+authors: [
+  "Alasdair Armstrong"
+  "Thomas Bauereiss"
+  "Brian Campbell"
+  "Shaked Flur"
+  "Jonathan French"
+  "Kathy Gray"
+  "Robert Norton"
+  "Christopher Pulte"
+  "Peter Sewell"
+  "Mark Wassell"
+]
+license: "BSD-2-Clause"
+homepage: "https://github.com/rems-project/sail"
+bug-reports: "https://github.com/rems-project/sail/issues"
+depends: [
+  "dune" {>= "3.21"}
+  "dune-site" {>= "3.0.2"}
+  "bisect_ppx" {dev & >= "2.5.0"}
+  "menhir" {>= "20240715" & build}
+  "ott" {>= "0.28" & build}
+  "lem" {>= "2018-12-14"}
+  "linksem" {>= "0.3"}
+  "conf-gmp"
+  "yojson" {>= "1.6.0"}
+  "pprint" {>= "20220103"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+dev-repo: "git+https://github.com/rems-project/sail.git"
+x-maintenance-intent: ["(latest)"]
+url {
+  src:
+    "https://github.com/rems-project/sail/releases/download/0.20.2/sail-0.20.2.tbz"
+  checksum: [
+    "sha256=3221c89257ef01da3b9f4768655b3b64e685a382e0978e9cdf256b288cec6474"
+    "sha512=a3077774869847dd20556f98a6364114727cd3cd4830fc6f3ff0837e018826ad102ce682b0b4e88aa8c1eceec6952c8415c66fd96f67a9000510aa77e928105f"
+  ]
+}
+x-commit-hash: "3b7af38d66466ecadad563158b07ce2f82fe05da"

--- a/packages/sail/sail.0.20.2/opam
+++ b/packages/sail/sail.0.20.2/opam
@@ -1,0 +1,74 @@
+opam-version: "2.0"
+synopsis:
+  "Sail is a language for describing the instruction semantics of processors"
+description: """
+Sail is a language for describing the instruction-set
+architecture (ISA) semantics of processors. Sail aims to provide a
+engineer-friendly, vendor-pseudocode-like language for describing
+instruction semantics. It is essentially a first-order imperative
+language, but with lightweight dependent typing for numeric types and
+bitvector lengths, which are automatically checked using Z3. It has
+been used for several papers, available from
+http://www.cl.cam.ac.uk/~pes20/sail/.
+"""
+maintainer: ["Sail Devs <cl-sail-dev@lists.cam.ac.uk>"]
+authors: [
+  "Alasdair Armstrong"
+  "Thomas Bauereiss"
+  "Brian Campbell"
+  "Shaked Flur"
+  "Jonathan French"
+  "Kathy Gray"
+  "Robert Norton"
+  "Christopher Pulte"
+  "Peter Sewell"
+  "Mark Wassell"
+]
+license: "BSD-2-Clause"
+homepage: "https://github.com/rems-project/sail"
+bug-reports: "https://github.com/rems-project/sail/issues"
+depends: [
+  "dune" {>= "3.21"}
+  "libsail" {= version}
+  "sail_maker" {= version & build}
+  "sail_ocaml_backend" {= version & post}
+  "sail_c_backend" {= version & post}
+  "sail_smt_backend" {= version & post}
+  "sail_sv_backend" {= version & post}
+  "sail_lem_backend" {= version & post}
+  "sail_coq_backend" {= version & post}
+  "sail_lean_backend" {= version & post}
+  "sail_latex_backend" {= version & post}
+  "sail_doc_backend" {= version & post}
+  "sail_output" {= version & post}
+  "linenoise" {>= "1.1.0" & os != "win32"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+dev-repo: "git+https://github.com/rems-project/sail.git"
+x-maintenance-intent: ["(latest)"]
+substs: [ "src/bin/manifest.ml" ]
+url {
+  src:
+    "https://github.com/rems-project/sail/releases/download/0.20.2/sail-0.20.2.tbz"
+  checksum: [
+    "sha256=3221c89257ef01da3b9f4768655b3b64e685a382e0978e9cdf256b288cec6474"
+    "sha512=a3077774869847dd20556f98a6364114727cd3cd4830fc6f3ff0837e018826ad102ce682b0b4e88aa8c1eceec6952c8415c66fd96f67a9000510aa77e928105f"
+  ]
+}
+x-commit-hash: "3b7af38d66466ecadad563158b07ce2f82fe05da"

--- a/packages/sail_c_backend/sail_c_backend.0.20.2/opam
+++ b/packages/sail_c_backend/sail_c_backend.0.20.2/opam
@@ -1,0 +1,50 @@
+opam-version: "2.0"
+synopsis: "Sail to C translation"
+maintainer: ["Sail Devs <cl-sail-dev@lists.cam.ac.uk>"]
+authors: [
+  "Alasdair Armstrong"
+  "Thomas Bauereiss"
+  "Brian Campbell"
+  "Shaked Flur"
+  "Jonathan French"
+  "Kathy Gray"
+  "Robert Norton"
+  "Christopher Pulte"
+  "Peter Sewell"
+  "Mark Wassell"
+]
+license: "BSD-2-Clause"
+homepage: "https://github.com/rems-project/sail"
+bug-reports: "https://github.com/rems-project/sail/issues"
+depends: [
+  "dune" {>= "3.21"}
+  "libsail" {= version}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+dev-repo: "git+https://github.com/rems-project/sail.git"
+x-maintenance-intent: ["(latest)"]
+url {
+  src:
+    "https://github.com/rems-project/sail/releases/download/0.20.2/sail-0.20.2.tbz"
+  checksum: [
+    "sha256=3221c89257ef01da3b9f4768655b3b64e685a382e0978e9cdf256b288cec6474"
+    "sha512=a3077774869847dd20556f98a6364114727cd3cd4830fc6f3ff0837e018826ad102ce682b0b4e88aa8c1eceec6952c8415c66fd96f67a9000510aa77e928105f"
+  ]
+}
+x-commit-hash: "3b7af38d66466ecadad563158b07ce2f82fe05da"

--- a/packages/sail_coq_backend/sail_coq_backend.0.20.2/opam
+++ b/packages/sail_coq_backend/sail_coq_backend.0.20.2/opam
@@ -1,0 +1,50 @@
+opam-version: "2.0"
+synopsis: "Sail to Coq translation"
+maintainer: ["Sail Devs <cl-sail-dev@lists.cam.ac.uk>"]
+authors: [
+  "Alasdair Armstrong"
+  "Thomas Bauereiss"
+  "Brian Campbell"
+  "Shaked Flur"
+  "Jonathan French"
+  "Kathy Gray"
+  "Robert Norton"
+  "Christopher Pulte"
+  "Peter Sewell"
+  "Mark Wassell"
+]
+license: "BSD-2-Clause"
+homepage: "https://github.com/rems-project/sail"
+bug-reports: "https://github.com/rems-project/sail/issues"
+depends: [
+  "dune" {>= "3.21"}
+  "libsail" {= version}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+dev-repo: "git+https://github.com/rems-project/sail.git"
+x-maintenance-intent: ["(latest)"]
+url {
+  src:
+    "https://github.com/rems-project/sail/releases/download/0.20.2/sail-0.20.2.tbz"
+  checksum: [
+    "sha256=3221c89257ef01da3b9f4768655b3b64e685a382e0978e9cdf256b288cec6474"
+    "sha512=a3077774869847dd20556f98a6364114727cd3cd4830fc6f3ff0837e018826ad102ce682b0b4e88aa8c1eceec6952c8415c66fd96f67a9000510aa77e928105f"
+  ]
+}
+x-commit-hash: "3b7af38d66466ecadad563158b07ce2f82fe05da"

--- a/packages/sail_doc_backend/sail_doc_backend.0.20.2/opam
+++ b/packages/sail_doc_backend/sail_doc_backend.0.20.2/opam
@@ -1,0 +1,52 @@
+opam-version: "2.0"
+synopsis: "Sail documentation generator"
+maintainer: ["Sail Devs <cl-sail-dev@lists.cam.ac.uk>"]
+authors: [
+  "Alasdair Armstrong"
+  "Thomas Bauereiss"
+  "Brian Campbell"
+  "Shaked Flur"
+  "Jonathan French"
+  "Kathy Gray"
+  "Robert Norton"
+  "Christopher Pulte"
+  "Peter Sewell"
+  "Mark Wassell"
+]
+license: "BSD-2-Clause"
+homepage: "https://github.com/rems-project/sail"
+bug-reports: "https://github.com/rems-project/sail/issues"
+depends: [
+  "dune" {>= "3.21"}
+  "libsail" {= version}
+  "base64" {>= "3.1.0"}
+  "omd" {>= "1.3.1" & < "1.4.0"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+dev-repo: "git+https://github.com/rems-project/sail.git"
+x-maintenance-intent: ["(latest)"]
+url {
+  src:
+    "https://github.com/rems-project/sail/releases/download/0.20.2/sail-0.20.2.tbz"
+  checksum: [
+    "sha256=3221c89257ef01da3b9f4768655b3b64e685a382e0978e9cdf256b288cec6474"
+    "sha512=a3077774869847dd20556f98a6364114727cd3cd4830fc6f3ff0837e018826ad102ce682b0b4e88aa8c1eceec6952c8415c66fd96f67a9000510aa77e928105f"
+  ]
+}
+x-commit-hash: "3b7af38d66466ecadad563158b07ce2f82fe05da"

--- a/packages/sail_latex_backend/sail_latex_backend.0.20.2/opam
+++ b/packages/sail_latex_backend/sail_latex_backend.0.20.2/opam
@@ -1,0 +1,51 @@
+opam-version: "2.0"
+synopsis: "Sail to LaTeX formatting"
+maintainer: ["Sail Devs <cl-sail-dev@lists.cam.ac.uk>"]
+authors: [
+  "Alasdair Armstrong"
+  "Thomas Bauereiss"
+  "Brian Campbell"
+  "Shaked Flur"
+  "Jonathan French"
+  "Kathy Gray"
+  "Robert Norton"
+  "Christopher Pulte"
+  "Peter Sewell"
+  "Mark Wassell"
+]
+license: "BSD-2-Clause"
+homepage: "https://github.com/rems-project/sail"
+bug-reports: "https://github.com/rems-project/sail/issues"
+depends: [
+  "dune" {>= "3.21"}
+  "libsail" {= version}
+  "omd" {>= "1.3.1" & < "1.4.0"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+dev-repo: "git+https://github.com/rems-project/sail.git"
+x-maintenance-intent: ["(latest)"]
+url {
+  src:
+    "https://github.com/rems-project/sail/releases/download/0.20.2/sail-0.20.2.tbz"
+  checksum: [
+    "sha256=3221c89257ef01da3b9f4768655b3b64e685a382e0978e9cdf256b288cec6474"
+    "sha512=a3077774869847dd20556f98a6364114727cd3cd4830fc6f3ff0837e018826ad102ce682b0b4e88aa8c1eceec6952c8415c66fd96f67a9000510aa77e928105f"
+  ]
+}
+x-commit-hash: "3b7af38d66466ecadad563158b07ce2f82fe05da"

--- a/packages/sail_lean_backend/sail_lean_backend.0.20.2/opam
+++ b/packages/sail_lean_backend/sail_lean_backend.0.20.2/opam
@@ -1,0 +1,50 @@
+opam-version: "2.0"
+synopsis: "Sail to Lean translation"
+maintainer: ["Sail Devs <cl-sail-dev@lists.cam.ac.uk>"]
+authors: [
+  "Alasdair Armstrong"
+  "Thomas Bauereiss"
+  "Brian Campbell"
+  "Shaked Flur"
+  "Jonathan French"
+  "Kathy Gray"
+  "Robert Norton"
+  "Christopher Pulte"
+  "Peter Sewell"
+  "Mark Wassell"
+]
+license: "BSD-2-Clause"
+homepage: "https://github.com/rems-project/sail"
+bug-reports: "https://github.com/rems-project/sail/issues"
+depends: [
+  "dune" {>= "3.21"}
+  "libsail" {= version}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+dev-repo: "git+https://github.com/rems-project/sail.git"
+x-maintenance-intent: ["(latest)"]
+url {
+  src:
+    "https://github.com/rems-project/sail/releases/download/0.20.2/sail-0.20.2.tbz"
+  checksum: [
+    "sha256=3221c89257ef01da3b9f4768655b3b64e685a382e0978e9cdf256b288cec6474"
+    "sha512=a3077774869847dd20556f98a6364114727cd3cd4830fc6f3ff0837e018826ad102ce682b0b4e88aa8c1eceec6952c8415c66fd96f67a9000510aa77e928105f"
+  ]
+}
+x-commit-hash: "3b7af38d66466ecadad563158b07ce2f82fe05da"

--- a/packages/sail_lem_backend/sail_lem_backend.0.20.2/opam
+++ b/packages/sail_lem_backend/sail_lem_backend.0.20.2/opam
@@ -1,0 +1,50 @@
+opam-version: "2.0"
+synopsis: "Sail to Lem translation"
+maintainer: ["Sail Devs <cl-sail-dev@lists.cam.ac.uk>"]
+authors: [
+  "Alasdair Armstrong"
+  "Thomas Bauereiss"
+  "Brian Campbell"
+  "Shaked Flur"
+  "Jonathan French"
+  "Kathy Gray"
+  "Robert Norton"
+  "Christopher Pulte"
+  "Peter Sewell"
+  "Mark Wassell"
+]
+license: "BSD-2-Clause"
+homepage: "https://github.com/rems-project/sail"
+bug-reports: "https://github.com/rems-project/sail/issues"
+depends: [
+  "dune" {>= "3.21"}
+  "libsail" {= version}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+dev-repo: "git+https://github.com/rems-project/sail.git"
+x-maintenance-intent: ["(latest)"]
+url {
+  src:
+    "https://github.com/rems-project/sail/releases/download/0.20.2/sail-0.20.2.tbz"
+  checksum: [
+    "sha256=3221c89257ef01da3b9f4768655b3b64e685a382e0978e9cdf256b288cec6474"
+    "sha512=a3077774869847dd20556f98a6364114727cd3cd4830fc6f3ff0837e018826ad102ce682b0b4e88aa8c1eceec6952c8415c66fd96f67a9000510aa77e928105f"
+  ]
+}
+x-commit-hash: "3b7af38d66466ecadad563158b07ce2f82fe05da"

--- a/packages/sail_maker/sail_maker.0.20.2/opam
+++ b/packages/sail_maker/sail_maker.0.20.2/opam
@@ -1,0 +1,50 @@
+opam-version: "2.0"
+synopsis: "Helper tool for compiling Sail"
+maintainer: ["Sail Devs <cl-sail-dev@lists.cam.ac.uk>"]
+authors: [
+  "Alasdair Armstrong"
+  "Thomas Bauereiss"
+  "Brian Campbell"
+  "Shaked Flur"
+  "Jonathan French"
+  "Kathy Gray"
+  "Robert Norton"
+  "Christopher Pulte"
+  "Peter Sewell"
+  "Mark Wassell"
+]
+license: "BSD-2-Clause"
+homepage: "https://github.com/rems-project/sail"
+bug-reports: "https://github.com/rems-project/sail/issues"
+depends: [
+  "dune" {>= "3.21"}
+  "ocaml" {>= "4.14.0"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+dev-repo: "git+https://github.com/rems-project/sail.git"
+x-maintenance-intent: ["(latest)"]
+url {
+  src:
+    "https://github.com/rems-project/sail/releases/download/0.20.2/sail-0.20.2.tbz"
+  checksum: [
+    "sha256=3221c89257ef01da3b9f4768655b3b64e685a382e0978e9cdf256b288cec6474"
+    "sha512=a3077774869847dd20556f98a6364114727cd3cd4830fc6f3ff0837e018826ad102ce682b0b4e88aa8c1eceec6952c8415c66fd96f67a9000510aa77e928105f"
+  ]
+}
+x-commit-hash: "3b7af38d66466ecadad563158b07ce2f82fe05da"

--- a/packages/sail_ocaml_backend/sail_ocaml_backend.0.20.2/opam
+++ b/packages/sail_ocaml_backend/sail_ocaml_backend.0.20.2/opam
@@ -1,0 +1,51 @@
+opam-version: "2.0"
+synopsis: "Sail to OCaml translation"
+maintainer: ["Sail Devs <cl-sail-dev@lists.cam.ac.uk>"]
+authors: [
+  "Alasdair Armstrong"
+  "Thomas Bauereiss"
+  "Brian Campbell"
+  "Shaked Flur"
+  "Jonathan French"
+  "Kathy Gray"
+  "Robert Norton"
+  "Christopher Pulte"
+  "Peter Sewell"
+  "Mark Wassell"
+]
+license: "BSD-2-Clause"
+homepage: "https://github.com/rems-project/sail"
+bug-reports: "https://github.com/rems-project/sail/issues"
+depends: [
+  "dune" {>= "3.21"}
+  "libsail" {= version}
+  "base64" {>= "3.1.0"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+dev-repo: "git+https://github.com/rems-project/sail.git"
+x-maintenance-intent: ["(latest)"]
+url {
+  src:
+    "https://github.com/rems-project/sail/releases/download/0.20.2/sail-0.20.2.tbz"
+  checksum: [
+    "sha256=3221c89257ef01da3b9f4768655b3b64e685a382e0978e9cdf256b288cec6474"
+    "sha512=a3077774869847dd20556f98a6364114727cd3cd4830fc6f3ff0837e018826ad102ce682b0b4e88aa8c1eceec6952c8415c66fd96f67a9000510aa77e928105f"
+  ]
+}
+x-commit-hash: "3b7af38d66466ecadad563158b07ce2f82fe05da"

--- a/packages/sail_output/sail_output.0.20.2/opam
+++ b/packages/sail_output/sail_output.0.20.2/opam
@@ -1,0 +1,50 @@
+opam-version: "2.0"
+synopsis: "Example Sail output plugin"
+maintainer: ["Sail Devs <cl-sail-dev@lists.cam.ac.uk>"]
+authors: [
+  "Alasdair Armstrong"
+  "Thomas Bauereiss"
+  "Brian Campbell"
+  "Shaked Flur"
+  "Jonathan French"
+  "Kathy Gray"
+  "Robert Norton"
+  "Christopher Pulte"
+  "Peter Sewell"
+  "Mark Wassell"
+]
+license: "BSD-2-Clause"
+homepage: "https://github.com/rems-project/sail"
+bug-reports: "https://github.com/rems-project/sail/issues"
+depends: [
+  "dune" {>= "3.21"}
+  "libsail" {= version}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+dev-repo: "git+https://github.com/rems-project/sail.git"
+x-maintenance-intent: ["(latest)"]
+url {
+  src:
+    "https://github.com/rems-project/sail/releases/download/0.20.2/sail-0.20.2.tbz"
+  checksum: [
+    "sha256=3221c89257ef01da3b9f4768655b3b64e685a382e0978e9cdf256b288cec6474"
+    "sha512=a3077774869847dd20556f98a6364114727cd3cd4830fc6f3ff0837e018826ad102ce682b0b4e88aa8c1eceec6952c8415c66fd96f67a9000510aa77e928105f"
+  ]
+}
+x-commit-hash: "3b7af38d66466ecadad563158b07ce2f82fe05da"

--- a/packages/sail_smt_backend/sail_smt_backend.0.20.2/opam
+++ b/packages/sail_smt_backend/sail_smt_backend.0.20.2/opam
@@ -1,0 +1,50 @@
+opam-version: "2.0"
+synopsis: "Sail to SMT translation"
+maintainer: ["Sail Devs <cl-sail-dev@lists.cam.ac.uk>"]
+authors: [
+  "Alasdair Armstrong"
+  "Thomas Bauereiss"
+  "Brian Campbell"
+  "Shaked Flur"
+  "Jonathan French"
+  "Kathy Gray"
+  "Robert Norton"
+  "Christopher Pulte"
+  "Peter Sewell"
+  "Mark Wassell"
+]
+license: "BSD-2-Clause"
+homepage: "https://github.com/rems-project/sail"
+bug-reports: "https://github.com/rems-project/sail/issues"
+depends: [
+  "dune" {>= "3.21"}
+  "libsail" {= version}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+dev-repo: "git+https://github.com/rems-project/sail.git"
+x-maintenance-intent: ["(latest)"]
+url {
+  src:
+    "https://github.com/rems-project/sail/releases/download/0.20.2/sail-0.20.2.tbz"
+  checksum: [
+    "sha256=3221c89257ef01da3b9f4768655b3b64e685a382e0978e9cdf256b288cec6474"
+    "sha512=a3077774869847dd20556f98a6364114727cd3cd4830fc6f3ff0837e018826ad102ce682b0b4e88aa8c1eceec6952c8415c66fd96f67a9000510aa77e928105f"
+  ]
+}
+x-commit-hash: "3b7af38d66466ecadad563158b07ce2f82fe05da"

--- a/packages/sail_sv_backend/sail_sv_backend.0.20.2/opam
+++ b/packages/sail_sv_backend/sail_sv_backend.0.20.2/opam
@@ -1,0 +1,50 @@
+opam-version: "2.0"
+synopsis: "Sail to Systemverilog translation"
+maintainer: ["Sail Devs <cl-sail-dev@lists.cam.ac.uk>"]
+authors: [
+  "Alasdair Armstrong"
+  "Thomas Bauereiss"
+  "Brian Campbell"
+  "Shaked Flur"
+  "Jonathan French"
+  "Kathy Gray"
+  "Robert Norton"
+  "Christopher Pulte"
+  "Peter Sewell"
+  "Mark Wassell"
+]
+license: "BSD-2-Clause"
+homepage: "https://github.com/rems-project/sail"
+bug-reports: "https://github.com/rems-project/sail/issues"
+depends: [
+  "dune" {>= "3.21"}
+  "libsail" {= version}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+dev-repo: "git+https://github.com/rems-project/sail.git"
+x-maintenance-intent: ["(latest)"]
+url {
+  src:
+    "https://github.com/rems-project/sail/releases/download/0.20.2/sail-0.20.2.tbz"
+  checksum: [
+    "sha256=3221c89257ef01da3b9f4768655b3b64e685a382e0978e9cdf256b288cec6474"
+    "sha512=a3077774869847dd20556f98a6364114727cd3cd4830fc6f3ff0837e018826ad102ce682b0b4e88aa8c1eceec6952c8415c66fd96f67a9000510aa77e928105f"
+  ]
+}
+x-commit-hash: "3b7af38d66466ecadad563158b07ce2f82fe05da"


### PR DESCRIPTION
Sail is a language for describing the instruction semantics of processors

- Project page: <a href="https://github.com/rems-project/sail">https://github.com/rems-project/sail</a>

##### CHANGES:

This is another bugfix release for Sail 0.20. It includes fixes for
the following issues and more:

* https://github.com/rems-project/sail/issues/1683
* https://github.com/rems-project/sail/issues/1664
* https://github.com/rems-project/sail/issues/1654

HOL4 support has been improved to support changes in Sail RISC-V.

The minimum OCaml version has been increased to OCaml 4.14, although
we highly recommend upgrading to at least OCaml 5.2. The minumum
version might be increased to require OCaml 5 in some future major
release.
