### PR TITLE
[new release] merlin (4 packages) (5.8-505) and lsp (3 packages) (1.27.0)

### DIFF
--- a/packages/dot-merlin-reader/dot-merlin-reader.5.8-505/opam
+++ b/packages/dot-merlin-reader/dot-merlin-reader.5.8-505/opam
@@ -1,0 +1,31 @@
+opam-version: "2.0"
+maintainer:   "defree@gmail.com"
+authors:      "The Merlin team"
+synopsis:     "Reads config files for merlin"
+homepage:     "https://github.com/ocaml/merlin"
+bug-reports:  "https://github.com/ocaml/merlin/issues"
+dev-repo:     "git+https://github.com/ocaml/merlin.git"
+license:      "MIT"
+x-maintenance-intent: ["(latest)"]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "ocaml" {>= "5.2" }
+  "dune" {>= "3.0.0"}
+  "merlin-lib" {= version}
+  "ocamlfind" {>= "1.6.0"}
+]
+description:
+  "Helper process: reads .merlin files and outputs the normalized content to
+  stdout."
+url {
+  src:
+    "https://github.com/ocaml/merlin/releases/download/v5.8-505/merlin-5.8-505.tbz"
+  checksum: [
+    "sha256=5642cde8486a84aad98fa5c590b70e8dcc6074d7fbdb3b9b8c46b2c5b42f653b"
+    "sha512=1d7a7751157e393d3ae248ef5ae24a6b4e81430666c61cc51a3d0ec35804523317036f3d7a3c7f18a7554337f4e5f5989fb677865b261ece3fd2b317903570ba"
+  ]
+}
+x-commit-hash: "6b3613715f92ecb466fe0377473201e382368edd"

--- a/packages/jsonrpc/jsonrpc.1.27.0/opam
+++ b/packages/jsonrpc/jsonrpc.1.27.0/opam
@@ -1,0 +1,50 @@
+opam-version: "2.0"
+synopsis: "Jsonrpc protocol implementation"
+description: "See https://www.jsonrpc.org/specification"
+maintainer: ["Rudi Grinberg <me@rgrinberg.com>"]
+authors: [
+  "Andrey Popp <8mayday@gmail.com>"
+  "Rusty Key <iam@stfoo.ru>"
+  "Louis Roché <louis@louisroche.net>"
+  "Oleksiy Golovko <alexei.golovko@gmail.com>"
+  "Rudi Grinberg <me@rgrinberg.com>"
+  "Sacha Ayoun <sachaayoun@gmail.com>"
+  "cannorin <cannorin@gmail.com>"
+  "Ulugbek Abdullaev <ulugbekna@gmail.com>"
+  "Thibaut Mattio <thibaut.mattio@gmail.com>"
+  "Max Lantas <mnxndev@outlook.com>"
+]
+license: "ISC"
+homepage: "https://github.com/ocaml/ocaml-lsp"
+bug-reports: "https://github.com/ocaml/ocaml-lsp/issues"
+depends: [
+  "dune" {>= "3.0"}
+  "yojson" {>= "2.0"}
+  "ocaml" {>= "4.08"}
+  "odoc" {with-doc}
+]
+dev-repo: "git+https://github.com/ocaml/ocaml-lsp.git"
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+
+x-maintenance-intent: [ "(latest)" ]
+url {
+  src:
+    "https://github.com/ocaml/ocaml-lsp/releases/download/1.27.0/lsp-1.27.0.tbz"
+  checksum: [
+    "sha256=043acd6923f8a5cbaad9154523570ab13973baeef698e2b5553213dd63792715"
+    "sha512=1444f221cbdc95edf7326fb2fda2921c41adf345b52a4dba8afdd51dc73875e558fd1b16f10225b45b60f2e0928f9088721af6109bb04e0adcd7db2d41747bfb"
+  ]
+}
+x-commit-hash: "b90cbe7cdfb096eaf32df92b8db6681c428a5643"

