### PR TITLE
Allow core and dependencies to be installed on arm32

### DIFF
--- a/packages/base/base.v0.17.2/opam
+++ b/packages/base/base.v0.17.2/opam
@@ -16,7 +16,7 @@ depends: [
   "dune"                    {>= "3.11.0"}
   "dune-configurator"
 ]
-available: arch != "arm32" & arch != "x86_32"
+available: arch != "x86_32"
 synopsis: "Full standard library replacement for OCaml"
 description: "
 Full standard library replacement for OCaml

--- a/packages/base/base.v0.17.3/opam
+++ b/packages/base/base.v0.17.3/opam
@@ -16,7 +16,7 @@ depends: [
   "dune"                    {>= "3.11.0"}
   "dune-configurator"
 ]
-available: arch != "arm32" & arch != "x86_32"
+available: arch != "x86_32"
 synopsis: "Full standard library replacement for OCaml"
 description: "
 Full standard library replacement for OCaml

--- a/packages/base_quickcheck/base_quickcheck.v0.17.1/opam
+++ b/packages/base_quickcheck/base_quickcheck.v0.17.1/opam
@@ -22,7 +22,7 @@ depends: [
   "dune"              {>= "3.11.0"}
   "ppxlib"            {>= "0.36.0"}
 ]
-available: arch != "arm32" & arch != "x86_32"
+available: arch != "x86_32"
 synopsis: "Randomized testing framework, designed for compatibility with Base"
 description: "
 Base_quickcheck provides randomized testing in the style of Haskell's Quickcheck library,

--- a/packages/ocaml_intrinsics_kernel/ocaml_intrinsics_kernel.v0.17.2/opam
+++ b/packages/ocaml_intrinsics_kernel/ocaml_intrinsics_kernel.v0.17.2/opam
@@ -13,7 +13,7 @@ depends: [
   "ocaml" {>= "5.1.0"}
   "dune" {>= "3.11.0"}
 ]
-available: arch != "arm32" & arch != "x86_32"
+available: arch != "x86_32"
 synopsis: "Intrinsics"
 description: "
 Provides functions to invoke amd64 instructions (such as cmov, min/maxsd, popcnt)

--- a/packages/ppx_bench/ppx_bench.v0.17.1/opam
+++ b/packages/ppx_bench/ppx_bench.v0.17.1/opam
@@ -15,7 +15,7 @@ depends: [
   "dune"            {>= "3.11.0"}
   "ppxlib"          {>= "0.36.0"}
 ]
-available: arch != "arm32" & arch != "x86_32"
+available: arch != "x86_32"
 synopsis: "Syntax extension for writing in-line benchmarks in ocaml code"
 description: "
 Part of the Jane Street's PPX rewriters collection.

--- a/packages/ppx_bin_prot/ppx_bin_prot.v0.17.1/opam
+++ b/packages/ppx_bin_prot/ppx_bin_prot.v0.17.1/opam
@@ -18,7 +18,7 @@ depends: [
   "dune"        {>= "3.11.0"}
   "ppxlib"      {>= "0.36.0"}
 ]
-available: arch != "arm32" & arch != "x86_32"
+available: arch != "x86_32"
 synopsis: "Generation of bin_prot readers and writers from types"
 description: "
 Part of the Jane Street's PPX rewriters collection.

--- a/packages/ppx_diff/ppx_diff.v0.17.1/opam
+++ b/packages/ppx_diff/ppx_diff.v0.17.1/opam
@@ -20,7 +20,7 @@ depends: [
   "dune"          {>= "3.11.0"}
   "ppxlib"        {>= "0.36.0"}
 ]
-available: arch != "arm32" & arch != "x86_32"
+available: arch != "x86_32"
 synopsis: "A PPX rewriter that genreates the implementation of [Ldiffable.S]."
 description: "
 A PPX rewriter that generates the implementation of [Ldiffable.S]. Generates diffs and update functions for OCaml types.

