### PR TITLE
data-encoding: disable tests

### DIFF
--- a/packages/data-encoding/data-encoding.0.5.1/opam
+++ b/packages/data-encoding/data-encoding.0.5.1/opam
@@ -23,7 +23,7 @@ depends: [
 ]
 build: [
   ["dune" "build" "-p" name "-j" jobs]
-  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+#  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
 ]
 synopsis: "Library of JSON and binary encoding combinators"
 url {

--- a/packages/data-encoding/data-encoding.0.5.2/opam
+++ b/packages/data-encoding/data-encoding.0.5.2/opam
@@ -23,7 +23,7 @@ depends: [
 ]
 build: [
   ["dune" "build" "-p" name "-j" jobs]
-  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+#  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
 ]
 synopsis: "Library of JSON and binary encoding combinators"
 url {

--- a/packages/data-encoding/data-encoding.0.5.3/opam
+++ b/packages/data-encoding/data-encoding.0.5.3/opam
@@ -23,7 +23,7 @@ depends: [
 ]
 build: [
   ["dune" "build" "-p" name "-j" jobs]
-  ["dune" "runtest" "-p" name "-j" jobs] {with-test & arch != "arm32" & arch != "x86_32"}
+#  ["dune" "runtest" "-p" name "-j" jobs] {with-test & arch != "arm32" & arch != "x86_32"}
 ]
 synopsis: "Library of JSON and binary encoding combinators"
 url {

--- a/packages/data-encoding/data-encoding.0.5/opam
+++ b/packages/data-encoding/data-encoding.0.5/opam
@@ -23,7 +23,7 @@ depends: [
 ]
 build: [
   ["dune" "build" "-p" name "-j" jobs]
-  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+#  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
 ]
 synopsis: "Library of JSON and binary encoding combinators"
 url {

--- a/packages/data-encoding/data-encoding.0.6/opam
+++ b/packages/data-encoding/data-encoding.0.6/opam
@@ -24,7 +24,7 @@ depends: [
 ]
 build: [
   ["dune" "build" "-p" name "-j" jobs]
-  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+#  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
 ]
 synopsis: "Library of JSON and binary encoding combinators"
 url {

--- a/packages/data-encoding/data-encoding.0.7.1/opam
+++ b/packages/data-encoding/data-encoding.0.7.1/opam
@@ -26,7 +26,7 @@ depends: [
 ]
 build: [
   ["dune" "build" "-p" name "-j" jobs]
-  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+#  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
 ]
 synopsis: "Library of JSON and binary encoding combinators"
 url {

--- a/packages/data-encoding/data-encoding.0.7/opam
+++ b/packages/data-encoding/data-encoding.0.7/opam
@@ -26,7 +26,7 @@ depends: [
 ]
 build: [
   ["dune" "build" "-p" name "-j" jobs]
-  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+#  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
 ]
 synopsis: "Library of JSON and binary encoding combinators"
 url {

--- a/packages/data-encoding/data-encoding.1.0.0/opam
+++ b/packages/data-encoding/data-encoding.1.0.0/opam
@@ -28,7 +28,7 @@ depends: [
 ]
 build: [
   ["dune" "build" "-p" name "-j" jobs]
-  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+#  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
 ]
 synopsis: "Library of JSON and binary encoding combinators"
 url {

--- a/packages/data-encoding/data-encoding.1.0.1/opam
+++ b/packages/data-encoding/data-encoding.1.0.1/opam
@@ -28,7 +28,7 @@ depends: [
 ]
 build: [
   ["dune" "build" "-p" name "-j" jobs]
-  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+#  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
 ]
 synopsis: "Library of JSON and binary encoding combinators"
 url {


### PR DESCRIPTION
Contains a brittle test on json generation that fails all the time, unnecessarily polluting the CI output

```
 File "test/pbt/dune", line 3, characters 43-58:
 3 |    test_json_stream_sizes test_classifiers test_sub_string
                                                ^^^^^^^^^^^^^^^
 (cd _build/default/test/pbt && ./test_sub_string.exe)
 Fatal error: exception File "test/pbt/test_sub_string.ml", line 35, characters 2-8: Assertion failed
 (cd _build/default/test/pbt && ./test_json_stream_sizes.exe)
 blitting with a lot of string boundaries: PASS

 string-seq with a lot of string boundaries: PASS

 File "test/pbt/dune", line 4, characters 3-27:
 4 |    json_roundtrip_in_binary)
        ^^^^^^^^^^^^^^^^^^^^^^^^
 (cd _build/default/test/pbt && ./json_roundtrip_in_binary.exe)
 json_json_roundtrip: FAIL

 When given the input:

     <float>

 the test threw an exception:

     File "test/pbt/json_roundtrip_in_binary.ml", line 92, characters 2-8: Assertion failed
     Raised at Dune__exe__Json_roundtrip_in_binary.test_json in file "test/pbt/json_roundtrip_in_binary.ml", line 92, characters 2-17
     Called from Crowbar.gen_apply.go.(fun) in file "src/crowbar.ml", line 352, characters 16-19

 json_binary(bson)_roundtrip: FAIL
```
or
```
File "test/pbt/dune", lines 83-87, characters 0-111:
 83 | (rule
 84 |  (alias runtest)
 85 |  (package data-encoding)
 86 |  (action
 87 |   (run node %{dep:./json_roundtrip_in_binary.bc.js})))
 (cd _build/default/test/pbt && /usr/bin/node json_roundtrip_in_binary.bc.js)
 json_json_roundtrip: FAIL

 When given the input:

     <float>

 the test threw an exception:

     File "test/pbt/json_roundtrip_in_binary.ml", line 92, characters 2-8: Assertion failed

 json_binary(bson)_roundtrip: FAIL

 When given the input:

     <float>

 the test threw an exception:

     File "test/pbt/json_roundtrip_in_binary.ml", line 116, characters 28-34: Assertion failed
```
depending on the version.

See e.g. https://opam.ci.ocaml.org/github/ocaml/opam-repository/commit/72f51de94a07b75e147fd7a49002aebddd7c8ca8

Last seen https://github.com/ocaml/opam-repository/pull/30088