### PR TITLE
[new release] ppx_deriving_jsont (0.2.0)

### DIFF
--- a/packages/ppx_deriving_jsont/ppx_deriving_jsont.0.2.0/opam
+++ b/packages/ppx_deriving_jsont/ppx_deriving_jsont.0.2.0/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+synopsis: "A ppx deriver for Jsont"
+description:
+  "A convenient tool to generate Jsont descriptions for various OCaml types."
+maintainer: ["Ulysse Gérard"]
+authors: ["Ulysse Gérard"]
+license: "MIT"
+homepage: "https://github.com/voodoos/ppx_deriving_jsont"
+bug-reports: "https://github.com/voodoos/ppx_deriving_jsont/issues"
+depends: [
+  "dune" {>= "3.17"}
+  "ppxlib" {>= "0.36.0"}
+  "jsont"
+  "bytesrw" {with-test}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/voodoos/ppx_deriving_jsont.git"
+url {
+  src:
+    "https://github.com/voodoos/ppx_deriving_jsont/releases/download/0.2.0/ppx_deriving_jsont-0.2.0.tbz"
+  checksum: [
+    "sha256=a3cae0eb1802906e1ce368e749f2a5e09a3bc94bb46a70614282088764db9112"
+    "sha512=e9aa5df11974dce7db8afbddc07ad2a61a43741b0506855835b2309f267da9da8aa73cc785796267f7d7e57519df007d2febb5b6ee520cddcd7545b454a5f1a9"
+  ]
+}
+x-commit-hash: "325e291737bf0c2debfa752302e6a9c0607b456a"


### PR DESCRIPTION
A ppx deriver for Jsont

- Project page: <a href="https://github.com/voodoos/ppx_deriving_jsont">https://github.com/voodoos/ppx_deriving_jsont</a>

##### CHANGES:

- Replace failwiths by Ppxlib's raise_errorf. This prevents the PPX from
  completely breaking Merlin's pipeline.
- Improved locations for error reporting.
- Prefix usages of Stdlib's function.
