### PR TITLE
[new release] ppx_deriving (6.1.2)

### DIFF
--- a/packages/ppx_deriving/ppx_deriving.6.1.2/opam
+++ b/packages/ppx_deriving/ppx_deriving.6.1.2/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+maintainer: "whitequark <whitequark@whitequark.org>"
+authors: [ "whitequark <whitequark@whitequark.org>" ]
+license: "MIT"
+homepage: "https://github.com/ocaml-ppx/ppx_deriving"
+doc: "https://ocaml-ppx.github.io/ppx_deriving/"
+bug-reports: "https://github.com/ocaml-ppx/ppx_deriving/issues"
+dev-repo: "git+https://github.com/ocaml-ppx/ppx_deriving.git"
+tags: [ "syntax" ]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+  ["dune" "build" "@doc" "-p" name "-j" jobs] {with-doc}
+]
+depends: [
+  "ocaml" {>= "4.05.0"}
+  "dune" {>= "1.6.3"}
+  "cppo" {>= "1.1.0" & build}
+  "ocamlfind"
+  "ppx_derivers"
+  "ppxlib" {>= "0.36.0"}
+  "ounit2" {with-test}
+]
+synopsis: "Type-driven code generation for OCaml"
+description: """
+ppx_deriving provides common infrastructure for generating
+code based on type definitions, and a set of useful plugins
+for common tasks.
+"""
+url {
+  src:
+    "https://github.com/ocaml-ppx/ppx_deriving/releases/download/6.1.2/ppx_deriving-6.1.2.tbz"
+  checksum: [
+    "sha256=5595bfe668d3434b1f1babb3ccb43d4cab3dc1d562b8d8c47c410d88546253ff"
+    "sha512=68ab402c8d1461d644eceb5804df66eaab445486adbfbab326114e91f301c2c7e2a5290f04d88a0617a836d3890b4f48f1e1d4bf9aee406c5c2f5362753229f1"
+  ]
+}
+x-commit-hash: "e3c26dff486d12081642c3cf8baa71d7aeeaaa34"


### PR DESCRIPTION
Type-driven code generation for OCaml

- Project page: <a href="https://github.com/ocaml-ppx/ppx_deriving">https://github.com/ocaml-ppx/ppx_deriving</a>
- Documentation: <a href="https://ocaml-ppx.github.io/ppx_deriving/">https://ocaml-ppx.github.io/ppx_deriving/</a>

##### CHANGES:

* Add location info to `create`, `eq`, `iter`, `make`, `ord`, `show`
  ocaml-ppx/ppx_deriving#297
  (@arvidj)

* Fix ord incorrectly quoting polymorphic comparison for builtins
  ocaml-ppx/ppx_deriving#305
  (@sim642)
