### PR TITLE
alt-ergo 0.95.2 uses autoconf too

### DIFF
--- a/packages/alt-ergo/alt-ergo.0.95.2/opam
+++ b/packages/alt-ergo/alt-ergo.0.95.2/opam
@@ -27,6 +27,7 @@ depends: [
   "zarith"
   "ocamlgraph" {>= "1.8.2"}
   "num"
+  "conf-autoconf"
 ]
 messages: [ "This release is too old. Please consider using version 1.30 that fixes many soundness bugs and brings a lot of improvements" ]
 synopsis:


### PR DESCRIPTION
Follows https://github.com/ocaml/opam-repository/pull/24028 observed on https://github.com/ocaml/opam-repository/pull/30092