### PR TITLE
Add upper bounds on dune 3.24 to lablgtk3, wasm_of_ocaml-compiler, and cppo (tests only)

### DIFF
--- a/packages/cppo/cppo.1.6.6/opam
+++ b/packages/cppo/cppo.1.6.6/opam
@@ -13,7 +13,7 @@ depends: [
 build: [
   ["dune" "subst"] {dev}
   ["dune" "build" "-p" name "-j" jobs]
-  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test & dune:version < "3.24"}
 ]
 dev-repo: "git+https://github.com/ocaml-community/cppo.git"
 synopsis: "Code preprocessor like cpp for OCaml"

--- a/packages/cppo/cppo.1.6.7/opam
+++ b/packages/cppo/cppo.1.6.7/opam
@@ -13,7 +13,7 @@ depends: [
 build: [
   ["dune" "subst"] {dev}
   ["dune" "build" "-p" name "-j" jobs]
-  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test & dune:version < "3.24"}
 ]
 dev-repo: "git+https://github.com/ocaml-community/cppo.git"
 synopsis: "Code preprocessor like cpp for OCaml"

--- a/packages/cppo/cppo.1.6.8/opam
+++ b/packages/cppo/cppo.1.6.8/opam
@@ -13,7 +13,7 @@ depends: [
 build: [
   ["dune" "subst"] {dev}
   ["dune" "build" "-p" name "-j" jobs]
-  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test & dune:version < "3.24"}
 ]
 dev-repo: "git+https://github.com/ocaml-community/cppo.git"
 synopsis: "Code preprocessor like cpp for OCaml"

--- a/packages/cppo/cppo.1.6.9/opam
+++ b/packages/cppo/cppo.1.6.9/opam
@@ -26,7 +26,7 @@ depends: [
 build: [
   ["dune" "subst"] {dev}
   ["dune" "build" "-p" name "-j" jobs]
-  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test & dune:version < "3.24"}
   ["dune" "build" "-p" name "@doc"] {with-doc}
 ]
 dev-repo: "git+https://github.com/ocaml-community/cppo.git"

--- a/packages/cppo/cppo.1.7.0/opam
+++ b/packages/cppo/cppo.1.7.0/opam
@@ -33,7 +33,7 @@ build: [
     "-j"
     jobs
     "@install"
-    "@runtest" {with-test}
+    "@runtest" {with-test & dune:version < "3.24"}
     "@doc" {with-doc}
   ]
 ]

--- a/packages/cppo/cppo.1.8.0/opam
+++ b/packages/cppo/cppo.1.8.0/opam
@@ -35,7 +35,7 @@ build: [
     "-j"
     jobs
     "@install"
-    "@runtest" {with-test}
+    "@runtest" {with-test & dune:version < "3.24"}
     "@doc" {with-doc}
   ]
 ]

--- a/packages/lablgtk3/lablgtk3.3.1.1/opam
+++ b/packages/lablgtk3/lablgtk3.3.1.1/opam
@@ -17,7 +17,7 @@ doc: "https://garrigue.github.io/lablgtk/lablgtk3"
 
 depends: [
   "ocaml"     {         >= "4.05.0" }
-  "dune"      {         >= "1.8.0"  }
+  "dune"      {         >= "1.8.0" & < "3.24.0"  }
   "cairo2"    {         >= "0.6"    }
   "conf-gtk3" { build & >= "18"     }
 ]

--- a/packages/lablgtk3/lablgtk3.3.1.2/opam
+++ b/packages/lablgtk3/lablgtk3.3.1.2/opam
@@ -17,7 +17,7 @@ doc: "https://garrigue.github.io/lablgtk/lablgtk3"
 
 depends: [
   "ocaml"     {         >= "4.09.0" }
-  "dune"      {         >= "1.8.0"  }
+  "dune"      {         >= "1.8.0" & < "3.24.0"  }
   "cairo2"    {         >= "0.6"    }
   "conf-gtk3" { build & >= "18"     }
 ]

