### PR TITLE
Fix the checksum of gen_ocaml_config.ml

### DIFF
--- a/packages/ocaml/ocaml.5.5.1/opam
+++ b/packages/ocaml/ocaml.5.5.1/opam
@@ -66,7 +66,7 @@ extra-source "gen_ocaml_config.ml" {
   src:
     "https://raw.githubusercontent.com/ocaml/ocaml/5799ec070df18cec96e5d828bc8e10b86cb0ed2c/tools/opam/gen_ocaml_config.ml"
   checksum: [
-    "sha512=e679b89e87cda2f012fd13685807b7f1e1037fc0fc8f5.5.1aebec5a299d5634960f532a3dbf2fe519d9a5e19759f8dd99170999c252c35dd5762d4d0509f4179a"
+    "sha512=e679b89e87cda2f012fd13685807b7f1e1037fc0fc8f525aebec5a299d5634960f532a3dbf2fe519d9a5e19759f8dd99170999c252c35dd5762d4d0509f4179a"
     "sha256=664da1ec2b19a7cfb55338ee10d9c8634cdca255d6cc46df66cd4d3e7e759969"
   ]
 }


### PR DESCRIPTION
//cc @Octachron the existing checksum includes `.` characters, which are not valid hex values. I copied the value from the 5.5.0/5.6.0 opam files.