### PR TITLE
OCaml manual 5.4.0 has bad checksum, +Errata, let's disable it

### DIFF
--- a/packages/ocaml-manual/ocaml-manual.5.4.0/opam
+++ b/packages/ocaml-manual/ocaml-manual.5.4.0/opam
@@ -20,3 +20,4 @@ url {
   src: "http://caml.inria.fr/distrib/ocaml-5.4/ocaml-5.4-refman-html.tar.gz"
   checksum: "sha256=114839f9fffd28f46a38af5c81913c5c4f11d606cda292fcd1d91d304bcda25b"
 }
+available: false


### PR DESCRIPTION
All useful information should be accessable in 5.4.0-1

CC @mseri, I used my bravery to try making your life a little bit easier )

```
  - [ocaml-manual.5.4.0]
    http://caml.inria.fr/distrib/ocaml-5.4/ocaml-5.4-refman-html.tar.gz
        (Bad checksum, expected
sha256=114839f9fffd28f46a38af5c81913c5c4f11d606cda292fcd1d91d304bcda25b)
```

```
✗ wget
http://caml.inria.fr/distrib/ocaml-5.4/ocaml-5.4-refman-html.tar.gz
-qO - | sha256sum
2ee64c79207ff072f25915d67ed697262ba961383a66200b553c71db462e4aff
-
```