--- a/packages/lsp/lsp.1.27.0/opam
+++ b/packages/lsp/lsp.1.27.0/opam
@@ -1,0 +1,60 @@
+opam-version: "2.0"
+synopsis: "LSP protocol implementation in OCaml"
+description: """
+
+Implementation of the LSP protocol in OCaml. It is designed to be as portable as
+possible and does not make any assumptions about IO.
+"""
+maintainer: ["Rudi Grinberg <me@rgrinberg.com>"]
+authors: [
+  "Andrey Popp <8mayday@gmail.com>"
+  "Rusty Key <iam@stfoo.ru>"
+  "Louis Roché <louis@louisroche.net>"
+  "Oleksiy Golovko <alexei.golovko@gmail.com>"
+  "Rudi Grinberg <me@rgrinberg.com>"
+  "Sacha Ayoun <sachaayoun@gmail.com>"
+  "cannorin <cannorin@gmail.com>"
+  "Ulugbek Abdullaev <ulugbekna@gmail.com>"
+  "Thibaut Mattio <thibaut.mattio@gmail.com>"
+  "Max Lantas <mnxndev@outlook.com>"
+]
+license: "ISC"
+homepage: "https://github.com/ocaml/ocaml-lsp"
+bug-reports: "https://github.com/ocaml/ocaml-lsp/issues"
+depends: [
+  "dune" {>= "3.0"}
+  "jsonrpc" {= version}
+  "yojson"
+  "ppx_yojson_conv_lib" {>= "v0.14"}
+  "cinaps" {with-test}
+  "ppx_expect" {>= "v0.17.0" & with-test}
+  "uutf" {>= "1.0.2"}
+  "odoc" {with-doc}
+  "ocaml" {>= "4.14"}
+  "ppx_yojson_conv" {with-dev-setup}
+]
+dev-repo: "git+https://github.com/ocaml/ocaml-lsp.git"
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+
+x-maintenance-intent: [ "(latest)" ]
+url {
+  src:
+    "https://github.com/ocaml/ocaml-lsp/releases/download/1.27.0/lsp-1.27.0.tbz"
+  checksum: [
+    "sha256=043acd6923f8a5cbaad9154523570ab13973baeef698e2b5553213dd63792715"
+    "sha512=1444f221cbdc95edf7326fb2fda2921c41adf345b52a4dba8afdd51dc73875e558fd1b16f10225b45b60f2e0928f9088721af6109bb04e0adcd7db2d41747bfb"
+  ]
+}
+x-commit-hash: "b90cbe7cdfb096eaf32df92b8db6681c428a5643"

--- a/packages/merlin-lib/merlin-lib.5.8-505/opam
+++ b/packages/merlin-lib/merlin-lib.5.8-505/opam
@@ -1,0 +1,36 @@
+opam-version: "2.0"
+maintainer:   "defree@gmail.com"
+authors:      "The Merlin team"
+homepage:     "https://github.com/ocaml/merlin"
+bug-reports:  "https://github.com/ocaml/merlin/issues"
+dev-repo:     "git+https://github.com/ocaml/merlin.git"
+license:      "MIT"
+x-maintenance-intent: ["(latest)"]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "ocaml" {>="5.5" & <"5.6"}
+  "dune" {>= "3.0.0"}
+  "csexp" {>= "1.5.1"}
+  "alcotest" {with-test & >= "1.3.0" }
+  "menhir"    {dev & >= "20230608"}
+  "menhirLib" {dev & >= "20230608"}
+  "menhirSdk" {dev & >= "20230608"}
+]
+synopsis:
+  "Merlin's libraries"
+description:
+  "These libraries provides access to low-level compiler interfaces and the
+  standard higher-level merlin protocol. The library is provided as-is, is not
+  thoroughly documented, and its public API might break with any new release."
+url {
+  src:
+    "https://github.com/ocaml/merlin/releases/download/v5.8-505/merlin-5.8-505.tbz"
+  checksum: [
+    "sha256=5642cde8486a84aad98fa5c590b70e8dcc6074d7fbdb3b9b8c46b2c5b42f653b"
+    "sha512=1d7a7751157e393d3ae248ef5ae24a6b4e81430666c61cc51a3d0ec35804523317036f3d7a3c7f18a7554337f4e5f5989fb677865b261ece3fd2b317903570ba"
+  ]
+}
+x-commit-hash: "6b3613715f92ecb466fe0377473201e382368edd"

