### PR TITLE
[new release] tls (6 packages) (2.1.1)

### DIFF
--- a/packages/tls-async/tls-async.2.1.1/opam
+++ b/packages/tls-async/tls-async.2.1.1/opam
@@ -1,0 +1,48 @@
+opam-version: "2.0"
+homepage:     "https://github.com/mirleft/ocaml-tls"
+dev-repo:     "git+https://github.com/mirleft/ocaml-tls.git"
+bug-reports:  "https://github.com/mirleft/ocaml-tls/issues"
+doc:          "https://mirleft.github.io/ocaml-tls/doc"
+maintainer:   ["Hannes Mehnert <hannes@mehnert.org>" "David Kaloper <david@numm.org>"]
+license:      "BSD-2-Clause"
+
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+depends: [
+  "ocaml" {>= "4.14.0"}
+  "dune" {>= "3.0"}
+  "tls" {= version}
+  "ptime" {>= "0.8.1"}
+  "async" {>= "v0.16"}
+  "async_unix" {>= "v0.16"}
+  "core" {>= "v0.16"}
+  "core_unix" {>= "v0.16"}
+  "cstruct-async"
+  "ppx_jane" {>= "v0.16"}
+  "mirage-crypto-rng" {>= "1.2.0"}
+]
+tags: [ "org:mirage"]
+synopsis: "Transport Layer Security purely in OCaml, Async layer"
+description: """
+Tls-async provides Async-friendly tls bindings
+"""
+x-maintenance-intent: [ "(latest)" ]
+authors: [
+  "David Kaloper <david@numm.org>"
+  "Hannes Mehnert <hannes@mehnert.org>"
+  "Eric Ebinger <github@eric.theebingers.com>"
+  "Calascibetta Romain <romain.calascibetta@gmail.com>"
+]
+url {
+  src:
+    "https://github.com/mirleft/ocaml-tls/releases/download/v2.1.1/tls-2.1.1.tbz"
+  checksum: [
+    "sha256=10bdf88a25ce891083cec18b73abe73af2c69a19e42d3d9516ae5972dac3f307"
+    "sha512=1025f3c2dcde68ff7d81f4d65f0b18751f6db73380802d807e8b73d097af577c8db5538a067da69c7880c298b55f4d65b769356b243719d7ff2e2623f6bda65b"
+  ]
+}
+x-commit-hash: "a420be8c2e06cf7f945426a7d001bebb7fdb27fd"

--- a/packages/tls-eio/tls-eio.2.1.1/opam
+++ b/packages/tls-eio/tls-eio.2.1.1/opam
@@ -1,0 +1,54 @@
+opam-version: "2.0"
+homepage:     "https://github.com/mirleft/ocaml-tls"
+dev-repo:     "git+https://github.com/mirleft/ocaml-tls.git"
+bug-reports:  "https://github.com/mirleft/ocaml-tls/issues"
+doc:          "https://mirleft.github.io/ocaml-tls/doc"
+authors:      ["Thomas Leonard"]
+maintainer:   ["Hannes Mehnert <hannes@mehnert.org>" "David Kaloper <david@numm.org>"]
+license:      "BSD-2-Clause"
+
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test & os != "macos"}
+]
+
+depends: [
+  "ocaml" {>= "5.0.0"}
+  "dune" {>= "3.0"}
+  "tls" {= version}
+  "mirage-crypto-rng" {>= "1.2.0"}
+  "eio" {>= "0.12"}
+  "eio_main" {>= "0.12" & with-test}
+  "mdx" {with-test}
+  "crowbar" {>= "0.2.1" & with-test}
+  "logs" {>= "0.7.0" & with-test}
+  "ptime" {>= "1.0.0"}
+]
+tags: [ "org:mirage"]
+synopsis: "Transport Layer Security purely in OCaml - Eio"
+description: """
+Transport Layer Security (TLS) is probably the most widely deployed security
+protocol on the Internet. It provides communication privacy to prevent
+eavesdropping, tampering, and message forgery. Furthermore, it optionally
+provides authentication of the involved endpoints. TLS is commonly deployed for
+securing web services ([HTTPS](http://tools.ietf.org/html/rfc2818)), emails,
+virtual private networks, and wireless networks.
+
+TLS uses asymmetric cryptography to exchange a symmetric key, and optionally
+authenticate (using X.509) either or both endpoints. It provides algorithmic
+agility, which means that the key exchange method, symmetric encryption
+algorithm, and hash algorithm are negotiated.
+
+Read our [Usenix Security 2015 paper](https://www.usenix.org/conference/usenixsecurity15/technical-sessions/presentation/kaloper-mersinjak).
+"""
+x-maintenance-intent: [ "(latest)" ]
+url {
+  src:
+    "https://github.com/mirleft/ocaml-tls/releases/download/v2.1.1/tls-2.1.1.tbz"
+  checksum: [
+    "sha256=10bdf88a25ce891083cec18b73abe73af2c69a19e42d3d9516ae5972dac3f307"
+    "sha512=1025f3c2dcde68ff7d81f4d65f0b18751f6db73380802d807e8b73d097af577c8db5538a067da69c7880c298b55f4d65b769356b243719d7ff2e2623f6bda65b"
+  ]
+}
+x-commit-hash: "a420be8c2e06cf7f945426a7d001bebb7fdb27fd"

