### PR TITLE
[new release] kdf (1.1.0)

### DIFF
--- a/packages/kdf/kdf.1.1.0/opam
+++ b/packages/kdf/kdf.1.1.0/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+maintainer: ["Alfredo Beaumont <alfredo.beaumont@gmail.com>" "Hannes Mehnert <hannes@mehnert.org>"]
+authors: ["Alfredo Beaumont <alfredo.beaumont@gmail.com>" "Sonia Meruelo <smeruelo@gmail.com>" "Hannes Mehnert <hannes@mehnert.org>"]
+license: "BSD-2-Clause"
+homepage: "https://github.com/robur-coop/kdf"
+doc: "https://robur-coop.github.io/kdf/doc"
+bug-reports: "https://github.com/robur-coop/kdf/issues"
+depends: [
+  "ocaml" {>= "4.13.0"}
+  "dune" {>= "1.8.0"}
+  "digestif" {>= "1.2.0"}
+  "mirage-crypto" {>= "1.0.0"}
+  "alcotest" {with-test & >= "0.8.1"}
+  "ohex" {with-test & >= "0.2.0"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/robur-coop/kdf.git"
+synopsis: "Key Derivation Functions: HKDF RFC 5869, PBKDF RFC 2898, SCRYPT RFC 7914"
+description: """
+A pure OCaml implementation of [scrypt](https://tools.ietf.org/html/rfc7914),
+[PBKDF 1 and 2 as defined by PKCS#5](https://tools.ietf.org/html/rfc2898),
+and [HKDF](https://tools.ietf.org/html/rfc5869).
+"""
+x-maintenance-intent: [ "(latest)" ]
+url {
+  src:
+    "https://github.com/robur-coop/kdf/releases/download/v1.1.0/kdf-1.1.0.tbz"
+  checksum: [
+    "sha256=996c165b6e9532816d4ae5c7e77527a70d2f111a25583c0aeb72f4b0278569c5"
+    "sha512=85a8e95389be1040fa1ac76dc49a87d205366b5220f5c023d5ec3e72d5c193a9379dfd920027b9b58aee227300a4c558763380f607cc6558497352c13a82ed15"
+  ]
+}
+x-commit-hash: "b218591fb7b9204602e76e82731addc32d655453"


### PR DESCRIPTION
Key Derivation Functions: HKDF RFC 5869, PBKDF RFC 2898, SCRYPT RFC 7914

- Project page: <a href="https://github.com/robur-coop/kdf">https://github.com/robur-coop/kdf</a>
- Documentation: <a href="https://robur-coop.github.io/kdf/doc">https://robur-coop.github.io/kdf/doc</a>

##### CHANGES:

* scrypt: fix for r > 8 (reported by @samoht robur-coop/kdf#1, fix by @hannesm in robur-coop/kdf#3 (inspired
  by @samoht robur-coop/kdf#2))
* scrypt: add tests for r > 8 and bad input (@hannesm robur-coop/kdf#3)
* scrypt, pbkdf: raise Failure instead of Invalid_argument (@hannesm robur-coop/kdf#3)
