### PR TITLE
[new release] reason and rtop (3.18.0)

### DIFF
--- a/packages/reason/reason.3.18.0/opam
+++ b/packages/reason/reason.3.18.0/opam
@@ -22,7 +22,7 @@ depends: [
   "merlin-extend" {>= "0.6.2"}
   "fix"
   "cppo"
-  "ppxlib" {>= "0.36"}
+  "ppxlib" {>= "0.38"}
   "odoc" {with-doc}
 ]
 build: [
@@ -41,9 +41,6 @@ build: [
 ]
 dev-repo: "git+https://github.com/reasonml/reason.git"
 x-maintenance-intent: ["(latest)"]
-pin-depends: [
-  [ "ppxlib.dev" "https://github.com/NathanReb/ppxlib/archive/547c6cfd69671e147767e0937d069c5b9eb2aa4a.tar.gz" ]
-]
 url {
   src:
     "https://github.com/reasonml/reason/releases/download/3.18.0/reason-3.18.0.tbz"

--- a/packages/reason/reason.3.18.0/opam
+++ b/packages/reason/reason.3.18.0/opam
@@ -1,0 +1,56 @@
+opam-version: "2.0"
+synopsis: "Reason: Syntax & Toolchain for OCaml"
+description: """
+Reason gives OCaml a new syntax that is remniscient of languages like
+JavaScript. It's also the umbrella project for a set of tools for the OCaml &
+JavaScript ecosystem."""
+maintainer: [
+  "Jordan Walke <jordojw@gmail.com>"
+  "Antonio Nuno Monteiro <anmonteiro@gmail.com>"
+]
+authors: ["Jordan Walke <jordojw@gmail.com>"]
+license: "MIT"
+homepage: "https://reasonml.github.io/"
+bug-reports: "https://github.com/reasonml/reason/issues"
+depends: [
+  "dune" {>= "3.18"}
+  "ocaml" {>= "4.08" & < "5.6"}
+  "ocamlfind" {build}
+  "cmdliner" {>= "1.1.0"}
+  "dune-build-info" {>= "2.9.3"}
+  "menhir" {>= "20180523"}
+  "merlin-extend" {>= "0.6.2"}
+  "fix"
+  "cppo"
+  "ppxlib" {>= "0.36"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/reasonml/reason.git"
+x-maintenance-intent: ["(latest)"]
+pin-depends: [
+  [ "ppxlib.dev" "https://github.com/NathanReb/ppxlib/archive/547c6cfd69671e147767e0937d069c5b9eb2aa4a.tar.gz" ]
+]
+url {
+  src:
+    "https://github.com/reasonml/reason/releases/download/3.18.0/reason-3.18.0.tbz"
+  checksum: [
+    "sha256=4fba6a16f54551b78e1d90eb2c167f6ee964caf5383bc2d2f93ceccc7e64dc44"
+    "sha512=b43e9245c79c3aaef494ba55027187f86884fbcff87aca77743b5c3d81ef7d5156f34c650c3cfb40719cf7ca87750c591fe338b21f82d4feed7092e47cb6880d"
+  ]
+}
+x-commit-hash: "470c25d19494928b8926d35ddcbc9ba46663e888"
+

--- a/packages/rtop/rtop.3.18.0/opam
+++ b/packages/rtop/rtop.3.18.0/opam
@@ -1,0 +1,45 @@
+opam-version: "2.0"
+synopsis: "Reason toplevel"
+description:
+  "rtop is the toplevel (or REPL) for Reason, based on utop (https://github.com/ocaml-community/utop)."
+maintainer: [
+  "Jordan Walke <jordojw@gmail.com>"
+  "Antonio Nuno Monteiro <anmonteiro@gmail.com>"
+]
+authors: ["Jordan Walke <jordojw@gmail.com>"]
+license: "MIT"
+homepage: "https://reasonml.github.io/"
+bug-reports: "https://github.com/reasonml/reason/issues"
+depends: [
+  "dune" {>= "3.18"}
+  "ocaml" {>= "4.08" & < "5.6"}
+  "reason" {= version}
+  "utop" {>= "2.0"}
+  "cppo"
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/reasonml/reason.git"
+x-maintenance-intent: ["(latest)"]
+url {
+  src:
+    "https://github.com/reasonml/reason/releases/download/3.18.0/reason-3.18.0.tbz"
+  checksum: [
+    "sha256=4fba6a16f54551b78e1d90eb2c167f6ee964caf5383bc2d2f93ceccc7e64dc44"
+    "sha512=b43e9245c79c3aaef494ba55027187f86884fbcff87aca77743b5c3d81ef7d5156f34c650c3cfb40719cf7ca87750c591fe338b21f82d4feed7092e47cb6880d"
+  ]
+}
+x-commit-hash: "470c25d19494928b8926d35ddcbc9ba46663e888"


### PR DESCRIPTION
Reason: Syntax & Toolchain for OCaml

- Project page: <a href="https://reasonml.github.io/">https://reasonml.github.io/</a>

##### CHANGES:

- build: remove unused AST migrations (@anmonteiro,
  [reasonml/reason#2911](https://github.com/reasonml/reason/pull/2911))
- Support OCaml 5.5 (@anmonteiro,
  [reasonml/reason#2912](https://github.com/reasonml/reason/pull/2912))
- fix(printer): add parens around value constraint aliases (@davesnx,
  [reasonml/reason#2913](https://github.com/reasonml/reason/pull/2913))