--- a/packages/tls-lwt/tls-lwt.2.1.1/opam
+++ b/packages/tls-lwt/tls-lwt.2.1.1/opam
@@ -1,0 +1,44 @@
+opam-version: "2.0"
+homepage:     "https://github.com/mirleft/ocaml-tls"
+dev-repo:     "git+https://github.com/mirleft/ocaml-tls.git"
+bug-reports:  "https://github.com/mirleft/ocaml-tls/issues"
+doc:          "https://mirleft.github.io/ocaml-tls/doc"
+maintainer:   ["Hannes Mehnert <hannes@mehnert.org>" "David Kaloper <david@numm.org>"]
+license:      "BSD-2-Clause"
+
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+depends: [
+  "ocaml" {>= "4.13.0"}
+  "dune" {>= "3.0"}
+  "tls" {= version}
+  "mirage-crypto-rng" {>= "1.2.0"}
+  "lwt" {>= "5.7.0"}
+  "cmdliner" {>= "1.1.0"}
+  "ptime" {>= "0.8.1"}
+  "randomconv" {with-test & >= "0.2.0"}
+  "x509" {with-test & >= "1.1.0"}
+]
+conflicts: [ "result" {< "1.5"} ]
+tags: [ "org:mirage"]
+synopsis: "Transport Layer Security purely in OCaml, Lwt layer"
+description: """
+Tls-lwt provides an effectful Tls_lwt module to be used with Lwt.
+"""
+x-maintenance-intent: [ "(latest)" ]
+authors: [
+  "David Kaloper <david@numm.org>" "Hannes Mehnert <hannes@mehnert.org>"
+]
+url {
+  src:
+    "https://github.com/mirleft/ocaml-tls/releases/download/v2.1.1/tls-2.1.1.tbz"
+  checksum: [
+    "sha256=10bdf88a25ce891083cec18b73abe73af2c69a19e42d3d9516ae5972dac3f307"
+    "sha512=1025f3c2dcde68ff7d81f4d65f0b18751f6db73380802d807e8b73d097af577c8db5538a067da69c7880c298b55f4d65b769356b243719d7ff2e2623f6bda65b"
+  ]
+}
+x-commit-hash: "a420be8c2e06cf7f945426a7d001bebb7fdb27fd"

