### PR TITLE
[new release] binsec (0.11.2)

### DIFF
--- a/packages/binsec/binsec.0.11.2/opam
+++ b/packages/binsec/binsec.0.11.2/opam
@@ -1,0 +1,111 @@
+opam-version: "2.0"
+synopsis: "Semantic analysis of binary executables"
+description: """
+
+BINSEC aims at developing an open-source platform filling the gap between formal
+methods over executable code and binary-level security analyses currently used
+in the security industry.
+
+The project targets the following applicative domains:
+
+    vulnerability analyses
+    malware comprehension
+    code protection
+    binary-level verification
+
+BINSEC is developed at CEA List in scientfic collaboration with Verimag and LORIA.
+
+An overview of some BINSEC features can be found in our SSPREW'17 tutorial."""
+maintainer: ["BINSEC <binsec@saxifrage.saclay.cea.fr>"]
+authors: [
+  "Adel Djoudi"
+  "Benoit Boero"
+  "Benjamin Farinier"
+  "Chakib Foulani"
+  "Dorian Lesbre"
+  "Frédéric Recoules"
+  "Guillaume Girol"
+  "Josselin Feist"
+  "Lesly-Ann Daniel"
+  "Mahmudul Faisal Al Ameen"
+  "Manh-Dung Nguyen"
+  "Mathéo Vergnolle"
+  "Matthieu Lemerre"
+  "Nicolas Bellec"
+  "Olivier Nicole"
+  "Richard Bonichon"
+  "Robin David"
+  "Sébastien Bardin"
+  "Soline Ducousso"
+  "Ta Thanh Dinh"
+  "Yaëlle Vinçont"
+  "Yanis Sellami"
+]
+license: "LGPL-2.1-or-later"
+tags: [
+  "binary code analysis"
+  "symbolic execution"
+  "deductive"
+  "program verification"
+  "formal specification"
+  "automated theorem prover"
+  "plugins"
+  "abstract interpretation"
+  "dataflow analysis"
+  "linking"
+  "disassembly"
+]
+homepage: "https://binsec.github.io"
+bug-reports: "mailto:binsec@saxifrage.saclay.cea.fr"
+depends: [
+  "dune" {>= "3.18"}
+  "ocaml" {>= "4.14"}
+  "menhir" {build & >= "20181113"}
+  "ocamlgraph" {>= "1.8.5"}
+  "zarith" {>= "1.13"}
+  "dune-site"
+  "dypgen"
+  "toml" {>= "6"}
+  "ounit2" {with-test & >= "2"}
+  "qcheck" {with-test & >= "0.90"}
+  "ppx_inline_test" {with-test}
+  "unionFind" {with-test}
+  "ocamlformat" {with-dev-setup & = "0.26.2"}
+  "odoc" {with-doc}
+]
+depopts: ["curses" "llvm" "unisim_archisec" "bitwuzla" "bitwuzla-cxx" "z3"]
+conflicts: [
+  "llvm" {< "6.0.0" | >= "16.0.0"}
+  "bitwuzla" {< "1.0.6"}
+  "bitwuzla-cxx" {< "0.4"}
+  "z3" {< "4.8.13"}
+  "unisim_archisec" {< "0.0.6"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+dev-repo: "git+https://github.com/binsec/binsec.git"
+x-maintenance-intent: ["(latest)"]
+available: [ os-family != "windows" ]
+url {
+  src:
+    "https://github.com/binsec/binsec/releases/download/0.11.2/binsec-0.11.2.tbz"
+  checksum: [
+    "sha256=b758f3428b62a03103403196af99a5bb7df77a35afbcc5ce2d2b1fbe6d2ab36b"
+    "sha512=afa4fdf09ae0c2ab02530d674f9f2c1473d156e0438b4cb9c262ffea2d98c448251de55cd6fb176562edaae3897aeabe873ffa1ad47f861c75e1943792d90261"
+  ]
+}
+x-commit-hash: "dfe4739f03a474cf2ebc5ae419760e57ce0050c3"


### PR DESCRIPTION
Semantic analysis of binary executables

- Project page: <a href="https://binsec.github.io">https://binsec.github.io</a>

##### CHANGES:

** Misc

- Update help wording in `make_coredump.sh` script and add a `--quiet` option

** Bugs

- Fix loader bug with zero-sized sections
- Fix minor typos in documentation (including binsec/binsec#62)
- Remove leftover SSE options for deleted features (binsec/binsec#64)
