### PR TITLE
Add upper bound on dune 3.24 for camomile 1.0.2 and 2.0.0

### DIFF
--- a/packages/camomile/camomile.1.0.2/opam
+++ b/packages/camomile/camomile.1.0.2/opam
@@ -12,7 +12,7 @@ homepage: "https://github.com/yoriyuki/Camomile"
 doc: "https://yoriyuki.github.io/Camomile/"
 bug-reports: "https://github.com/yoriyuki/Camomile/issues"
 depends: [
-  "dune" {>= "1.11"}
+  "dune" {>= "1.11" & < "3.24.0"}
   "ocaml" {>= "4.02.3" & < "5.0"}
 ]
 dev-repo: "git+https://github.com/yoriyuki/Camomile.git"

--- a/packages/camomile/camomile.2.0.0/opam
+++ b/packages/camomile/camomile.2.0.0/opam
@@ -13,7 +13,7 @@ homepage: "https://github.com/savonet/Camomile"
 doc: "https://savonet.github.io/Camomile/"
 bug-reports: "https://github.com/savonet/Camomile/issues"
 depends: [
-  "dune" {>= "3.4"}
+  "dune" {>= "3.4" & < "3.24.0"}
   "dune-site"
   "camlp-streams"
   "stdlib-random" {with-test}


### PR DESCRIPTION
Upstream fix to regain compat with dune 3.24 is at https://github.com/ocaml-community/Camomile/pull/13