### PR TITLE
Bound test running on dune:version < 3.24 for packages with brittle path handling of dune variables

### DIFF
--- a/packages/avro/avro.0.1/opam
+++ b/packages/avro/avro.0.1/opam
@@ -23,7 +23,7 @@ build: [
     "-j"
     jobs
     "@install"
-    "@runtest" {with-test}
+    "@runtest" {with-test & dune:version < "3.24"}
     "@doc" {with-doc}
   ]
 ]

--- a/packages/batsat/batsat.0.7/opam
+++ b/packages/batsat/batsat.0.7/opam
@@ -6,7 +6,7 @@ build: [
   ["./build_rust.sh"]
   ["dune" "build" "-p" name "-j" jobs]
   ["dune" "build" "@doc" "-p" name "-j" jobs] {with-doc}
-  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test & dune:version < "3.24"}
 ]
 # TODO: add dependency on cargo?
 depends: [

--- a/packages/gospel/gospel.0.1.0/opam
+++ b/packages/gospel/gospel.0.1.0/opam
@@ -14,7 +14,7 @@ bug-reports: "https://github.com/ocaml-gospel/gospel/issues"
 build: [
   ["dune" "subst"] {dev}
   ["dune" "build" "-p" name "-j" jobs]
-  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test & dune:version < "3.24"}
 ]
 
 depends: [

--- a/packages/gospel/gospel.0.2.0/opam
+++ b/packages/gospel/gospel.0.2.0/opam
@@ -40,7 +40,7 @@ build: [
     "-j"
     jobs
     "@install"
-    "@runtest" {with-test}
+    "@runtest" {with-test & dune:version < "3.24"}
     "@doc" {with-doc}
   ]
 ]

--- a/packages/gospel/gospel.0.3.0/opam
+++ b/packages/gospel/gospel.0.3.0/opam
@@ -28,7 +28,7 @@ build: [
     "-j"
     jobs
     "@install"
-    "@runtest" {with-test}
+    "@runtest" {with-test & dune:version < "3.24"}
     "@doc" {with-doc}
   ]
 ]

--- a/packages/gospel/gospel.0.3.1/opam
+++ b/packages/gospel/gospel.0.3.1/opam
@@ -28,7 +28,7 @@ build: [
     "-j"
     jobs
     "@install"
-    "@runtest" {with-test}
+    "@runtest" {with-test & dune:version < "3.24"}
     "@doc" {with-doc}
   ]
 ]

--- a/packages/landmarks-ppx/landmarks-ppx.1.7/opam
+++ b/packages/landmarks-ppx/landmarks-ppx.1.7/opam
@@ -26,7 +26,7 @@ build: [
     "-j"
     jobs
     "@install"
-    "@runtest" {with-test}
+    "@runtest" {with-test & dune:version < "3.24"}
     "@doc" {with-doc}
   ]
 ]

--- a/packages/minisat/minisat.0.6/opam
+++ b/packages/minisat/minisat.0.6/opam
@@ -3,7 +3,7 @@ maintainer: "simon.cruanes.2007@m4x.org"
 synopsis: "Bindings to the SAT solver Minisat, with the solver included."
 build: [
   ["dune" "build" "-p" name "-j" jobs]
-  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test & dune:version < "3.24"}
   ["dune" "build" "@doc" "-p" name "-j" jobs] {with-doc}
 ]
 license: "BSD-2-clause"

--- a/packages/ocaml-protoc/ocaml-protoc.3.1.1/opam
+++ b/packages/ocaml-protoc/ocaml-protoc.3.1.1/opam
@@ -24,7 +24,7 @@ build: [
     "-j"
     jobs
     "@install"
-    "@runtest" {with-test}
+    "@runtest" {with-test & dune:version < "3.24"}
     "@doc" {with-doc}
   ]
 ]

--- a/packages/ocaml-protoc/ocaml-protoc.3.1/opam
+++ b/packages/ocaml-protoc/ocaml-protoc.3.1/opam
@@ -24,7 +24,7 @@ build: [
     "-j"
     jobs
     "@install"
-    "@runtest" {with-test}
+    "@runtest" {with-test & dune:version < "3.24"}
     "@doc" {with-doc}
   ]
 ]

