### PR TITLE
[new release] x509 (1.1.1)

### DIFF
--- a/packages/x509/x509.1.1.1/opam
+++ b/packages/x509/x509.1.1.1/opam
@@ -1,0 +1,60 @@
+opam-version: "2.0"
+maintainer: [
+  "Hannes Mehnert <hannes@mehnert.org>"
+]
+authors: [
+  "Hannes Mehnert <hannes@mehnert.org>"
+  "David Kaloper <dk505@cam.ac.uk>"
+]
+license: "BSD-2-Clause"
+tags: "org:mirage"
+homepage: "https://github.com/mirleft/ocaml-x509"
+doc: "https://mirleft.github.io/ocaml-x509/doc"
+bug-reports: "https://github.com/mirleft/ocaml-x509/issues"
+depends: [
+  "ocaml" {>= "4.13.0"}
+  "dune" {>= "2.0"}
+  "asn1-combinators" {>= "0.3.1"}
+  "ptime"
+  "base64" {>= "3.3.0"}
+  "mirage-crypto" {>= "1.0.0"}
+  "mirage-crypto-pk"
+  "mirage-crypto-ec" {>= "0.10.7"}
+  "mirage-crypto-rng"
+  "mirage-crypto-rng" {with-test & >= "1.2.0"}
+  "fmt" {>= "0.8.7"}
+  "alcotest" {with-test}
+  "gmap" {>= "0.3.0"}
+  "domain-name" {>= "0.3.0"}
+  "logs"
+  "kdf" {>= "1.0.0"}
+  "ohex" {>= "0.2.0"}
+  "ipaddr" {>= "5.2.0"}
+]
+conflicts: [ "result" {< "1.5"} ]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/mirleft/ocaml-x509.git"
+synopsis: "Public Key Infrastructure (RFC 5280, PKCS) purely in OCaml"
+description: """
+X.509 is a public key infrastructure used mostly on the Internet.  It consists
+of certificates which include public keys and identifiers, signed by an
+authority. Authorities must be exchanged over a second channel to establish the
+trust relationship. This library implements most parts of RFC5280 and RFC6125.
+The Public Key Cryptography Standards (PKCS) defines encoding and decoding
+(in ASN.1 DER and PEM format), which is also implemented by this library -
+namely PKCS 1, PKCS 5, PKCS 7, PKCS 8, PKCS 9, PKCS 10, and PKCS 12.
+"""
+x-maintenance-intent: [ "(latest)" ]
+url {
+  src:
+    "https://github.com/mirleft/ocaml-x509/releases/download/v1.1.1/x509-1.1.1.tbz"
+  checksum: [
+    "sha256=b6b159dc56ba45c373027f20e60779b5ef8d6fb7854e8b428a8dd9afe140ca55"
+    "sha512=08843f5cbe592514d81b6eb44a6fad0a502d741cacf4087251781c21ac9e2a623b5d49cd50e058813cd73f6beac4dfa2aea3acc54ebd7f84ddb808d0f4536449"
+  ]
+}
+x-commit-hash: "c239fc4cfeecb5915417d2addfc2abab508c8eec"


### PR DESCRIPTION
Public Key Infrastructure (RFC 5280, PKCS) purely in OCaml

- Project page: <a href="https://github.com/mirleft/ocaml-x509">https://github.com/mirleft/ocaml-x509</a>
- Documentation: <a href="https://mirleft.github.io/ocaml-x509/doc">https://mirleft.github.io/ocaml-x509/doc</a>

##### CHANGES:

* Signing_request.decode_der: avoid exception, return an error when an unknown
  OID is used in attributes (mirleft/ocaml-x509#183 @samoht)