--- a/packages/ppx_expect/ppx_expect.v0.16.2/opam
+++ b/packages/ppx_expect/ppx_expect.v0.16.2/opam
@@ -22,7 +22,7 @@ depends: [
 conflicts: [
   "js_of_ocaml-compiler" {< "5.8"}
 ]
-available: arch != "arm32" & arch != "x86_32"
+available: arch != "x86_32"
 synopsis: "Cram like framework for OCaml"
 description: "
 Part of the Jane Street's PPX rewriters collection.

--- a/packages/ppx_expect/ppx_expect.v0.17.3/opam
+++ b/packages/ppx_expect/ppx_expect.v0.17.3/opam
@@ -18,7 +18,7 @@ depends: [
   "dune"            {>= "3.11.0"}
   "ppxlib"          {>= "0.36.0"}
 ]
-available: arch != "arm32" & arch != "x86_32"
+available: arch != "x86_32"
 conflicts: [
   "js_of_ocaml-compiler" {< "5.8"}
 ]

--- a/packages/ppx_globalize/ppx_globalize.v0.17.2/opam
+++ b/packages/ppx_globalize/ppx_globalize.v0.17.2/opam
@@ -16,7 +16,7 @@ depends: [
   "dune"        {>= "3.11.0"}
   "ppxlib"      {>= "0.36.0"}
 ]
-available: arch != "arm32" & arch != "x86_32"
+available: arch != "x86_32"
 synopsis: "A ppx rewriter that generates functions to copy local values to the global heap"
 description: "
 Part of the Jane Street's PPX rewriters collection.

--- a/packages/ppx_inline_test/ppx_inline_test.v0.17.1/opam
+++ b/packages/ppx_inline_test/ppx_inline_test.v0.17.1/opam
@@ -16,7 +16,7 @@ depends: [
   "dune"     {>= "3.11.0"}
   "ppxlib"   {>= "0.36.0"}
 ]
-available: arch != "arm32" & arch != "x86_32"
+available: arch != "x86_32"
 synopsis: "Syntax extension for writing in-line tests in ocaml code"
 description: "
 Part of the Jane Street's PPX rewriters collection.

--- a/packages/ppx_let/ppx_let.v0.17.1/opam
+++ b/packages/ppx_let/ppx_let.v0.17.1/opam
@@ -16,7 +16,7 @@ depends: [
   "dune"     {>= "3.11.0"}
   "ppxlib"   {>= "0.36.0"}
 ]
-available: arch != "arm32" & arch != "x86_32"
+available: arch != "x86_32"
 synopsis: "Monadic let-bindings"
 description: "
 Part of the Jane Street's PPX rewriters collection.

--- a/packages/ppx_optcomp/ppx_optcomp.v0.17.1/opam
+++ b/packages/ppx_optcomp/ppx_optcomp.v0.17.1/opam
@@ -16,7 +16,7 @@ depends: [
   "dune"   {>= "3.11.0"}
   "ppxlib" {>= "0.36.0"}
 ]
-available: arch != "arm32" & arch != "x86_32"
+available: arch != "x86_32"
 synopsis: "Optional compilation for OCaml"
 description: "
 Part of the Jane Street's PPX rewriters collection.

--- a/packages/ppx_sexp_conv/ppx_sexp_conv.v0.17.1/opam
+++ b/packages/ppx_sexp_conv/ppx_sexp_conv.v0.17.1/opam
@@ -17,7 +17,7 @@ depends: [
   "dune"        {>= "3.11.0"}
   "ppxlib"      {>= "0.36.0"}
 ]
-available: arch != "arm32" & arch != "x86_32"
+available: arch != "x86_32"
 synopsis: "[@@deriving] plugin to generate S-expression conversion functions"
 description: "
 Part of the Jane Street's PPX rewriters collection.

--- a/packages/ppx_stable/ppx_stable.v0.17.1/opam
+++ b/packages/ppx_stable/ppx_stable.v0.17.1/opam
@@ -15,7 +15,7 @@ depends: [
   "dune"   {>= "3.11.0"}
   "ppxlib" {>= "0.36.0"}
 ]
-available: arch != "arm32" & arch != "x86_32"
+available: arch != "x86_32"
 synopsis: "Stable types conversions generator"
 description: "
 A ppx extension for easier implementation of conversion functions between almost

--- a/packages/ppx_tydi/ppx_tydi.v0.17.1/opam
+++ b/packages/ppx_tydi/ppx_tydi.v0.17.1/opam
@@ -15,7 +15,7 @@ depends: [
   "dune"   {>= "3.11.0"}
   "ppxlib" {>= "0.36.0"}
 ]
-available: arch != "arm32" & arch != "x86_32"
+available: arch != "x86_32"
 synopsis: "Let expressions, inferring pattern type from expression."
 description: "
 Provides a ppx for [let%tydi]: type-directed [let] bindings. In [let%tydi a = b in ...], [a]'s type is inferred from [b] rather than the other way around. This is convenient for record patterns whose fields are not in scope.

--- a/packages/ppx_typerep_conv/ppx_typerep_conv.v0.17.1/opam
+++ b/packages/ppx_typerep_conv/ppx_typerep_conv.v0.17.1/opam
@@ -16,7 +16,7 @@ depends: [
   "dune"    {>= "3.11.0"}
   "ppxlib"  {>= "0.36.0"}
 ]
-available: arch != "arm32" & arch != "x86_32"
+available: arch != "x86_32"
 synopsis: "Generation of runtime types from type declarations"
 description: "
 Part of the Jane Street's PPX rewriters collection.

--- a/packages/ppx_variants_conv/ppx_variants_conv.v0.17.1/opam
+++ b/packages/ppx_variants_conv/ppx_variants_conv.v0.17.1/opam
@@ -16,7 +16,7 @@ depends: [
   "dune"        {>= "3.11.0"}
   "ppxlib"      {>= "0.36.0"}
 ]
-available: arch != "arm32" & arch != "x86_32"
+available: arch != "x86_32"
 synopsis: "Generation of accessor and iteration functions for ocaml variant types"
 description: "
 Part of the Jane Street's PPX rewriters collection.

--- a/packages/ppxlib_jane/ppxlib_jane.v0.17.3/opam
+++ b/packages/ppxlib_jane/ppxlib_jane.v0.17.3/opam
@@ -14,7 +14,7 @@ depends: [
   "dune"   {>= "3.11.0"}
   "ppxlib" {>= "0.36.0"}
 ]
-available: arch != "arm32" & arch != "x86_32"
+available: arch != "x86_32"
 synopsis: "Utilities for working with Jane Street AST constructs"
 description: "
 Part of the Jane Street's PPX rewriters collection.

--- a/packages/ppxlib_jane/ppxlib_jane.v0.17.4/opam
+++ b/packages/ppxlib_jane/ppxlib_jane.v0.17.4/opam
@@ -14,7 +14,7 @@ depends: [
   "dune"   {>= "3.11.0"}
   "ppxlib" {>= "0.36.0"}
 ]
-available: arch != "arm32" & arch != "x86_32"
+available: arch != "x86_32"
 synopsis: "Utilities for working with Jane Street AST constructs"
 description: "
 Part of the Jane Street's PPX rewriters collection.


### PR DESCRIPTION
This is a follow on to https://github.com/ocaml/opam-repository/pull/27519

Similar to that PR, these are spurious bounds, and have been removed in the upcoming v0.18 release (cf. https://github.com/janestreet/core/issues/173#issuecomment-4460712097)