--- a/packages/tls-miou-unix/tls-miou-unix.2.1.1/opam
+++ b/packages/tls-miou-unix/tls-miou-unix.2.1.1/opam
@@ -1,0 +1,43 @@
+opam-version: "2.0"
+homepage:     "https://github.com/mirleft/ocaml-tls"
+dev-repo:     "git+https://github.com/mirleft/ocaml-tls.git"
+bug-reports:  "https://github.com/mirleft/ocaml-tls/issues"
+doc:          "https://mirleft.github.io/ocaml-tls/"
+maintainer:   ["Romain Calascibetta <romain.calascibetta@gmail.com>"]
+license:      "BSD-2-Clause"
+
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+depends: [
+  "ocaml" {>= "5.0.0"}
+  "dune" {>= "3.0"}
+  "tls" {= version}
+  "mirage-crypto-rng-miou-unix" {>= "1.0.0" & with-test}
+  "x509" {>= "1.0.0"}
+  "miou" {>= "0.3.0"}
+  "crowbar" {with-test}
+  "rresult" {with-test}
+  "ohex" {with-test}
+  "ptime" {with-test}
+  "hxd" {with-test}
+]
+tags: [ "org:mirage"]
+synopsis: "Transport Layer Security purely in OCaml, Miou+Unix layer"
+description: """
+Tls-miou provides an effectful Tls_miou module to be used with Miou and Unix.
+"""
+x-maintenance-intent: [ "(latest)" ]
+authors: "Romain Calascibetta <romain.calascibetta@gmail.com>"
+url {
+  src:
+    "https://github.com/mirleft/ocaml-tls/releases/download/v2.1.1/tls-2.1.1.tbz"
+  checksum: [
+    "sha256=10bdf88a25ce891083cec18b73abe73af2c69a19e42d3d9516ae5972dac3f307"
+    "sha512=1025f3c2dcde68ff7d81f4d65f0b18751f6db73380802d807e8b73d097af577c8db5538a067da69c7880c298b55f4d65b769356b243719d7ff2e2623f6bda65b"
+  ]
+}
+x-commit-hash: "a420be8c2e06cf7f945426a7d001bebb7fdb27fd"

--- a/packages/tls-mirage/tls-mirage.2.1.1/opam
+++ b/packages/tls-mirage/tls-mirage.2.1.1/opam
@@ -1,0 +1,46 @@
+opam-version: "2.0"
+homepage:     "https://github.com/mirleft/ocaml-tls"
+dev-repo:     "git+https://github.com/mirleft/ocaml-tls.git"
+bug-reports:  "https://github.com/mirleft/ocaml-tls/issues"
+doc:          "https://mirleft.github.io/ocaml-tls/doc"
+maintainer:   ["Hannes Mehnert <hannes@mehnert.org>" "David Kaloper <david@numm.org>"]
+license:      "BSD-2-Clause"
+
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+depends: [
+  "ocaml" {>= "4.13.0"}
+  "dune" {>= "3.0"}
+  "tls" {= version}
+  "fmt" {>= "0.8.7"}
+  "lwt" {>= "3.0.0"}
+  "mirage-flow" {>= "4.0.0"}
+  "mirage-kv" {>= "3.0.0"}
+  "mirage-ptime" {>= "4.0.0"}
+  "ptime" {>= "0.8.1"}
+  "mirage-crypto" {>= "1.0.0"}
+  "mirage-crypto-pk" {>= "1.0.0"}
+]
+tags: [ "org:mirage"]
+synopsis: "Transport Layer Security purely in OCaml, MirageOS layer"
+description: """
+Tls-mirage provides an effectful FLOW module to be used in the MirageOS
+ecosystem.
+"""
+x-maintenance-intent: [ "(latest)" ]
+authors: [
+  "David Kaloper <david@numm.org>" "Hannes Mehnert <hannes@mehnert.org>"
+]
+url {
+  src:
+    "https://github.com/mirleft/ocaml-tls/releases/download/v2.1.1/tls-2.1.1.tbz"
+  checksum: [
+    "sha256=10bdf88a25ce891083cec18b73abe73af2c69a19e42d3d9516ae5972dac3f307"
+    "sha512=1025f3c2dcde68ff7d81f4d65f0b18751f6db73380802d807e8b73d097af577c8db5538a067da69c7880c298b55f4d65b769356b243719d7ff2e2623f6bda65b"
+  ]
+}
+x-commit-hash: "a420be8c2e06cf7f945426a7d001bebb7fdb27fd"

