### PR TITLE
[new release] x509 (1.1.0)

### DIFF
--- a/packages/x509/x509.1.1.0/opam
+++ b/packages/x509/x509.1.1.0/opam
@@ -1,0 +1,60 @@
+opam-version: "2.0"
+maintainer: [
+  "Hannes Mehnert <hannes@mehnert.org>"
+]
+authors: [
+  "Hannes Mehnert <hannes@mehnert.org>"
+  "David Kaloper <dk505@cam.ac.uk>"
+]
+license: "BSD-2-Clause"
+tags: "org:mirage"
+homepage: "https://github.com/mirleft/ocaml-x509"
+doc: "https://mirleft.github.io/ocaml-x509/doc"
+bug-reports: "https://github.com/mirleft/ocaml-x509/issues"
+depends: [
+  "ocaml" {>= "4.13.0"}
+  "dune" {>= "2.0"}
+  "asn1-combinators" {>= "0.3.1"}
+  "ptime"
+  "base64" {>= "3.3.0"}
+  "mirage-crypto" {>= "1.0.0"}
+  "mirage-crypto-pk"
+  "mirage-crypto-ec" {>= "0.10.7"}
+  "mirage-crypto-rng"
+  "mirage-crypto-rng" {with-test & >= "1.2.0"}
+  "fmt" {>= "0.8.7"}
+  "alcotest" {with-test}
+  "gmap" {>= "0.3.0"}
+  "domain-name" {>= "0.3.0"}
+  "logs"
+  "kdf" {>= "1.0.0"}
+  "ohex" {>= "0.2.0"}
+  "ipaddr" {>= "5.2.0"}
+]
+conflicts: [ "result" {< "1.5"} ]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/mirleft/ocaml-x509.git"
+synopsis: "Public Key Infrastructure (RFC 5280, PKCS) purely in OCaml"
+description: """
+X.509 is a public key infrastructure used mostly on the Internet.  It consists
+of certificates which include public keys and identifiers, signed by an
+authority. Authorities must be exchanged over a second channel to establish the
+trust relationship. This library implements most parts of RFC5280 and RFC6125.
+The Public Key Cryptography Standards (PKCS) defines encoding and decoding
+(in ASN.1 DER and PEM format), which is also implemented by this library -
+namely PKCS 1, PKCS 5, PKCS 7, PKCS 8, PKCS 9, PKCS 10, and PKCS 12.
+"""
+x-maintenance-intent: [ "(latest)" ]
+url {
+  src:
+    "https://github.com/mirleft/ocaml-x509/releases/download/v1.1.0/x509-1.1.0.tbz"
+  checksum: [
+    "sha256=05843be22c10f4ca0ecf24ad39ab002e89560f53cc22128ac3d14745e16bfa7d"
+    "sha512=fa87705e9486dc28b11d36407be0d0ef50a9d2bf99bcf5a5af0b26384673db85fc03d59e56b52139e6264679b0770f45707b8e794af0ecdb87c6066d66b678b8"
+  ]
+}
+x-commit-hash: "c5463e12de2eaeff147580e0a5c0828eae4e5f00"


### PR DESCRIPTION
Public Key Infrastructure (RFC 5280, PKCS) purely in OCaml

- Project page: <a href="https://github.com/mirleft/ocaml-x509">https://github.com/mirleft/ocaml-x509</a>
- Documentation: <a href="https://mirleft.github.io/ocaml-x509/doc">https://mirleft.github.io/ocaml-x509/doc</a>

##### CHANGES:

* Add Signing_request.sign_certificate which takes the issuer as certificate and
  does some validity checks (mirleft/ocaml-x509#182 @hannesm)
* Document the need for checking KeyUsage/ExtendedKeyUsage extensions in
  Validation functions (mirleft/ocaml-x509#182 @hannesm)
* If a CA certificate has a extendedKeyUsage, it must contain Any or Server_auth
  (mirleft/ocaml-x509#182 @hannesm)
* Restrict server certificates to not have a Name_constraints extension
  (mirleft/ocaml-x509#182 @hannesm)
* Add validation of name constraints when validating the chain of trust
  (mirleft/ocaml-x509#182 @hannesm)

The last 3 fixes were tested with bettertls from Netflix.
