### PR TITLE
Package opam-minver.0.1.0

### DIFF
--- a/packages/opam-minver/opam-minver.0.1.0/opam
+++ b/packages/opam-minver/opam-minver.0.1.0/opam
@@ -1,0 +1,42 @@
+opam-version: "2.0"
+synopsis: "Find minimum dependency versions for an opam project"
+description: """
+opam-minver reads a project's .opam file to enumerate its dependencies,
+then performs a binary search over each dependency's available versions
+(including the OCaml compiler version) to find the oldest version set
+at which the project successfully builds and passes its tests.
+Once found, it writes the discovered lower bounds back into the .opam
+file and removes the temporary opam switches it created along the way.
+"""
+maintainer: ["chrisa"]
+authors: ["Chris A <onetimerobot@protonmail.com>"]
+license: "MIT"
+homepage: "https://github.com/luminous-moose/opam-minver"
+bug-reports: "https://github.com/luminous-moose/opam-minver/issues"
+depends: [
+  "ocaml" {>= "4.14.0"}
+  "dune" {>= "1.6.3"}
+  "opam-format" {>= "2.0.0"}
+  "opam-core" {>= "2.0.0"}
+  "cmdliner" {>= "0.9.4"}
+  "logs" {>= "0.7.0"}
+  "fmt" {>= "0.8.0"}
+  "ppx_regexp" {>= "0.3.1"}
+  "parsexp" {>= "v0.11.0"}
+  "sexplib0" {>= "v0.11.0"}
+  "base" {with-test & >= "v0.13.1"}
+  "ppx_inline_test" {with-test & >= "v0.13.0"}
+  "ppx_expect" {with-test & >= "v0.13.0"}
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+]
+url {
+  src:
+    "https://github.com/luminous-moose/opam-minver/archive/refs/tags/0.1.0.tar.gz"
+  checksum: [
+    "md5=b915d97c55fc787821d6c41f587a9c74"
+    "sha512=26879db98b54858b82a9a0d33e551bdeec1507554c7ac7309d14c7b19d0bbc366ad803a5a659850a75c59b788b33a300d8dd70f003f2729ef8c2113cd2ad35ab"
+  ]
+}
+


### PR DESCRIPTION
### `opam-minver.0.1.0`
Find minimum dependency versions for an opam project
opam-minver reads a project's .opam file to enumerate its dependencies,
then performs a binary search over each dependency's available versions
(including the OCaml compiler version) to find the oldest version set
at which the project successfully builds and passes its tests.
Once found, it writes the discovered lower bounds back into the .opam
file and removes the temporary opam switches it created along the way.



---
* Homepage: https://github.com/luminous-moose/opam-minver
* Bug tracker: https://github.com/luminous-moose/opam-minver/issues

---
:camel: Pull-request generated by opam-publish v3.0.0