--- a/packages/tls/tls.2.1.1/opam
+++ b/packages/tls/tls.2.1.1/opam
@@ -1,0 +1,66 @@
+opam-version: "2.0"
+homepage:     "https://github.com/mirleft/ocaml-tls"
+dev-repo:     "git+https://github.com/mirleft/ocaml-tls.git"
+bug-reports:  "https://github.com/mirleft/ocaml-tls/issues"
+doc:          "https://mirleft.github.io/ocaml-tls/doc"
+maintainer:   ["Hannes Mehnert <hannes@mehnert.org>" "David Kaloper <david@numm.org>"]
+license:      "BSD-2-Clause"
+
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+depends: [
+  "ocaml" {>= "4.13.0"}
+  "dune" {>= "3.0"}
+  "mirage-crypto" {>= "1.1.0"}
+  "mirage-crypto-ec" {>= "1.0.0"}
+  "mirage-crypto-pk" {>= "1.0.0"}
+  "mirage-crypto-rng" {>= "1.2.0"}
+  "x509" {>= "1.0.0"}
+  "domain-name" {>= "0.3.0"}
+  "fmt" {>= "0.8.7"}
+  "ounit2" {with-test & >= "2.2.0"}
+  "kdf" {>= "1.0.0"}
+  "logs"
+  "ipaddr"
+  "ohex" {>= "0.2.0"}
+  "digestif" {>= "1.2.0"}
+  "ptime" {>= "1.2.0"}
+  "alcotest" {with-test}
+  "cmdliner" {with-test & >= "1.3.0"}
+]
+conflicts: [ "result" {< "1.5"} ]
+tags: [ "org:mirage"]
+synopsis: "Transport Layer Security purely in OCaml"
+description: """
+Transport Layer Security (TLS) is probably the most widely deployed security
+protocol on the Internet. It provides communication privacy to prevent
+eavesdropping, tampering, and message forgery. Furthermore, it optionally
+provides authentication of the involved endpoints. TLS is commonly deployed for
+securing web services ([HTTPS](http://tools.ietf.org/html/rfc2818)), emails,
+virtual private networks, and wireless networks.
+
+TLS uses asymmetric cryptography to exchange a symmetric key, and optionally
+authenticate (using X.509) either or both endpoints. It provides algorithmic
+agility, which means that the key exchange method, symmetric encryption
+algorithm, and hash algorithm are negotiated.
+
+Read our [Usenix Security 2015 paper](https://www.usenix.org/conference/usenixsecurity15/technical-sessions/presentation/kaloper-mersinjak).
+"""
+available: [ arch != "arm32" ] # see SIGBUS failures at https://github.com/ocaml/opam-repository/pull/26387
+x-maintenance-intent: [ "(latest)" ]
+authors: [
+  "David Kaloper <david@numm.org>" "Hannes Mehnert <hannes@mehnert.org>"
+]
+url {
+  src:
+    "https://github.com/mirleft/ocaml-tls/releases/download/v2.1.1/tls-2.1.1.tbz"
+  checksum: [
+    "sha256=10bdf88a25ce891083cec18b73abe73af2c69a19e42d3d9516ae5972dac3f307"
+    "sha512=1025f3c2dcde68ff7d81f4d65f0b18751f6db73380802d807e8b73d097af577c8db5538a067da69c7880c298b55f4d65b769356b243719d7ff2e2623f6bda65b"
+  ]
+}
+x-commit-hash: "a420be8c2e06cf7f945426a7d001bebb7fdb27fd"


### PR DESCRIPTION
Transport Layer Security purely in OCaml

- Project page: <a href="https://github.com/mirleft/ocaml-tls">https://github.com/mirleft/ocaml-tls</a>
- Documentation: <a href="https://mirleft.github.io/ocaml-tls/doc">https://mirleft.github.io/ocaml-tls/doc</a>

##### CHANGES:

* tls-async, tls-lwt, tls-mirage, tls-miou-unix, tls-eio, tls.unix: add ?ip in
  client_of_fd (and similar functions) to check the IP address in the
  server certificate. Also adds 'Config.ip : config -> Ipaddr.t -> config'
  The motivation was testing with bettertls (mirleft/ocaml-tls#523 @hannesm)
* tls, client 1.3: fix KeyUpdate (the out state is now Client13 Established, it
  used to be Server13 Established - which was a typo) (mirleft/ocaml-tls#524 @samoht)
