### PR TITLE
[new release] ppx_deriving_jsont (0.2.1)

### DIFF
--- a/packages/ppx_deriving_jsont/ppx_deriving_jsont.0.2.1/opam
+++ b/packages/ppx_deriving_jsont/ppx_deriving_jsont.0.2.1/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+synopsis: "A ppx deriver for Jsont"
+description:
+  "A convenient tool to generate Jsont descriptions for various OCaml types."
+maintainer: ["Ulysse Gérard"]
+authors: ["Ulysse Gérard"]
+license: "MIT"
+homepage: "https://github.com/voodoos/ppx_deriving_jsont"
+bug-reports: "https://github.com/voodoos/ppx_deriving_jsont/issues"
+depends: [
+  "dune" {>= "3.17"}
+  "ppxlib" {>= "0.36.0"}
+  "jsont"
+  "bytesrw" {with-test}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/voodoos/ppx_deriving_jsont.git"
+url {
+  src:
+    "https://github.com/voodoos/ppx_deriving_jsont/releases/download/0.2.1/ppx_deriving_jsont-0.2.1.tbz"
+  checksum: [
+    "sha256=1aa66273ad815b663134385680e5339a9fd26792d40e47f32d183716be156f68"
+    "sha512=3fd52a72f0d7572cf20bf20bc6efcc877cdf80dffb80db49ddce35b9a70ef2ab1b63d423e5c3989a9a539e39232f8824197298efe51d9c1ce9e4ef86ac7a7874"
+  ]
+}
+x-commit-hash: "e3073c330680fdd52b98a6be78d37c642cf1ea0a"


### PR DESCRIPTION
A ppx deriver for Jsont

- Project page: <a href="https://github.com/voodoos/ppx_deriving_jsont">https://github.com/voodoos/ppx_deriving_jsont</a>

##### CHANGES:

- Replace failwiths by Ppxlib's raise_errorf. This prevents the PPX from
  completely breaking Merlin's pipeline.
- Improved locations for error reporting.
- Prefix usages of Stdlib's function.
