### PR TITLE
Package opam-minver.0.1.1

### DIFF
--- a/packages/opam-minver/opam-minver.0.1.1/opam
+++ b/packages/opam-minver/opam-minver.0.1.1/opam
@@ -1,0 +1,42 @@
+opam-version: "2.0"
+synopsis: "Find minimum dependency versions for an opam project"
+description: """
+opam-minver reads a project's .opam file to enumerate its dependencies,
+then performs a binary search over each dependency's available versions
+(including the OCaml compiler version) to find the oldest version set
+at which the project successfully builds and passes its tests.
+Once found, it writes the discovered lower bounds back into the .opam
+file and removes the temporary opam switches it created along the way.
+"""
+maintainer: ["chrisa"]
+authors: ["Chris A <onetimerobot@protonmail.com>"]
+license: "MIT"
+homepage: "https://github.com/luminous-moose/opam-minver"
+dev-repo: "git+https://github.com/luminous-moose/opam-minver.git"
+bug-reports: "https://github.com/luminous-moose/opam-minver/issues"
+depends: [
+  "ocaml" {>= "4.14.0"}
+  "dune" {>= "3.15.3"}
+  "opam-format" {>= "2.2.0"}
+  "opam-core" {>= "2.2.0"}
+  "cmdliner" {>= "1.3.0"}
+  "logs" {>= "0.7.0"}
+  "fmt" {>= "0.9.0"}
+  "parsexp" {>= "v0.15.0"}
+  "sexplib0" {>= "v0.15.1"}
+  "base" {with-test & >= "v0.15.1"}
+  "ppx_inline_test" {with-test & >= "v0.15.1"}
+  "ppx_expect" {with-test & >= "v0.15.1"}
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+]
+url {
+  src:
+    "https://github.com/luminous-moose/opam-minver/archive/refs/tags/0.1.1.tar.gz"
+  checksum: [
+    "md5=75923ee9e839803d5850a57003e6adbe"
+    "sha512=f88704b75ea6b3b1db3710b4e02515d2be535c23ddd9b2ffe3370dbcb61322f27f7e4c5d50cce25f511f49420c30eb799763b685ab3ed6ab734f1d2c3331e20d"
+  ]
+}
+


### PR DESCRIPTION
### `opam-minver.0.1.1`
Find minimum dependency versions for an opam project
opam-minver reads a project's .opam file to enumerate its dependencies,
then performs a binary search over each dependency's available versions
(including the OCaml compiler version) to find the oldest version set
at which the project successfully builds and passes its tests.
Once found, it writes the discovered lower bounds back into the .opam
file and removes the temporary opam switches it created along the way.



---
* Homepage: https://github.com/luminous-moose/opam-minver
* Source repo: git+https://github.com/luminous-moose/opam-minver.git
* Bug tracker: https://github.com/luminous-moose/opam-minver/issues

---
:camel: Pull-request generated by opam-publish v3.0.0