--- a/packages/ocaml-protoc/ocaml-protoc.4.0/opam
+++ b/packages/ocaml-protoc/ocaml-protoc.4.0/opam
@@ -26,8 +26,8 @@ build: [
     "-j"
     jobs
     "@install"
-    "@src/examples/runtest" {with-test}
-    "@src/tests/expectation/runtest" {with-test}
+    "@src/examples/runtest" {with-test & dune:version < "3.24"}
+    "@src/tests/expectation/runtest" {with-test & dune:version < "3.24"}
     "@doc" {with-doc}
   ]
 ]

--- a/packages/ocaml-protoc/ocaml-protoc.4.1/opam
+++ b/packages/ocaml-protoc/ocaml-protoc.4.1/opam
@@ -26,8 +26,8 @@ build: [
     "-j"
     jobs
     "@install"
-    "@src/examples/runtest" {with-test}
-    "@src/tests/expectation/runtest" {with-test}
+    "@src/examples/runtest" {with-test & dune:version < "3.24"}
+    "@src/tests/expectation/runtest" {with-test & dune:version < "3.24"}
     "@doc" {with-doc}
   ]
 ]

--- a/packages/ortac-wrapper/ortac-wrapper.0.8.0/opam
+++ b/packages/ortac-wrapper/ortac-wrapper.0.8.0/opam
@@ -41,7 +41,7 @@ build: [
     jobs
     "--promote-install-files=false"
     "@install"
-    "@runtest" {with-test}
+    "@runtest" {with-test & dune:version < "3.24"}
     "@doc" {with-doc}
   ]
   ["dune" "install" "-p" name "--create-install-files" name]

--- a/packages/ppx_interact/ppx_interact.0.1.0/opam
+++ b/packages/ppx_interact/ppx_interact.0.1.0/opam
@@ -23,7 +23,7 @@ build: [
     "-j"
     jobs
     "@install"
-    "@runtest" {with-test}
+    "@runtest" {with-test & dune:version < "3.24"}
     "@doc" {with-doc}
   ]
 ]

--- a/packages/ppx_interact/ppx_interact.0.1.1/opam
+++ b/packages/ppx_interact/ppx_interact.0.1.1/opam
@@ -24,7 +24,7 @@ build: [
     "-j"
     jobs
     "@install"
-    "@runtest" {with-test}
+    "@runtest" {with-test & dune:version < "3.24"}
     "@doc" {with-doc}
   ]
 ]

--- a/packages/ppx_interact/ppx_interact.0.2.0/opam
+++ b/packages/ppx_interact/ppx_interact.0.2.0/opam
@@ -24,7 +24,7 @@ build: [
     "-j"
     jobs
     "@install"
-    "@runtest" {with-test}
+    "@runtest" {with-test & dune:version < "3.24"}
     "@doc" {with-doc}
   ]
 ]

--- a/packages/ppx_matches/ppx_matches.0.1.0/opam
+++ b/packages/ppx_matches/ppx_matches.0.1.0/opam
@@ -23,7 +23,7 @@ build: [
     "-j"
     jobs
     "@install"
-    "@runtest" {with-test}
+    "@runtest" {with-test & dune:version < "3.24"}
     "@doc" {with-doc}
   ]
 ]

--- a/packages/ppx_minidebug/ppx_minidebug.0.6.2/opam
+++ b/packages/ppx_minidebug/ppx_minidebug.0.6.2/opam
@@ -34,7 +34,7 @@ build: [
     "-j"
     jobs
     "@install"
-    "@runtest" {with-test}
+    "@runtest" {with-test & dune:version < "3.24"}
     "@doc" {with-doc}
   ]
 ]

--- a/packages/ppx_minidebug/ppx_minidebug.1.6.0/opam
+++ b/packages/ppx_minidebug/ppx_minidebug.1.6.0/opam
@@ -38,7 +38,7 @@ build: [
     "-j"
     jobs
     "@install"
-    "@runtest" {with-test}
+    "@runtest" {with-test & dune:version < "3.24"}
     "@doc" {with-doc}
   ]
 ]

--- a/packages/ppx_minidebug/ppx_minidebug.2.0.2/opam
+++ b/packages/ppx_minidebug/ppx_minidebug.2.0.2/opam
@@ -38,7 +38,7 @@ build: [
     "-j"
     jobs
     "@install"
-    "@runtest" {with-test}
+    "@runtest" {with-test & dune:version < "3.24"}
     "@doc" {with-doc}
   ]
 ]

