### PR TITLE
hl_yaml.1.0.0: add yojson 3 upper bound

### DIFF
--- a/packages/hl_yaml/hl_yaml.1.0.0/opam
+++ b/packages/hl_yaml/hl_yaml.1.0.0/opam
@@ -22,7 +22,7 @@ depends: [
   "dune" { >= "1.9.0" }
 
   # DEPENDENCIES
-  "yojson"
+  "yojson" { < "3" }
   "ppx_deriving_yojson"
   "yaml" { >= "3.2.0" }
 


### PR DESCRIPTION
Found in #30167 revdeps.

Tests fail otherwise due to well-known breaking change in yojson 3 (https://github.com/ocaml-community/yojson/blob/master/CHANGES.md#300):
```
#=== ERROR while compiling hl_yaml.1.0.0 ======================================#
# context              2.5.1 | linux/x86_64 | ocaml-base-compiler.5.5.0 | file:///home/opam/opam-repository
# path                 ~/.opam/5.5/.opam-switch/build/hl_yaml.1.0.0
# command              ~/.opam/opam-init/hooks/sandbox.sh build dune build -p hl_yaml -j 71
# exit-code            1
# env-file             ~/.opam/log/hl_yaml-7-8993d4.env
# output-file          ~/.opam/log/hl_yaml-7-8993d4.out
### output ###
# (cd _build/default && /home/opam/.opam/5.5/bin/ocamlc.opt -w -40 -g -bin-annot -bin-annot-occurrences -I src/.hl_yaml.objs/byte -I /home/opam/.opam/5.5/lib/ctypes -I /home/opam/.opam/5.5/lib/ctypes/stubs -I /home/opam/.opam/5.5/lib/integers -I /home/opam/.opam/5.5/lib/ocaml/str -I /home/opam/.opam/5.5/lib/ocaml/unix -I /home/opam/.opam/5.5/lib/ppx_deriving/runtime -I /home/opam/.opam/5.5/lib/ppx_deriving_yojson/runtime -I /home/opam/.opam/5.5/lib/stdlib-shims -I /home/opam/.opam/5.5/lib/yaml -I /home/opam/.opam/5.5/lib/yaml/bindings -I /home/opam/.opam/5.5/lib/yaml/bindings/types -I /home/opam/.opam/5.5/lib/yaml/c -I /home/opam/.opam/5.5/lib/yaml/ffi -I /home/opam/.opam/5.5/lib/yaml/types -I /home/opam/.opam/5.5/lib/yojson -cmi-file src/.hl_yaml.objs/byte/hl_yaml__Spec.cmi -no-alias-deps -open Hl_yaml__ -o src/.hl_yaml.objs/byte/hl_yaml__Spec.cmo -c -impl src/spec.pp.ml)
# File "src/spec.ml", line 89, characters 15-23:
# 89 | | (`Intlit _ | `Tuple _ | `Variant _) as json -> infer (Yojson.Safe.to_basic json :> Yojson.Safe.t)
#                     ^^^^^^^^
# Error: This pattern matches values of type [? `Tuple of 'a ]
#        but a pattern was expected which matches values of type Yojson.Safe.t
#        The second variant type does not allow tag(s) `Tuple
# (cd _build/default && /home/opam/.opam/5.5/bin/ocamlopt.opt -w -40 -g -I src/.hl_yaml.objs/byte -I src/.hl_yaml.objs/native -I /home/opam/.opam/5.5/lib/ctypes -I /home/opam/.opam/5.5/lib/ctypes/stubs -I /home/opam/.opam/5.5/lib/integers -I /home/opam/.opam/5.5/lib/ocaml/str -I /home/opam/.opam/5.5/lib/ocaml/unix -I /home/opam/.opam/5.5/lib/ppx_deriving/runtime -I /home/opam/.opam/5.5/lib/ppx_deriving_yojson/runtime -I /home/opam/.opam/5.5/lib/stdlib-shims -I /home/opam/.opam/5.5/lib/yaml -I /home/opam/.opam/5.5/lib/yaml/bindings -I /home/opam/.opam/5.5/lib/yaml/bindings/types -I /home/opam/.opam/5.5/lib/yaml/c -I /home/opam/.opam/5.5/lib/yaml/ffi -I /home/opam/.opam/5.5/lib/yaml/types -I /home/opam/.opam/5.5/lib/yojson -cmi-file src/.hl_yaml.objs/byte/hl_yaml__Spec.cmi -no-alias-deps -open Hl_yaml__ -o src/.hl_yaml.objs/native/hl_yaml__Spec.cmx -c -impl src/spec.pp.ml)
# File "src/spec.ml", line 89, characters 15-23:
# 89 | | (`Intlit _ | `Tuple _ | `Variant _) as json -> infer (Yojson.Safe.to_basic json :> Yojson.Safe.t)
#                     ^^^^^^^^
# Error: This pattern matches values of type [? `Tuple of 'a ]
#        but a pattern was expected which matches values of type Yojson.Safe.t
#        The second variant type does not allow tag(s) `Tuple
# (cd _build/default && /home/opam/.opam/5.5/bin/ocamlc.opt -w -40 -g -bin-annot -bin-annot-occurrences -I src/.hl_yaml.objs/byte -I /home/opam/.opam/5.5/lib/ctypes -I /home/opam/.opam/5.5/lib/ctypes/stubs -I /home/opam/.opam/5.5/lib/integers -I /home/opam/.opam/5.5/lib/ocaml/str -I /home/opam/.opam/5.5/lib/ocaml/unix -I /home/opam/.opam/5.5/lib/ppx_deriving/runtime -I /home/opam/.opam/5.5/lib/ppx_deriving_yojson/runtime -I /home/opam/.opam/5.5/lib/stdlib-shims -I /home/opam/.opam/5.5/lib/yaml -I /home/opam/.opam/5.5/lib/yaml/bindings -I /home/opam/.opam/5.5/lib/yaml/bindings/types -I /home/opam/.opam/5.5/lib/yaml/c -I /home/opam/.opam/5.5/lib/yaml/ffi -I /home/opam/.opam/5.5/lib/yaml/types -I /home/opam/.opam/5.5/lib/yojson -cmi-file src/.hl_yaml.objs/byte/hl_yaml.cmi -no-alias-deps -open Hl_yaml__ -o src/.hl_yaml.objs/byte/hl_yaml.cmo -c -impl src/hl_yaml.pp.ml)
# File "src/hl_yaml.ml", line 114, characters 10-18:
# 114 |          |`Tuple _
#                 ^^^^^^^^
# Error: This pattern matches values of type [? `Tuple of 'a ]
#        but a pattern was expected which matches values of type Yojson.Safe.t
#        The second variant type does not allow tag(s) `Tuple
```