### PR TITLE
[new release] migra (2.1.1)

### DIFF
--- a/packages/migra/migra.2.1.1/opam
+++ b/packages/migra/migra.2.1.1/opam
@@ -1,0 +1,56 @@
+opam-version: "2.0"
+synopsis:
+  "A database migration tool and library for OCaml supporting PostgreSQL, MariaDB/MySQL, and SQLite"
+description:
+  "A database migration tool and library for OCaml. Migrations are plain SQL with up and down sections, and the database (PostgreSQL, MariaDB/MySQL, or SQLite) is selected from the connection URL. Applied migrations are tracked with checksums, and drift (a modified, missing, or out-of-order migration) is detected before anything runs. It can be used from the command line or embedded as a library to migrate on application startup."
+maintainer: ["David Sinclair <dsincl12@gmail.com>"]
+authors: ["David Sinclair"]
+license: "MIT"
+tags: ["database" "migrations" "postgresql" "mariadb" "mysql" "sqlite"]
+homepage: "https://github.com/dsincl12/migra"
+doc: "https://github.com/dsincl12/migra"
+bug-reports: "https://github.com/dsincl12/migra/issues"
+depends: [
+  "dune" {>= "3.12"}
+  "ocaml" {>= "4.14.0"}
+  "dune-build-info" {>= "3.12"}
+  "lwt" {>= "5.6.0"}
+  "alcotest" {with-test & >= "1.7.0"}
+  "alcotest-lwt" {with-test & >= "1.7.0"}
+  "caqti" {>= "2.0.0"}
+  "caqti-lwt" {>= "2.0.0"}
+  "caqti-dynload" {>= "2.0.0"}
+  "uri" {>= "4.4.0"}
+  "cmdliner" {>= "2.0.0"}
+  "logs" {>= "0.7.0"}
+  "logs-ppx" {>= "0.2.0"}
+  "fmt" {>= "0.9.0"}
+  "odoc" {with-doc}
+]
+depopts: [
+  "caqti-driver-postgresql" "caqti-driver-mariadb" "caqti-driver-sqlite3"
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/dsincl12/migra.git"
+url {
+  src:
+    "https://github.com/dsincl12/migra/releases/download/2.1.1/migra-2.1.1.tbz"
+  checksum: [
+    "sha256=793336d05c296f0283ee174074933cbebf38c5cd982bc4745f8d1261fa6f1907"
+    "sha512=ad32e72875fc4046bc133a8bea15b3ee41cd6985f509221b7d6bb1bfd713b4b2c0b441b89179d09a89067c205bdc0a17ddd2b8ab8eb6a84f747aa04f4ce006f7"
+  ]
+}
+x-commit-hash: "37496d6694f28e7055e08c7971cea7809eb8fca5"


### PR DESCRIPTION
A database migration tool and library for OCaml supporting PostgreSQL, MariaDB/MySQL, and SQLite

- Project page: <a href="https://github.com/dsincl12/migra">https://github.com/dsincl12/migra</a>
- Documentation: <a href="https://github.com/dsincl12/migra">https://github.com/dsincl12/migra</a>

##### CHANGES:

### Fixed
- `migrate` and every command that ensures the tracking table no longer fail
  on MySQL. `ensure_migrations_table` ran `ALTER TABLE ... ADD COLUMN IF NOT
  EXISTS`, a MariaDB-only extension that MySQL rejects as a syntax error, so
  migra was effectively broken against `mysql://` servers. The table is now
  created with the `checksum` column directly, with no post-creation backfill.
- `status` and `--dry-run` no longer take the wrong path when another database
  (MySQL/MariaDB) or schema (PostgreSQL) on the same server has a
  `schema_migrations` table. `table_exists` now resolves on the connection's
  own database and search_path - PostgreSQL via `to_regclass`, MySQL/MariaDB
  via `DATABASE()` - instead of matching by table name across the whole server.
- An invalid migrations-table name passed to `--table` (an empty or extra
  segment such as `public.`, `a..b`, or `a.b.c`) is now rejected with a clear
  validation error instead of surfacing later as a database parse error.
- The `redo` command's `--help` text and the README's `redo` one-liner now
  describe its actual behavior: roll back the last migration(s), then run all
  pending migrations.