--- a/packages/merlin/merlin.5.8-505/opam
+++ b/packages/merlin/merlin.5.8-505/opam
@@ -1,0 +1,42 @@
+opam-version: "2.0"
+maintainer:   "defree@gmail.com"
+authors:      "The Merlin team"
+homepage:     "https://github.com/ocaml/merlin"
+bug-reports:  "https://github.com/ocaml/merlin/issues"
+dev-repo:     "git+https://github.com/ocaml/merlin.git"
+license:      "MIT"
+x-maintenance-intent: ["(latest)"]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+depends: [
+  "dune" {>= "3.0.0"}
+  "merlin-lib" {= version}
+  "dot-merlin-reader" {= version}
+  "ocaml-index" {= version & post}
+  "yojson" {>= "2.0.0"}
+  "conf-jq" {with-test}
+  "ppxlib" {with-test}
+  "ppx_string" {with-test}
+#  "reason" {with-test} Removed temporarily until reason is compatible with 5.5
+]
+conflicts: [
+  "seq" {!= "base"}
+]
+synopsis:
+  "Editor service that provides advanced IDE features for OCaml"
+description:
+  "Merlin is an assistant for editing OCaml code. It aims to provide the features
+  available in modern IDEs: error reporting, auto completion, source browsing and
+  much more. It can be used as a standalone server or through an LSP server."
+url {
+  src:
+    "https://github.com/ocaml/merlin/releases/download/v5.8-505/merlin-5.8-505.tbz"
+  checksum: [
+    "sha256=5642cde8486a84aad98fa5c590b70e8dcc6074d7fbdb3b9b8c46b2c5b42f653b"
+    "sha512=1d7a7751157e393d3ae248ef5ae24a6b4e81430666c61cc51a3d0ec35804523317036f3d7a3c7f18a7554337f4e5f5989fb677865b261ece3fd2b317903570ba"
+  ]
+}
+x-commit-hash: "6b3613715f92ecb466fe0377473201e382368edd"

--- a/packages/ocaml-index/ocaml-index.5.8-505/opam
+++ b/packages/ocaml-index/ocaml-index.5.8-505/opam
@@ -1,0 +1,42 @@
+opam-version: "2.0"
+synopsis: "A tool that indexes value usages from cmt files"
+description:
+  "ocaml-index should integrate with the build system to index codebase and allow tools such as Merlin to perform project-wide occurrences queries."
+maintainer: ["ulysse@tarides.com"]
+authors: ["ulysse@tarides.com"]
+license: "MIT"
+homepage: "https://github.com/ocaml/merlin/ocaml-index"
+bug-reports: "https://github.com/ocaml/merlin/issues"
+x-maintenance-intent: ["(latest)"]
+depends: [
+  "dune" {>= "3.0.0"}
+  "ocaml" {>= "5.4"}
+  "merlin-lib" {= version}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+dev-repo: "git+https://github.com/ocaml/merlin.git"
+url {
+  src:
+    "https://github.com/ocaml/merlin/releases/download/v5.8-505/merlin-5.8-505.tbz"
+  checksum: [
+    "sha256=5642cde8486a84aad98fa5c590b70e8dcc6074d7fbdb3b9b8c46b2c5b42f653b"
+    "sha512=1d7a7751157e393d3ae248ef5ae24a6b4e81430666c61cc51a3d0ec35804523317036f3d7a3c7f18a7554337f4e5f5989fb677865b261ece3fd2b317903570ba"
+  ]
+}
+x-commit-hash: "6b3613715f92ecb466fe0377473201e382368edd"

--- a/packages/ocaml-lsp-server/ocaml-lsp-server.1.27.0/opam
+++ b/packages/ocaml-lsp-server/ocaml-lsp-server.1.27.0/opam
@@ -62,12 +62,6 @@ build: [
     "@doc" {with-doc}
   ]
 ]