--- a/packages/lablgtk3/lablgtk3.3.1.3/opam
+++ b/packages/lablgtk3/lablgtk3.3.1.3/opam
@@ -17,7 +17,7 @@ doc: "https://garrigue.github.io/lablgtk/lablgtk3/lablgtk3"
 
 depends: [
   "ocaml"     {         >= "4.09.0" }
-  "dune"      {         >= "1.8.0"  }
+  "dune"      {         >= "1.8.0" & < "3.24.0"  }
   "cairo2"    {         >= "0.6"    }
   "conf-gtk3" { build & >= "18"     }
   "camlp-streams" { build           }

--- a/packages/lablgtk3/lablgtk3.3.1.4/opam
+++ b/packages/lablgtk3/lablgtk3.3.1.4/opam
@@ -18,7 +18,7 @@ doc: "https://garrigue.github.io/lablgtk/lablgtk3/lablgtk3"
 depends: [
   "ocaml"     {         >= "4.09.0" }
   "camlp-streams" {     >= "5.0" & build }
-  "dune"      {         >= "1.8.0"  }
+  "dune"      {         >= "1.8.0" & < "3.24.0"  }
   "cairo2"    {         >= "0.6"    }
   "conf-gtk3" {         >= "18"     }
   "ocamlfind" { dev                 }

--- a/packages/lablgtk3/lablgtk3.3.1.5-1/opam
+++ b/packages/lablgtk3/lablgtk3.3.1.5-1/opam
@@ -18,7 +18,7 @@ doc: "https://garrigue.github.io/lablgtk/lablgtk3/lablgtk3"
 depends: [
   "ocaml"     {         >= "4.09.0" }
   "camlp-streams" {     >= "5.0" & build }
-  "dune"      {         >= "1.8.0"  }
+  "dune"      {         >= "1.8.0" & < "3.24.0"  }
   "cairo2"    {         >= "0.6"    }
   "conf-gtk3" {         >= "18"     }
   "ocamlfind" { dev                 }

--- a/packages/lablgtk3/lablgtk3.3.1.5/opam
+++ b/packages/lablgtk3/lablgtk3.3.1.5/opam
@@ -18,7 +18,7 @@ doc: "https://garrigue.github.io/lablgtk/lablgtk3/lablgtk3"
 depends: [
   "ocaml"     {         >= "4.09.0" }
   "camlp-streams" {     >= "5.0" & build }
-  "dune"      {         >= "1.8.0"  }
+  "dune"      {         >= "1.8.0" & < "3.24.0"  }
   "cairo2"    {         >= "0.6"    }
   "conf-gtk3" {         >= "18"     }
   "ocamlfind" { dev                 }

--- a/packages/wasm_of_ocaml-compiler/wasm_of_ocaml-compiler.6.1.0/opam
+++ b/packages/wasm_of_ocaml-compiler/wasm_of_ocaml-compiler.6.1.0/opam
@@ -11,7 +11,7 @@ homepage: "https://ocsigen.org/js_of_ocaml/latest/manual/overview"
 doc: "https://ocsigen.org/js_of_ocaml/latest/manual/overview"
 bug-reports: "https://github.com/ocsigen/js_of_ocaml/issues"
 depends: [
-  "dune" {>= "3.19"}
+  "dune" {>= "3.19" & < "3.24.0"}
   "ocaml" {>= "4.14"}
   "js_of_ocaml" {= version}
   "num" {with-test}

--- a/packages/wasm_of_ocaml-compiler/wasm_of_ocaml-compiler.6.1.1/opam
+++ b/packages/wasm_of_ocaml-compiler/wasm_of_ocaml-compiler.6.1.1/opam
@@ -11,7 +11,7 @@ homepage: "https://ocsigen.org/js_of_ocaml/latest/manual/overview"
 doc: "https://ocsigen.org/js_of_ocaml/latest/manual/overview"
 bug-reports: "https://github.com/ocsigen/js_of_ocaml/issues"
 depends: [
-  "dune" {>= "3.19"}
+  "dune" {>= "3.19" & < "3.24.0"}
   "ocaml" {>= "4.14"}
   "js_of_ocaml" {= version}
   "num" {with-test}

--- a/packages/wasm_of_ocaml-compiler/wasm_of_ocaml-compiler.6.2.0/opam
+++ b/packages/wasm_of_ocaml-compiler/wasm_of_ocaml-compiler.6.2.0/opam
@@ -11,7 +11,7 @@ homepage: "https://ocsigen.org/js_of_ocaml/latest/manual/overview"
 doc: "https://ocsigen.org/js_of_ocaml/latest/manual/overview"
 bug-reports: "https://github.com/ocsigen/js_of_ocaml/issues"
 depends: [
-  "dune" {>= "3.19"}
+  "dune" {>= "3.19" & < "3.24.0"}
   "ocaml" {>= "4.14"}
   "js_of_ocaml" {= version}
   "num" {with-test}

--- a/packages/wasm_of_ocaml-compiler/wasm_of_ocaml-compiler.6.3.0/opam
+++ b/packages/wasm_of_ocaml-compiler/wasm_of_ocaml-compiler.6.3.0/opam
@@ -11,7 +11,7 @@ homepage: "https://ocsigen.org/js_of_ocaml/latest/manual/overview"
 doc: "https://ocsigen.org/js_of_ocaml/latest/manual/overview"
 bug-reports: "https://github.com/ocsigen/js_of_ocaml/issues"
 depends: [
-  "dune" {>= "3.19"}
+  "dune" {>= "3.19" & < "3.24.0"}
   "ocaml" {>= "4.14"}
   "js_of_ocaml" {= version}
   "num" {with-test}

--- a/packages/wasm_of_ocaml-compiler/wasm_of_ocaml-compiler.6.3.2/opam
+++ b/packages/wasm_of_ocaml-compiler/wasm_of_ocaml-compiler.6.3.2/opam
@@ -11,7 +11,7 @@ homepage: "https://ocsigen.org/js_of_ocaml/latest/manual/overview"
 doc: "https://ocsigen.org/js_of_ocaml/latest/manual/overview"
 bug-reports: "https://github.com/ocsigen/js_of_ocaml/issues"
 depends: [
-  "dune" {>= "3.19"}
+  "dune" {>= "3.19" & < "3.24.0"}
   "ocaml" {>= "4.14"}
   "js_of_ocaml" {= version}
   "num" {with-test}


### PR DESCRIPTION
These packages make use of non-normalized paths from dune variables. But in dune 3.24 the representation of variables expanding to paths within the current directory changes to always include the `./` prefix. As a result, test or builds in these packages. This change is introduced in https://github.com/ocaml/dune/pull/15156

If needed, then patch releases could also be added based on the following upstream PRs:

- https://github.com/garrigue/lablgtk/pull/195
- https://github.com/ocaml-community/cppo/pull/106
- https://github.com/ocsigen/js_of_ocaml/pull/2371