### PR TITLE
release camlp5 8.05.02 (fixes one busted test due to 5.5.0)

### DIFF
--- a/packages/camlp5/camlp5.8.05.02/opam
+++ b/packages/camlp5/camlp5.8.05.02/opam
@@ -1,0 +1,72 @@
+
+opam-version: "2.0"
+synopsis: "Preprocessor-pretty-printer of OCaml"
+description: """
+Camlp5 is a preprocessor and pretty-printer for OCaml programs. It also provides parsing and printing tools.
+
+As a preprocessor, it allows to:
+
+extend the syntax of OCaml,
+redefine the whole syntax of the language.
+As a pretty printer, it allows to:
+
+display OCaml programs in an elegant way,
+convert from one syntax to another,
+check the results of syntax extensions.
+Camlp5 also provides some parsing and pretty printing tools:
+
+extensible grammars
+extensible printers
+stream parsers and lexers
+pretty print module
+It works as a shell command and can also be used in the OCaml toplevel."""
+x-maintenance-intent: [ "(latest)" ]
+maintainer: ["Chet Murthy <chetsky@gmail.com>"]
+authors: ["Daniel de Rauglaudre" "Chet Murthy"]
+license: "BSD-3-Clause"
+homepage: "https://camlp5.github.io"
+doc: "https://camlp5.github.io/doc/html"
+bug-reports: "https://github.com/camlp5/camlp5/issues"
+depends: [
+  "ocaml" {>= "4.10" & < "5.6.0" }
+  "ocamlfind"
+  "camlp-streams" { >= "5.0" }
+  "conf-perl"
+  "conf-bash"
+  "camlp5-buildscripts" { >= "0.06" }
+  "conf-diffutils" { with-test & (os-distribution = "alpine" | os-distribution = "freebsd") }
+  "re" { >= "1.11.0" }
+  "ounit2" { with-test }
+  "pcre2" { >= "8.0.4" }
+  "rresult"
+  "bos"
+  "fmt"
+  "mdx" {>= "2.3.0" & with-test}
+]
+build: [
+  ["./configure" "--prefix" prefix "-libdir" lib "-mandir" man "-oversion" ocaml:version]
+  [make "-j%{jobs}%" "DEBUG=-g" "world.opt"]
+  [make "-j%{jobs}%" "DEBUG=-g" "all"]
+  [make "-C" "testsuite" "clean" "all-tests"] { with-test }
+  [make "-C" "test" "clean" "all"] { with-test & os != "macos" & os != "opensuse-tumbleweed" }
+  [make "-C" "mdx-tests" "clean" "all"] { with-test & os != "macos" & os != "opensuse-tumbleweed" }
+#  [make "-C" "scripts" "clean" "test"] { with-test }
+]
+install: [make "install"]
+conflicts: [
+   "ocaml-option-bytecode-only"
+   "frama-clang" { <= "0.0.18" }
+   "GT" { <= "0.5.4" }
+   "hol_light" { <= "3.1.0" }
+   "lablgl" { <= "1.07" }
+   "p5scm" { <= "0.4.0" }
+   "pa_ppx" { <= "0.20" }
+]
+x-ci-accept-failures: [ "freebsd" "opensuse-tumbleweed" ]
+dev-repo: "git+https://github.com/camlp5/camlp5.git"
+url {
+  src: "https://github.com/camlp5/camlp5/archive/refs/tags/8.05.02.tar.gz"
+  checksum: [
+    "sha512=c51e1ea61aed7a6f4793ad4cbde0a8c7f498f8ec5bcb06fc78072a137cad900e1bc486007d30f6f26cd91f847aa044f745521f4e0a1cd6919889f60d8a5f68af"
+  ]
+}


### PR DESCRIPTION
there was a new fix in `5.5.0~rc1` that wasn't in `5.5.0~beta1`. The test was for the behaviour in beta1.  So needed to update to reflect the rc1 & release behaviour.

Thanks to glondu@ for pointing this out.