-
-pin-depends: [
-  [ "merlin-lib.5.7-504" "git+https://github.com/ocaml/merlin.git#main" ]
-  [ "ocaml-index.5.7-504" "git+https://github.com/ocaml/merlin.git#main" ]
-]
-
 x-maintenance-intent: [ "(latest)" ]
 url {
   src:

--- a/packages/ocaml-lsp-server/ocaml-lsp-server.1.27.0/opam
+++ b/packages/ocaml-lsp-server/ocaml-lsp-server.1.27.0/opam
@@ -1,0 +1,80 @@
+opam-version: "2.0"
+synopsis: "LSP Server for OCaml"
+description: "An LSP server for OCaml."
+maintainer: ["Rudi Grinberg <me@rgrinberg.com>"]
+authors: [
+  "Andrey Popp <8mayday@gmail.com>"
+  "Rusty Key <iam@stfoo.ru>"
+  "Louis Roché <louis@louisroche.net>"
+  "Oleksiy Golovko <alexei.golovko@gmail.com>"
+  "Rudi Grinberg <me@rgrinberg.com>"
+  "Sacha Ayoun <sachaayoun@gmail.com>"
+  "cannorin <cannorin@gmail.com>"
+  "Ulugbek Abdullaev <ulugbekna@gmail.com>"
+  "Thibaut Mattio <thibaut.mattio@gmail.com>"
+  "Max Lantas <mnxndev@outlook.com>"
+]
+license: "ISC"
+homepage: "https://github.com/ocaml/ocaml-lsp"
+bug-reports: "https://github.com/ocaml/ocaml-lsp/issues"
+depends: [
+  "dune" {>= "3.0"}
+  "yojson"
+  "base" {>= "v0.16.0"}
+  "lsp" {= version}
+  "jsonrpc" {= version}
+  "re" {>= "1.5.0"}
+  "ppx_yojson_conv_lib" {>= "v0.14"}
+  "dune-rpc" {>= "3.22.0"}
+  "chrome-trace" {>= "3.3.0"}
+  "dyn"
+  "stdune" {>= "3.22.0"}
+  "fiber" {>= "3.1.1" & < "4.0.0"}
+  "ocaml" {>= "5.5" & < "5.6"}
+  "xdg"
+  "ordering"
+  "dune-build-info" {>= "3.22.0"}
+  "spawn"
+  "astring"
+  "camlp-streams"
+  "ppx_expect" {>= "v0.17.0" & with-test}
+  "ocamlformat" {with-test & = "0.28.1"}
+  "ocamlc-loc" {>= "3.7.0"}
+  "pp" {>= "1.1.2"}
+  "csexp" {>= "1.5"}
+  "ocamlformat-rpc-lib" {>= "0.21.0"}
+  "odoc" {with-doc}
+  "merlin-lib" {>= "5.8" & < "5.9"}
+  "ocaml-index" {post}
+  "ppx_yojson_conv" {with-dev-setup}
+]
+dev-repo: "git+https://github.com/ocaml/ocaml-lsp.git"
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+
+pin-depends: [
+  [ "merlin-lib.5.7-504" "git+https://github.com/ocaml/merlin.git#main" ]
+  [ "ocaml-index.5.7-504" "git+https://github.com/ocaml/merlin.git#main" ]
+]
+
+x-maintenance-intent: [ "(latest)" ]
+url {
+  src:
+    "https://github.com/ocaml/ocaml-lsp/releases/download/1.27.0/lsp-1.27.0.tbz"
+  checksum: [
+    "sha256=043acd6923f8a5cbaad9154523570ab13973baeef698e2b5553213dd63792715"
+    "sha512=1444f221cbdc95edf7326fb2fda2921c41adf345b52a4dba8afdd51dc73875e558fd1b16f10225b45b60f2e0928f9088721af6109bb04e0adcd7db2d41747bfb"
+  ]
+}
+x-commit-hash: "b90cbe7cdfb096eaf32df92b8db6681c428a5643"


### PR DESCRIPTION
Merlin and OCaml-LSP release with support for 5.5:

# Merlin CHANGES:

Tue Jun 23 12:15:42 CEST 2026

  + merlin library
    - Support for OCaml 5.5 (ocaml/merlin#2077, fixes ocaml/merlin#2024)
    - Fix signature-help with type aliases (ocaml/merlin#2067, fixes ocaml/merlin#1927)
    - Fix locate on punned let bindings, to use the common identifier as the
      expression (instead of the pattern) (ocaml/merlin#2066)
  + test suite
    - Remove the FIXME line for ocaml/merlin#1404 as the issue was already fixed and add two tests (ocaml/merlin#2073).


# LSP  CHANGES:
    
## Features
    
- Upgrade to OCaml 5.5 (ocaml/ocaml-lsp#1609)
    
## Fixes
    
- Fix compatibility with upcoming Dune versions by avoiding the `Stdune.Pid`
      module. (ocaml/ocaml-lsp#1608)