### PR TITLE
diskuvbox.0.2.0: add cmdliner 2.0.0 upper bound

### DIFF
--- a/packages/diskuvbox/diskuvbox.0.2.0/opam
+++ b/packages/diskuvbox/diskuvbox.0.2.0/opam
@@ -18,7 +18,7 @@ depends: [
   "logs" {>= "0.7.0"}
   "result" {>= "1.5"}
   "mdx" {>= "2.0.0" & with-test}
-  "cmdliner" {>= "1.1.0"}
+  "cmdliner" {>= "1.1.0" & < "2.0.0"}
 ]
 dev-repo: "git+https://github.com/diskuv/diskuvbox.git"
 # Until Dune 3+ the auto-generated '.opam' will have an invalid ["dune" "install" ...] step


### PR DESCRIPTION
Found in #30167 revdeps.

Tests fail otherwise due to well-known breaking change in cmdliner 2.0.0 (https://github.com/dbuenzli/cmdliner/blob/master/CHANGES.md#v200-2025-09-26-zagreb):
```
#=== ERROR while compiling diskuvbox.0.2.0 ====================================#
# context              2.5.1 | linux/x86_64 | ocaml-base-compiler.4.14.4 | file:///home/opam/opam-repository
# path                 ~/.opam/4.14/.opam-switch/build/diskuvbox.0.2.0
# command              ~/.opam/opam-init/hooks/sandbox.sh build dune build -p diskuvbox -j 71 @install @runtest
# exit-code            1
# env-file             ~/.opam/log/diskuvbox-7-02e9d3.env
# output-file          ~/.opam/log/diskuvbox-7-02e9d3.out
### output ###
# File "src/bin/tests/find-up.t", line 1, characters 0-0:
# /usr/bin/git --no-pager diff --no-index --color=always -u _build/default/src/bin/tests/find-up.t _build/default/src/bin/tests/find-up.t.corrected
# diff --git a/_build/default/src/bin/tests/find-up.t b/_build/default/src/bin/tests/find-up.t.corrected
# index 3249472..aebbf58 100644
# --- a/_build/default/src/bin/tests/find-up.t
# +++ b/_build/default/src/bin/tests/find-up.t.corrected
# @@ -4,24 +4,40 @@ Use diskuvbox to find a nonexistent file
#  Create a directory structure
#    $ install -d a/b/c/d/e/f
#    $ ./diskuvbox.exe touch a/b/i-am-here
# +  Usage: diskuvbox [--help] [COMMAND] …
# +  diskuvbox: unknown command 'touch'. Must be one of 'copy-dir', 'copy-file',
# +             'copy-file-into', 'find-up', 'help', 'touch-file' or 'tree'
# +  [124]
#    $ ./diskuvbox.exe touch a/b/c/i-am-also-here
# +  Usage: diskuvbox [--help] [COMMAND] …
# +  diskuvbox: unknown command 'touch'. Must be one of 'copy-dir', 'copy-file',
# +             'copy-file-into', 'find-up', 'help', 'touch-file' or 'tree'
# +  [124]
#    $ ./diskuvbox.exe touch a/b/c/d/something-that-wont-be-searched
# +  Usage: diskuvbox [--help] [COMMAND] …
# +  diskuvbox: unknown command 'touch'. Must be one of 'copy-dir', 'copy-file',
# +             'copy-file-into', 'find-up', 'help', 'touch-file' or 'tree'
# +  [124]
#
#  Use diskuvbox to find i-am-here
#    $ ./diskuvbox.exe find-up a/b/c/d/e/f i-am-here
# -  a/b/i-am-here
#
#  Use diskuvbox to find i-am-here or i-am-also-here
#    $ ./diskuvbox.exe find-up a/b/c/d/e/f i-am-here i-am-also-here
# -  a/b/c/i-am-also-here
#
#  Use diskuvbox to find .you-better-find-me in the same directory
#    $ ./diskuvbox.exe touch .you-better-find-me
# +  Usage: diskuvbox [--help] [COMMAND] …
# +  diskuvbox: unknown command 'touch'. Must be one of 'copy-dir', 'copy-file',
# +             'copy-file-into', 'find-up', 'help', 'touch-file' or 'tree'
# +  [124]
#    $ ./diskuvbox.exe find-up . .you-better-find-me
# -  ./.you-better-find-me
#
#  Use diskuvbox to find .and-this-one-too in a child directory
#    $ install -d z
#    $ ./diskuvbox.exe touch z/.and-this-one-too
# +  Usage: diskuvbox [--help] [COMMAND] …
# +  diskuvbox: unknown command 'touch'. Must be one of 'copy-dir', 'copy-file',
# +             'copy-file-into', 'find-up', 'help', 'touch-file' or 'tree'
# +  [124]
#    $ ./diskuvbox.exe find-up z .and-this-one-too
# -  z/.and-this-one-too
```