### PR TITLE
[new release] caisar (6.0)

### DIFF
--- a/packages/caisar/caisar.6.0/opam
+++ b/packages/caisar/caisar.6.0/opam
@@ -1,0 +1,69 @@
+opam-version: "2.0"
+synopsis:
+  "A platform for characterizing the safety and robustness of artificial intelligence based software"
+maintainer: ["AISER team, Software Safety and Security Laboratory, CEA-List"]
+authors: ["AISER team, Software Safety and Security Laboratory, CEA-List"]
+license: "LGPL-2.1-only"
+homepage: "https://git.frama-c.com/pub/caisar"
+doc: "https://git.frama-c.com/pub/caisar"
+bug-reports: "https://git.frama-c.com/pub/caisar/issues"
+depends: [
+  "dune" {>= "3.12"}
+  "ocaml" {>= "4.14"}
+  "dune-site" {>= "2.9.0"}
+  "zarith" {>= "1.7"}
+  "ocplib-endian" {>= "1.0"}
+  "base" {>= "v0.16.0"}
+  "cmdliner" {>= "1.1.1" & < "2.0.0"}
+  "fmt" {>= "0.8.9"}
+  "logs" {>= "0.7.0"}
+  "yojson" {>= "1.7.0"}
+  "menhirLib" {>= "20210310"}
+  "csv" {>= "2.4"}
+  "why3" {>= "1.8.2"}
+  "re" {>= "1.12.0"}
+  "fpath" {>= "0.7.3"}
+  "yaml" {>= "3.1.0"}
+  "ocaml-protoc-plugin" {>= "4.2.0"}
+  "stdio" {>= "v0.14.0"}
+  "ocamlgraph" {>= "1.8.8"}
+  "ppx_deriving" {>= "5.1"}
+  "ppx_inline_test" {>= "0.12.0"}
+  "conf-jq" {>= "1" & with-test}
+  "conf-texlive" {>= "1" & with-test}
+  "conf-python-3" {>= "9.0.0" & with-test}
+  "ppx_deriving_yojson" {>= "3.6.1"}
+  "ppx_deriving_yaml" {>= "0.3.0"}
+  "ppx_deriving_jsonschema" {>= "0.0.4" & < "0.0.5"}
+  "ppx_variants_conv" {>= "0.18"}
+  "why3find" {>= "1.2.0" & with-doc}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+dev-repo: "git+https://git.frama-c.com/pub/caisar.git"
+available:
+  arch = "x86_64"
+url {
+  src:
+    "https://git.frama-c.com/api/v4/projects/1082/packages/generic/caisar/6.0/caisar-6.0.tbz"
+  checksum: [
+    "sha256=fea07c24524bbea3810b44dcf9dc70cead28f9202a853b0f8e007f29ebf2c576"
+    "sha512=c5b59a9a834a17aa4520dc184c23c1f697ab5cddfdd86c74de3b7374c3b59bd380944757da64a4823eeeb4b799b4fab4ccc134b626e5d5cf5d6bc256938e6c9f"
+  ]
+}
+x-commit-hash: "531df65457853f9b5faabc0ec240269eacb08526"


### PR DESCRIPTION
CHANGES:

- [cmdline] Deprecate options `--prover-altern` and `--prover-precision` in favor of a redesigned option `-p PROVER[:ALTERN][:PRECISION][,...]` or `--prover=PROVER[:ALTERN][:PRECISION][,...]` to indicate the provers to use. `PROVER[:ALTERN][:PRECISION][,...]` is comma-separated list of `PROVER[:ALTERN][:PRECISION]` items; `PROVER` is case-insensitive, `ALTERN` is case-sensitive, and `PRECISION` takes values from 0 (default, fastest but imprecise verification) to 5 (accurate but slow verification).

- [cmdline] Deprecate option `--dataset` as dataset filenames can be simply defined via `--define` option.

- [cmdline] Rename option `--format` into `--speclang` as CAISAR supports WhyML and VNN-LIB specification languages.

- [doc] Added the documentation for CAISAR WhyML standard libraries.