### PR TITLE
ocf 0.7.0 uses autoconf too

### DIFF
--- a/packages/ocf/ocf.0.7.0/opam
+++ b/packages/ocf/ocf.0.7.0/opam
@@ -13,6 +13,7 @@ depends: [
   "ocamlfind" {build}
   "yojson" {>= "1.7.0" & < "3"}
   "ppx_tools" {>= "6.3"}
+  "conf-autoconf"
 ]
 build: [
   ["./configure" "--prefix" prefix]


### PR DESCRIPTION
Follows https://github.com/ocaml/opam-repository/pull/24028 observed on https://github.com/ocaml/opam-repository/pull/30092