### PR TITLE
[new release] ezcurl (2 packages) (0.4)

### DIFF
--- a/packages/ezcurl-lwt/ezcurl-lwt.0.4/opam
+++ b/packages/ezcurl-lwt/ezcurl-lwt.0.4/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+synopsis: "Friendly wrapper around OCurl, Lwt version"
+maintainer: ["simon.cruanes.2007@m4x.org"]
+authors: ["Simon Cruanes"]
+license: "MIT"
+tags: ["curl" "web" "http" "client" "lwt"]
+homepage: "https://github.com/c-cube/ezcurl"
+doc: "https://c-cube.github.io/ezcurl/"
+bug-reports: "https://github.com/c-cube/ezcurl/issues"
+depends: [
+  "dune" {>= "3.0"}
+  "ezcurl" {= version}
+  "lwt"
+  "curl_lwt"
+  "mdx" {with-test}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/c-cube/ezcurl.git"
+url {
+  src:
+    "https://github.com/c-cube/ezcurl/releases/download/v0.4/ezcurl-0.4.tbz"
+  checksum: [
+    "sha256=25575d5f0e9d5712ae115f002b2d783a13780653b883846ba8141022d809afa3"
+    "sha512=1dee9be6d53d15243977bdb1d2fdc5933735617b0d67ed2a41857e83815c02f08f94eadab6a1fc0a3a693bab7c0ed89ec1fbd186b6b810b0463d029a100e7dec"
+  ]
+}
+x-commit-hash: "90c5b56ff462e660311e283bf37fc94e045929d9"

--- a/packages/ezcurl/ezcurl.0.4/opam
+++ b/packages/ezcurl/ezcurl.0.4/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+synopsis: "Friendly wrapper around OCurl"
+maintainer: ["simon.cruanes.2007@m4x.org"]
+authors: ["Simon Cruanes"]
+license: "MIT"
+tags: ["curl" "web" "http" "client"]
+homepage: "https://github.com/c-cube/ezcurl"
+doc: "https://c-cube.github.io/ezcurl/"
+bug-reports: "https://github.com/c-cube/ezcurl/issues"
+depends: [
+  "dune" {>= "3.0"}
+  "curl" {>= "0.8"}
+  "odoc" {with-doc}
+  "tiny_httpd" {>= "0.19" & with-test}
+  "ocaml" {>= "4.11"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/c-cube/ezcurl.git"
+url {
+  src:
+    "https://github.com/c-cube/ezcurl/releases/download/v0.4/ezcurl-0.4.tbz"
+  checksum: [
+    "sha256=25575d5f0e9d5712ae115f002b2d783a13780653b883846ba8141022d809afa3"
+    "sha512=1dee9be6d53d15243977bdb1d2fdc5933735617b0d67ed2a41857e83815c02f08f94eadab6a1fc0a3a693bab7c0ed89ec1fbd186b6b810b0463d029a100e7dec"
+  ]
+}
+x-commit-hash: "90c5b56ff462e660311e283bf37fc94e045929d9"


### PR DESCRIPTION
Friendly wrapper around OCurl

- Project page: <a href="https://github.com/c-cube/ezcurl">https://github.com/c-cube/ezcurl</a>
- Documentation: <a href="https://c-cube.github.io/ezcurl/">https://c-cube.github.io/ezcurl/</a>

##### CHANGES:

- explicit dep on `curl_lwt`
- add `QUERY` method
- move to ocaml >= 4.11 bc curl bindings did
- move to `curl` instead of `ocurl` as underlying library
- set options after resetting curl handle (c-cube/ezcurl#29)
- add custom method variant for extended HTTP methods
- reset easy handle before use
- fix: `PATCH` does upload
