### PR TITLE
config-file 1.1 and 1.2 use autoconf too

### DIFF
--- a/packages/config-file/config-file.1.1/opam
+++ b/packages/config-file/config-file.1.1/opam
@@ -10,7 +10,7 @@ remove: [
   ["./configure" "--prefix" prefix]
   [make "uninstall"]
 ]
-depends: ["ocaml" {< "5.0"} "ocamlfind" "camlp4"]
+depends: ["ocaml" {< "5.0"} "ocamlfind" "camlp4" "conf-autoconf"]
 install: [make "install"]
 synopsis: "Small library to define, load and save options files."
 url {

--- a/packages/config-file/config-file.1.2/opam
+++ b/packages/config-file/config-file.1.2/opam
@@ -14,6 +14,7 @@ depends: [
   "ocaml" {>= "4.00" & < "5.0"}
   "ocamlfind"
   "camlp4"
+  "conf-autoconf"
 ]
 install: [make "install"]
 synopsis: "Small library to define, load and save options files."


### PR DESCRIPTION
Follows https://github.com/ocaml/opam-repository/pull/24028 observed on https://github.com/ocaml/opam-repository/pull/30092