--- a/packages/ppx_minidebug/ppx_minidebug.2.2.0/opam
+++ b/packages/ppx_minidebug/ppx_minidebug.2.2.0/opam
@@ -39,7 +39,7 @@ build: [
     "-j"
     jobs
     "@install"
-    "@runtest" {with-test}
+    "@runtest" {with-test & dune:version < "3.24"}
     "@doc" {with-doc}
   ]
 ]

--- a/packages/ppx_repr/ppx_repr.0.6.0/opam
+++ b/packages/ppx_repr/ppx_repr.0.6.0/opam
@@ -34,7 +34,7 @@ build: [
     "-j"
     jobs
     "@install"
-    "@runtest" {with-test}
+    "@runtest" {with-test & dune:version < "3.24"}
     "@doc" {with-doc}
   ]
 ]

--- a/packages/ppx_repr/ppx_repr.0.7.0/opam
+++ b/packages/ppx_repr/ppx_repr.0.7.0/opam
@@ -31,7 +31,7 @@ build: [
     "-j"
     jobs
     "@install"
-    "@runtest" {with-test}
+    "@runtest" {with-test & dune:version < "3.24"}
     "@doc" {with-doc}
   ]
 ]

--- a/packages/ppx_repr/ppx_repr.0.8.0/opam
+++ b/packages/ppx_repr/ppx_repr.0.8.0/opam
@@ -31,7 +31,7 @@ build: [
     "-j"
     jobs
     "@install"
-    "@runtest" {with-test}
+    "@runtest" {with-test & dune:version < "3.24"}
     "@doc" {with-doc}
   ]
 ]

--- a/packages/ppx_yojson/ppx_yojson.1.1.0/opam
+++ b/packages/ppx_yojson/ppx_yojson.1.1.0/opam
@@ -23,7 +23,7 @@ build: [
     "-j"
     jobs
     "@install"
-    "@runtest" {with-test}
+    "@runtest" {with-test & dune:version < "3.24"}
     "@doc" {with-doc}
   ]
 ]

--- a/packages/ppx_yojson/ppx_yojson.1.2.0/opam
+++ b/packages/ppx_yojson/ppx_yojson.1.2.0/opam
@@ -24,7 +24,7 @@ build: [
     "-j"
     jobs
     "@install"
-    "@runtest" {with-test}
+    "@runtest" {with-test & dune:version < "3.24"}
     "@doc" {with-doc}
   ]
 ]

--- a/packages/ppx_yojson/ppx_yojson.1.3.0/opam
+++ b/packages/ppx_yojson/ppx_yojson.1.3.0/opam
@@ -25,7 +25,7 @@ build: [
     "-j"
     jobs
     "@install"
-    "@runtest" {with-test}
+    "@runtest" {with-test & dune:version < "3.24"}
     "@doc" {with-doc}
   ]
 ]

--- a/packages/vlt/vlt.0.1/opam
+++ b/packages/vlt/vlt.0.1/opam
@@ -20,7 +20,7 @@ depends: [
 build: [
   ["dune" "subst"] {dev}
   ["dune" "build" "-p" name "-j" jobs]
-  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test & dune:version < "3.24"}
 ]
 dev-repo: "git+https://github.com/codinuum/vlt.git"
 url {

--- a/packages/vlt/vlt.0.2.4/opam
+++ b/packages/vlt/vlt.0.2.4/opam
@@ -29,7 +29,7 @@ build: [
     "-j"
     jobs
     "@install"
-    "@runtest" {with-test}
+    "@runtest" {with-test & dune:version < "3.24"}
     "@doc" {with-doc}
   ]
 ]

--- a/packages/vlt/vlt.0.2.5/opam
+++ b/packages/vlt/vlt.0.2.5/opam
@@ -32,7 +32,7 @@ build: [
     "-j"
     jobs
     "@install"
-    "@runtest" {with-test}
+    "@runtest" {with-test & dune:version < "3.24"}
     "@doc" {with-doc}
   ]
 ]


### PR DESCRIPTION
These packages make use of non-normalized paths from dune variables in their tests. But in dune 3.24 the representation of variables expanding to paths within the current directory changes to always include the `./` prefix. As a result, test in these package versions have trivial errors with dune >= 3.24. This breaking change to dune was introduced in ocaml/dune#15156 and the breakage was detected in https://github.com/ocaml/opam-repository/pull/30092#issuecomment-4785169727