### PR TITLE
[new release] Caqti 3.0.0

### DIFF
--- a/packages/caqti-async/caqti-async.3.0.0/opam
+++ b/packages/caqti-async/caqti-async.3.0.0/opam
@@ -13,7 +13,7 @@ depends: [
   "core" {>= "v0.16.1"}
   "core_unix"
   "domain-name"
-  "dune" {>= "3.9"}
+  "dune" {>= "3.23.1"}
   "ipaddr"
   "logs"
   "ocaml"

--- a/packages/caqti-async/caqti-async.3.0.0/opam
+++ b/packages/caqti-async/caqti-async.3.0.0/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+maintainer: "Petter A. Urkedal <paurkedal@gmail.com>"
+x-maintenance-intent: ["(latest)"]
+authors: "Petter A. Urkedal <paurkedal@gmail.com>"
+license: "LGPL-3.0-or-later WITH LGPL-3.0-linking-exception"
+homepage: "https://github.com/paurkedal/ocaml-caqti/"
+doc: "https://paurkedal.github.io/ocaml-caqti/index.html"
+bug-reports: "https://github.com/paurkedal/ocaml-caqti/issues"
+depends: [
+  "async_kernel" {>= "v0.17.0"}
+  "async_unix" {>= "v0.11.0"}
+  "caqti" {>= "3.0.0" & < "3.1.0~"}
+  "core" {>= "v0.16.1"}
+  "core_unix"
+  "domain-name"
+  "dune" {>= "3.9"}
+  "ipaddr"
+  "logs"
+  "ocaml"
+  "alcotest" {with-test & >= "1.5.0"}
+  "alcotest-async" {with-test}
+  "cmdliner" {with-test & >= "1.1.0"}
+  "caqti-driver-sqlite3" {with-test}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+  ["dune" "build" "@doc" "-p" name "-j" jobs] {with-doc}
+]
+dev-repo: "git+https://github.com/paurkedal/ocaml-caqti.git"
+synopsis: "Async support for Caqti"
+url {
+  src:
+    "https://github.com/paurkedal/ocaml-caqti/releases/download/v3.0.0/caqti-v3.0.0.tbz"
+  checksum: [
+    "sha256=3ceea06ba0e8e8bcab0386b5817b68cb30fce457eaa25ada0182891d66f6a0b9"
+    "sha512=e01f546a45b04cafd5fa262e9228e5a1aabd5e0942059c073a4181c928450baf3d990cc59ffb1a33dff445b46a0e218224a23dca96e8d24cdd0ab793d08e4538"
+  ]
+}
+x-commit-hash: "4c2501dba825ae9a6c8123ebcd95b1866251fc87"

--- a/packages/caqti-driver-mariadb/caqti-driver-mariadb.3.0.0/opam
+++ b/packages/caqti-driver-mariadb/caqti-driver-mariadb.3.0.0/opam
@@ -11,7 +11,7 @@ depends: [
   "ocaml"
   "caqti" {>= "3.0.0" & < "3.1.0~"}
   "cmdliner" {with-test & >= "1.1.0"}
-  "dune" {>= "3.9"}
+  "dune" {>= "3.23.1"}
   "mariadb" {>= "1.3.0"}
   "odoc" {with-doc}
 ]

--- a/packages/caqti-driver-mariadb/caqti-driver-mariadb.3.0.0/opam
+++ b/packages/caqti-driver-mariadb/caqti-driver-mariadb.3.0.0/opam
@@ -1,0 +1,33 @@
+opam-version: "2.0"
+maintainer: "Petter A. Urkedal <paurkedal@gmail.com>"
+x-maintenance-intent: ["(latest)"]
+authors: "Petter A. Urkedal <paurkedal@gmail.com>"
+license: "LGPL-3.0-or-later WITH LGPL-3.0-linking-exception"
+homepage: "https://github.com/paurkedal/ocaml-caqti/"
+doc: "https://paurkedal.github.io/ocaml-caqti/index.html"
+bug-reports: "https://github.com/paurkedal/ocaml-caqti/issues"
+depends: [
+  "alcotest" {with-test & >= "1.5.0"}
+  "ocaml"
+  "caqti" {>= "3.0.0" & < "3.1.0~"}
+  "cmdliner" {with-test & >= "1.1.0"}
+  "dune" {>= "3.9"}
+  "mariadb" {>= "1.3.0"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+  ["dune" "build" "@doc" "-p" name "-j" jobs] {with-doc}
+]
+dev-repo: "git+https://github.com/paurkedal/ocaml-caqti.git"
+synopsis: "MariaDB driver for Caqti using C bindings"
+url {
+  src:
+    "https://github.com/paurkedal/ocaml-caqti/releases/download/v3.0.0/caqti-v3.0.0.tbz"
+  checksum: [
+    "sha256=3ceea06ba0e8e8bcab0386b5817b68cb30fce457eaa25ada0182891d66f6a0b9"
+    "sha512=e01f546a45b04cafd5fa262e9228e5a1aabd5e0942059c073a4181c928450baf3d990cc59ffb1a33dff445b46a0e218224a23dca96e8d24cdd0ab793d08e4538"
+  ]
+}
+x-commit-hash: "4c2501dba825ae9a6c8123ebcd95b1866251fc87"

--- a/packages/caqti-driver-pgx/caqti-driver-pgx.3.0.0/opam
+++ b/packages/caqti-driver-pgx/caqti-driver-pgx.3.0.0/opam
@@ -12,7 +12,7 @@ depends: [
   "ocaml" {>= "4.08"}
   "caqti" {>= "3.0.0" & < "3.1.0~"}
   "domain-name"
-  "dune" {>= "3.9"}
+  "dune" {>= "3.23.1"}
   "ipaddr"
   "pgx" {>= "2.0"}
 ]

--- a/packages/caqti-driver-pgx/caqti-driver-pgx.3.0.0/opam
+++ b/packages/caqti-driver-pgx/caqti-driver-pgx.3.0.0/opam
@@ -1,0 +1,33 @@
+opam-version: "2.0"
+maintainer: "Petter A. Urkedal <paurkedal@gmail.com>"
+x-maintenance-intent: ["(latest)"]
+authors: [
+  "Petter A. Urkedal <paurkedal@gmail.com>"
+]
+license: "LGPL-3.0-or-later WITH LGPL-3.0-linking-exception"
+homepage: "https://github.com/paurkedal/ocaml-caqti/"
+doc: "https://paurkedal.github.io/ocaml-caqti/index.html"
+bug-reports: "https://github.com/paurkedal/ocaml-caqti/issues"
+depends: [
+  "ocaml" {>= "4.08"}
+  "caqti" {>= "3.0.0" & < "3.1.0~"}
+  "domain-name"
+  "dune" {>= "3.9"}
+  "ipaddr"
+  "pgx" {>= "2.0"}
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/paurkedal/ocaml-caqti.git"
+synopsis: "PostgreSQL driver for Caqti based on the pure-OCaml PGX library"
+url {
+  src:
+    "https://github.com/paurkedal/ocaml-caqti/releases/download/v3.0.0/caqti-v3.0.0.tbz"
+  checksum: [
+    "sha256=3ceea06ba0e8e8bcab0386b5817b68cb30fce457eaa25ada0182891d66f6a0b9"
+    "sha512=e01f546a45b04cafd5fa262e9228e5a1aabd5e0942059c073a4181c928450baf3d990cc59ffb1a33dff445b46a0e218224a23dca96e8d24cdd0ab793d08e4538"
+  ]
+}
+x-commit-hash: "4c2501dba825ae9a6c8123ebcd95b1866251fc87"

--- a/packages/caqti-driver-postgresql/caqti-driver-postgresql.3.0.0/opam
+++ b/packages/caqti-driver-postgresql/caqti-driver-postgresql.3.0.0/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+maintainer: "Petter A. Urkedal <paurkedal@gmail.com>"
+x-maintenance-intent: ["(latest)"]
+authors: [
+  "Petter A. Urkedal <paurkedal@gmail.com>"
+  "James Owen <james@cryptosense.com>"
+]
+license: "LGPL-3.0-or-later WITH LGPL-3.0-linking-exception"
+homepage: "https://github.com/paurkedal/ocaml-caqti/"
+doc: "https://paurkedal.github.io/ocaml-caqti/index.html"
+bug-reports: "https://github.com/paurkedal/ocaml-caqti/issues"
+depends: [
+  "alcotest" {with-test & >= "1.5.0"}
+  "ocaml"
+  "caqti" {>= "3.0.0" & < "3.1.0~"}
+  "cmdliner" {with-test & >= "1.1.0"}
+  "dune" {>= "3.9"}
+  "odoc" {with-doc}
+  "postgresql" {>= "5.0.0"}
+  "uri" {>= "4.0.0"}
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+  ["dune" "build" "@doc" "-p" name "-j" jobs] {with-doc}
+]
+dev-repo: "git+https://github.com/paurkedal/ocaml-caqti.git"
+synopsis: "PostgreSQL driver for Caqti based on C bindings"
+url {
+  src:
+    "https://github.com/paurkedal/ocaml-caqti/releases/download/v3.0.0/caqti-v3.0.0.tbz"
+  checksum: [
+    "sha256=3ceea06ba0e8e8bcab0386b5817b68cb30fce457eaa25ada0182891d66f6a0b9"
+    "sha512=e01f546a45b04cafd5fa262e9228e5a1aabd5e0942059c073a4181c928450baf3d990cc59ffb1a33dff445b46a0e218224a23dca96e8d24cdd0ab793d08e4538"
+  ]
+}
+x-commit-hash: "4c2501dba825ae9a6c8123ebcd95b1866251fc87"

--- a/packages/caqti-driver-postgresql/caqti-driver-postgresql.3.0.0/opam
+++ b/packages/caqti-driver-postgresql/caqti-driver-postgresql.3.0.0/opam
@@ -14,7 +14,7 @@ depends: [
   "ocaml"
   "caqti" {>= "3.0.0" & < "3.1.0~"}
   "cmdliner" {with-test & >= "1.1.0"}
-  "dune" {>= "3.9"}
+  "dune" {>= "3.23.1"}
   "odoc" {with-doc}
   "postgresql" {>= "5.0.0"}
   "uri" {>= "4.0.0"}

--- a/packages/caqti-driver-sqlite3/caqti-driver-sqlite3.3.0.0/opam
+++ b/packages/caqti-driver-sqlite3/caqti-driver-sqlite3.3.0.0/opam
@@ -1,0 +1,33 @@
+opam-version: "2.0"
+maintainer: "Petter A. Urkedal <paurkedal@gmail.com>"
+x-maintenance-intent: ["(latest)"]
+authors: "Petter A. Urkedal <paurkedal@gmail.com>"
+license: "LGPL-3.0-or-later WITH LGPL-3.0-linking-exception"
+homepage: "https://github.com/paurkedal/ocaml-caqti/"
+doc: "https://paurkedal.github.io/ocaml-caqti/index.html"
+bug-reports: "https://github.com/paurkedal/ocaml-caqti/issues"
+depends: [
+  "alcotest" {with-test & >= "1.5.0"}
+  "ocaml"
+  "caqti" {>= "3.0.0" & < "3.1.0~"}
+  "cmdliner" {with-test & >= "1.1.0"}
+  "dune" {>= "3.9"}
+  "odoc" {with-doc}
+  "sqlite3" {>= "5.0.1"}
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+  ["dune" "build" "@doc" "-p" name "-j" jobs] {with-doc}
+]
+dev-repo: "git+https://github.com/paurkedal/ocaml-caqti.git"
+synopsis: "Sqlite3 driver for Caqti using C bindings"
+url {
+  src:
+    "https://github.com/paurkedal/ocaml-caqti/releases/download/v3.0.0/caqti-v3.0.0.tbz"
+  checksum: [
+    "sha256=3ceea06ba0e8e8bcab0386b5817b68cb30fce457eaa25ada0182891d66f6a0b9"
+    "sha512=e01f546a45b04cafd5fa262e9228e5a1aabd5e0942059c073a4181c928450baf3d990cc59ffb1a33dff445b46a0e218224a23dca96e8d24cdd0ab793d08e4538"
+  ]
+}
+x-commit-hash: "4c2501dba825ae9a6c8123ebcd95b1866251fc87"

--- a/packages/caqti-driver-sqlite3/caqti-driver-sqlite3.3.0.0/opam
+++ b/packages/caqti-driver-sqlite3/caqti-driver-sqlite3.3.0.0/opam
@@ -11,7 +11,7 @@ depends: [
   "ocaml"
   "caqti" {>= "3.0.0" & < "3.1.0~"}
   "cmdliner" {with-test & >= "1.1.0"}
-  "dune" {>= "3.9"}
+  "dune" {>= "3.23.1"}
   "odoc" {with-doc}
   "sqlite3" {>= "5.0.1"}
 ]

--- a/packages/caqti-dynload/caqti-dynload.3.0.0/opam
+++ b/packages/caqti-dynload/caqti-dynload.3.0.0/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+maintainer: "Petter A. Urkedal <paurkedal@gmail.com>"
+x-maintenance-intent: ["(latest)"]
+authors: "Petter A. Urkedal <paurkedal@gmail.com>"
+license: "LGPL-3.0-or-later WITH LGPL-3.0-linking-exception"
+homepage: "https://github.com/paurkedal/ocaml-caqti/"
+doc: "https://paurkedal.github.io/ocaml-caqti/index.html"
+bug-reports: "https://github.com/paurkedal/ocaml-caqti/issues"
+depends: [
+  "caqti" {>= "3.0.0" & < "4.0.0~"}
+  "dune" {>= "3.9"}
+  "ocaml"
+  "ocamlfind"
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/paurkedal/ocaml-caqti.git"
+synopsis: "Dynamic linking of Caqti drivers using findlib.dynload"
+description: """
+This library registers a dynamic linker which will be called when
+encoutering an unhandled database URI.  It tries to load a findlib package
+named "caqti-driver-<scheme>" where "<scheme>" is the scheme of the URI,
+which is expected register a driver for the scheme.
+
+This is a separate package to avoid the dependency on the findlib.dynload
+for architectures, like MirageOS, where dynamic linking may be unavailable.
+The alternative is to link drivers directly into the application.
+"""
+url {
+  src:
+    "https://github.com/paurkedal/ocaml-caqti/releases/download/v3.0.0/caqti-v3.0.0.tbz"
+  checksum: [
+    "sha256=3ceea06ba0e8e8bcab0386b5817b68cb30fce457eaa25ada0182891d66f6a0b9"
+    "sha512=e01f546a45b04cafd5fa262e9228e5a1aabd5e0942059c073a4181c928450baf3d990cc59ffb1a33dff445b46a0e218224a23dca96e8d24cdd0ab793d08e4538"
+  ]
+}
+x-commit-hash: "4c2501dba825ae9a6c8123ebcd95b1866251fc87"

--- a/packages/caqti-dynload/caqti-dynload.3.0.0/opam
+++ b/packages/caqti-dynload/caqti-dynload.3.0.0/opam
@@ -8,7 +8,7 @@ doc: "https://paurkedal.github.io/ocaml-caqti/index.html"
 bug-reports: "https://github.com/paurkedal/ocaml-caqti/issues"
 depends: [
   "caqti" {>= "3.0.0" & < "4.0.0~"}
-  "dune" {>= "3.9"}
+  "dune" {>= "3.23.1"}
   "ocaml"
   "ocamlfind"
 ]

--- a/packages/caqti-eio/caqti-eio.3.0.0/opam
+++ b/packages/caqti-eio/caqti-eio.3.0.0/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+maintainer: "Petter A. Urkedal <paurkedal@gmail.com>"
+x-maintenance-intent: ["(latest)"]
+authors: "Petter A. Urkedal <paurkedal@gmail.com>"
+license: "LGPL-3.0-or-later WITH LGPL-3.0-linking-exception"
+homepage: "https://github.com/paurkedal/ocaml-caqti/"
+doc: "https://paurkedal.github.io/ocaml-caqti/index.html"
+bug-reports: "https://github.com/paurkedal/ocaml-caqti/issues"
+depends: [
+  "caqti" {>= "3.0.0" & < "3.1.0~"}
+  "dune" {>= "3.9"}
+  "eio" {>= "0.12"}
+  "logs"
+  "ocaml" {>= "5.0.0~"}
+  "alcotest" {with-test & >= "1.5.0"}
+  "caqti-driver-sqlite3" {with-test}
+  "cmdliner" {with-test & >= "1.1.0"}
+  "eio_main" {with-test}
+  "mirage-crypto-rng" {with-test & >= "1.2.0"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+  ["dune" "build" "@doc" "-p" name "-j" jobs] {with-doc}
+]
+dev-repo: "git+https://github.com/paurkedal/ocaml-caqti.git"
+synopsis: "Eio support for Caqti"
+url {
+  src:
+    "https://github.com/paurkedal/ocaml-caqti/releases/download/v3.0.0/caqti-v3.0.0.tbz"
+  checksum: [
+    "sha256=3ceea06ba0e8e8bcab0386b5817b68cb30fce457eaa25ada0182891d66f6a0b9"
+    "sha512=e01f546a45b04cafd5fa262e9228e5a1aabd5e0942059c073a4181c928450baf3d990cc59ffb1a33dff445b46a0e218224a23dca96e8d24cdd0ab793d08e4538"
+  ]
+}
+x-commit-hash: "4c2501dba825ae9a6c8123ebcd95b1866251fc87"

--- a/packages/caqti-eio/caqti-eio.3.0.0/opam
+++ b/packages/caqti-eio/caqti-eio.3.0.0/opam
@@ -8,7 +8,7 @@ doc: "https://paurkedal.github.io/ocaml-caqti/index.html"
 bug-reports: "https://github.com/paurkedal/ocaml-caqti/issues"
 depends: [
   "caqti" {>= "3.0.0" & < "3.1.0~"}
-  "dune" {>= "3.9"}
+  "dune" {>= "3.23.1"}
   "eio" {>= "0.12"}
   "logs"
   "ocaml" {>= "5.0.0~"}

--- a/packages/caqti-lwt/caqti-lwt.3.0.0/opam
+++ b/packages/caqti-lwt/caqti-lwt.3.0.0/opam
@@ -8,7 +8,7 @@ doc: "https://paurkedal.github.io/ocaml-caqti/index.html"
 bug-reports: "https://github.com/paurkedal/ocaml-caqti/issues"
 depends: [
   "caqti" {>= "3.0.0" & < "3.1.0~"}
-  "dune" {>= "3.9"}
+  "dune" {>= "3.23.1"}
   "domain-name"
   "ipaddr"
   "logs"

--- a/packages/caqti-lwt/caqti-lwt.3.0.0/opam
+++ b/packages/caqti-lwt/caqti-lwt.3.0.0/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+maintainer: "Petter A. Urkedal <paurkedal@gmail.com>"
+x-maintenance-intent: ["(latest)"]
+authors: "Petter A. Urkedal <paurkedal@gmail.com>"
+license: "LGPL-3.0-or-later WITH LGPL-3.0-linking-exception"
+homepage: "https://github.com/paurkedal/ocaml-caqti/"
+doc: "https://paurkedal.github.io/ocaml-caqti/index.html"
+bug-reports: "https://github.com/paurkedal/ocaml-caqti/issues"
+depends: [
+  "caqti" {>= "3.0.0" & < "3.1.0~"}
+  "dune" {>= "3.9"}
+  "domain-name"
+  "ipaddr"
+  "logs"
+  "mtime" {>= "2.0.0"}
+  "lwt" {>= "5.3.0"}
+  "ocaml"
+  "alcotest" {with-test & >= "1.5.0"}
+  "alcotest-lwt" {with-test & >= "1.5.0"}
+  "cmdliner" {with-test & >= "1.1.0"}
+  "caqti-driver-sqlite3" {with-test}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+  ["dune" "build" "@doc" "-p" name "-j" jobs] {with-doc}
+]
+dev-repo: "git+https://github.com/paurkedal/ocaml-caqti.git"
+synopsis: "Lwt support for Caqti"
+url {
+  src:
+    "https://github.com/paurkedal/ocaml-caqti/releases/download/v3.0.0/caqti-v3.0.0.tbz"
+  checksum: [
+    "sha256=3ceea06ba0e8e8bcab0386b5817b68cb30fce457eaa25ada0182891d66f6a0b9"
+    "sha512=e01f546a45b04cafd5fa262e9228e5a1aabd5e0942059c073a4181c928450baf3d990cc59ffb1a33dff445b46a0e218224a23dca96e8d24cdd0ab793d08e4538"
+  ]
+}
+x-commit-hash: "4c2501dba825ae9a6c8123ebcd95b1866251fc87"

--- a/packages/caqti-miou/caqti-miou.3.0.0/opam
+++ b/packages/caqti-miou/caqti-miou.3.0.0/opam
@@ -8,7 +8,7 @@ doc: "https://paurkedal.github.io/ocaml-caqti/index.html"
 bug-reports: "https://github.com/paurkedal/ocaml-caqti/issues"
 depends: [
   "caqti" {>= "3.0.0" & < "3.1.0~"}
-  "dune" {>= "3.9"}
+  "dune" {>= "3.23.1"}
   "miou" {>= "0.3.0"}
   "logs"
   "ocaml" {>= "5.0.0~"}

--- a/packages/caqti-miou/caqti-miou.3.0.0/opam
+++ b/packages/caqti-miou/caqti-miou.3.0.0/opam
@@ -1,0 +1,36 @@
+opam-version: "2.0"
+maintainer: "Petter A. Urkedal <paurkedal@gmail.com>"
+x-maintenance-intent: ["(latest)"]
+authors: "Romain Calascibetta <romain.calascibetta@gmail.com>"
+license: "LGPL-3.0-or-later WITH LGPL-3.0-linking-exception"
+homepage: "https://github.com/paurkedal/ocaml-caqti/"
+doc: "https://paurkedal.github.io/ocaml-caqti/index.html"
+bug-reports: "https://github.com/paurkedal/ocaml-caqti/issues"
+depends: [
+  "caqti" {>= "3.0.0" & < "3.1.0~"}
+  "dune" {>= "3.9"}
+  "miou" {>= "0.3.0"}
+  "logs"
+  "ocaml" {>= "5.0.0~"}
+  "alcotest" {with-test & >= "1.5.0"}
+  "caqti-driver-sqlite3" {with-test}
+  "cmdliner" {with-test & >= "1.1.0"}
+  "mirage-crypto-rng-miou-unix" {with-test}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+  ["dune" "build" "@doc" "-p" name "-j" jobs] {with-doc}
+]
+dev-repo: "git+https://github.com/paurkedal/ocaml-caqti.git"
+synopsis: "Miou support for Caqti"
+url {
+  src:
+    "https://github.com/paurkedal/ocaml-caqti/releases/download/v3.0.0/caqti-v3.0.0.tbz"
+  checksum: [
+    "sha256=3ceea06ba0e8e8bcab0386b5817b68cb30fce457eaa25ada0182891d66f6a0b9"
+    "sha512=e01f546a45b04cafd5fa262e9228e5a1aabd5e0942059c073a4181c928450baf3d990cc59ffb1a33dff445b46a0e218224a23dca96e8d24cdd0ab793d08e4538"
+  ]
+}
+x-commit-hash: "4c2501dba825ae9a6c8123ebcd95b1866251fc87"

--- a/packages/caqti-mirage/caqti-mirage.3.0.0/opam
+++ b/packages/caqti-mirage/caqti-mirage.3.0.0/opam
@@ -1,0 +1,43 @@
+opam-version: "2.0"
+maintainer: "Petter A. Urkedal <paurkedal@gmail.com>"
+x-maintenance-intent: ["(latest)"]
+authors: "Petter A. Urkedal <paurkedal@gmail.com>"
+license: "LGPL-3.0-or-later WITH LGPL-3.0-linking-exception"
+homepage: "https://github.com/paurkedal/ocaml-caqti/"
+doc: "https://paurkedal.github.io/ocaml-caqti/index.html"
+bug-reports: "https://github.com/paurkedal/ocaml-caqti/issues"
+depends: [
+  "caqti" {>= "3.0.0" & < "3.1.0~"}
+  "caqti-lwt" {>= "3.0.0" & < "3.1.0~"}
+  "caqti-tls" {>= "3.0.0" & < "3.1.0~"}
+  "dns-client" {>= "7.0.0"}
+  "dns-client-mirage" {>= "7.0.0"}
+  "domain-name"
+  "dune" {>= "3.9"}
+  "ipaddr"
+  "logs"
+  "lwt" {>= "5.3.0"}
+  "mirage-channel"
+  "mirage-sleep"
+  "ocaml"
+  "odoc" {with-doc}
+  "tls"
+  "tls-mirage" {>= "1.0.0"}
+  "tcpip" {>= "8.1.0"}
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+  ["dune" "build" "@doc" "-p" name "-j" jobs] {with-doc}
+]
+dev-repo: "git+https://github.com/paurkedal/ocaml-caqti.git"
+synopsis: "MirageOS support for Caqti including TLS"
+url {
+  src:
+    "https://github.com/paurkedal/ocaml-caqti/releases/download/v3.0.0/caqti-v3.0.0.tbz"
+  checksum: [
+    "sha256=3ceea06ba0e8e8bcab0386b5817b68cb30fce457eaa25ada0182891d66f6a0b9"
+    "sha512=e01f546a45b04cafd5fa262e9228e5a1aabd5e0942059c073a4181c928450baf3d990cc59ffb1a33dff445b46a0e218224a23dca96e8d24cdd0ab793d08e4538"
+  ]
+}
+x-commit-hash: "4c2501dba825ae9a6c8123ebcd95b1866251fc87"

--- a/packages/caqti-mirage/caqti-mirage.3.0.0/opam
+++ b/packages/caqti-mirage/caqti-mirage.3.0.0/opam
@@ -13,7 +13,7 @@ depends: [
   "dns-client" {>= "7.0.0"}
   "dns-client-mirage" {>= "7.0.0"}
   "domain-name"
-  "dune" {>= "3.9"}
+  "dune" {>= "3.23.1"}
   "ipaddr"
   "logs"
   "lwt" {>= "5.3.0"}

--- a/packages/caqti-tls/caqti-tls.3.0.0/opam
+++ b/packages/caqti-tls/caqti-tls.3.0.0/opam
@@ -8,7 +8,7 @@ doc: "https://paurkedal.github.io/ocaml-caqti/index.html"
 bug-reports: "https://github.com/paurkedal/ocaml-caqti/issues"
 depends: [
   "caqti" {>= "3.0.0" & < "3.1.0~"}
-  "dune" {>= "3.9"}
+  "dune" {>= "3.23.1"}
   "ocaml"
   "odoc" {with-doc}
   "tls" {>= "1.0.0"}

--- a/packages/caqti-tls/caqti-tls.3.0.0/opam
+++ b/packages/caqti-tls/caqti-tls.3.0.0/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+maintainer: "Petter A. Urkedal <paurkedal@gmail.com>"
+x-maintenance-intent: ["(latest)"]
+authors: "Petter A. Urkedal <paurkedal@gmail.com>"
+license: "LGPL-3.0-or-later WITH LGPL-3.0-linking-exception"
+homepage: "https://github.com/paurkedal/ocaml-caqti/"
+doc: "https://paurkedal.github.io/ocaml-caqti/index.html"
+bug-reports: "https://github.com/paurkedal/ocaml-caqti/issues"
+depends: [
+  "caqti" {>= "3.0.0" & < "3.1.0~"}
+  "dune" {>= "3.9"}
+  "ocaml"
+  "odoc" {with-doc}
+  "tls" {>= "1.0.0"}
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+  ["dune" "build" "@doc" "-p" name "-j" jobs] {with-doc}
+]
+dev-repo: "git+https://github.com/paurkedal/ocaml-caqti.git"
+synopsis: "Caqti TLS support for PGX; config and caqti.unix implementation"
+description: """
+This package contains the shared configuration and caqti.unix-specific
+implementation of TLS for the Caqti network API.  This package only applies
+to PGX, since drivers based on bindings use their own TLS implementation
+(libpq, mariadb) or have no need for it (sqlite3).
+
+The implementation for caqti-eio and caqti-lwt can be found in caqti-tls-eio
+and caqti-tls-lwt, respectively.
+"""
+url {
+  src:
+    "https://github.com/paurkedal/ocaml-caqti/releases/download/v3.0.0/caqti-v3.0.0.tbz"
+  checksum: [
+    "sha256=3ceea06ba0e8e8bcab0386b5817b68cb30fce457eaa25ada0182891d66f6a0b9"
+    "sha512=e01f546a45b04cafd5fa262e9228e5a1aabd5e0942059c073a4181c928450baf3d990cc59ffb1a33dff445b46a0e218224a23dca96e8d24cdd0ab793d08e4538"
+  ]
+}
+x-commit-hash: "4c2501dba825ae9a6c8123ebcd95b1866251fc87"

--- a/packages/caqti-type-calendar/caqti-type-calendar.3.0.0/opam
+++ b/packages/caqti-type-calendar/caqti-type-calendar.3.0.0/opam
@@ -1,0 +1,31 @@
+opam-version: "2.0"
+maintainer: "Petter A. Urkedal <paurkedal@gmail.com>"
+x-maintenance-intent: ["(latest)"]
+authors: "Petter A. Urkedal <paurkedal@gmail.com>"
+license: "LGPL-3.0-or-later WITH LGPL-3.0-linking-exception"
+homepage: "https://github.com/paurkedal/ocaml-caqti/"
+doc: "https://paurkedal.github.io/ocaml-caqti/index.html"
+bug-reports: "https://github.com/paurkedal/ocaml-caqti/issues"
+depends: [
+  "caqti" {>= "3.0.0" & < "4.0.0~"}
+  "calendar" {>= "2.0"}
+  "dune" {>= "3.9"}
+  "ocaml"
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+  ["dune" "build" "@doc" "-p" name "-j" jobs] {with-doc}
+]
+dev-repo: "git+https://github.com/paurkedal/ocaml-caqti.git"
+synopsis: "Date and time field types using the calendar library"
+url {
+  src:
+    "https://github.com/paurkedal/ocaml-caqti/releases/download/v3.0.0/caqti-v3.0.0.tbz"
+  checksum: [
+    "sha256=3ceea06ba0e8e8bcab0386b5817b68cb30fce457eaa25ada0182891d66f6a0b9"
+    "sha512=e01f546a45b04cafd5fa262e9228e5a1aabd5e0942059c073a4181c928450baf3d990cc59ffb1a33dff445b46a0e218224a23dca96e8d24cdd0ab793d08e4538"
+  ]
+}
+x-commit-hash: "4c2501dba825ae9a6c8123ebcd95b1866251fc87"

--- a/packages/caqti-type-calendar/caqti-type-calendar.3.0.0/opam
+++ b/packages/caqti-type-calendar/caqti-type-calendar.3.0.0/opam
@@ -9,7 +9,7 @@ bug-reports: "https://github.com/paurkedal/ocaml-caqti/issues"
 depends: [
   "caqti" {>= "3.0.0" & < "4.0.0~"}
   "calendar" {>= "2.0"}
-  "dune" {>= "3.9"}
+  "dune" {>= "3.23.1"}
   "ocaml"
   "odoc" {with-doc}
 ]

--- a/packages/caqti/caqti.3.0.0/opam
+++ b/packages/caqti/caqti.3.0.0/opam
@@ -1,0 +1,69 @@
+opam-version: "2.0"
+maintainer: "Petter A. Urkedal <paurkedal@gmail.com>"
+x-maintenance-intent: ["(latest)"]
+authors: [
+  "Petter A. Urkedal <paurkedal@gmail.com>"
+  "Nathan Rebours <nathan@cryptosense.com>"
+  "Basile Clément"
+]
+license: "LGPL-3.0-or-later WITH LGPL-3.0-linking-exception"
+homepage: "https://github.com/paurkedal/ocaml-caqti/"
+doc: "https://paurkedal.github.io/ocaml-caqti/index.html"
+bug-reports: "https://github.com/paurkedal/ocaml-caqti/issues"
+depends: [
+  "alcotest" {with-test & >= "1.5.0"}
+  "angstrom" {>= "0.14.0"}
+  "bigstringaf"
+  "cmdliner" {with-test & >= "1.1.0"}
+  "domain-name" {>= "0.2.0"}
+  "dune" {>= "3.9"}
+  "dune-site"
+  "ipaddr" {>= "3.0.0"}
+  "logs"
+  "lru" {>= "0.3.1"}
+  "lwt-dllist"
+  "mdx" {with-test & >= "2.3.0"}
+  "mtime" {>= "2.0.0"}
+  "ocaml" {>= "4.08.0"}
+  "odoc" {with-doc}
+  "ptime"
+  "re" {with-test}
+  "uri" {>= "2.2.0"}
+  "x509"
+]
+conflicts: [
+  "result" {< "1.5"}
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs "@install"]
+  ["dune" "install" "-p" name "--create-install-file" name]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test & ocaml >= "5.1"} # Type.eq
+  ["dune" "build" "@doc" "-p" name "-j" jobs] {with-doc}
+]
+dev-repo: "git+https://github.com/paurkedal/ocaml-caqti.git"
+synopsis: "Unified interface to relational database libraries"
+description: """
+Caqti provides a monadic cooperative-threaded OCaml connector API for
+relational databases.
+
+The purpose of Caqti is further to help make applications independent of a
+particular database system. This is achieved by defining a common signature,
+which is implemented by the database drivers. Connection parameters are
+specified as an URI, which is typically provided at run-time. Caqti then
+loads a driver which can handle the URI, and provides a first-class module
+which implements the driver API and additional convenience functionality.
+
+Caqti does not make assumptions about the structure of the query language,
+and only provides the type information needed at the edges of communication
+between the OCaml code and the database; i.e. for encoding parameters and
+decoding returned tuples. It is hoped that this agnostic choice makes it a
+suitable target for higher level interfaces and code generators."""
+url {
+  src:
+    "https://github.com/paurkedal/ocaml-caqti/releases/download/v3.0.0/caqti-v3.0.0.tbz"
+  checksum: [
+    "sha256=3ceea06ba0e8e8bcab0386b5817b68cb30fce457eaa25ada0182891d66f6a0b9"
+    "sha512=e01f546a45b04cafd5fa262e9228e5a1aabd5e0942059c073a4181c928450baf3d990cc59ffb1a33dff445b46a0e218224a23dca96e8d24cdd0ab793d08e4538"
+  ]
+}
+x-commit-hash: "4c2501dba825ae9a6c8123ebcd95b1866251fc87"

--- a/packages/caqti/caqti.3.0.0/opam
+++ b/packages/caqti/caqti.3.0.0/opam
@@ -16,7 +16,7 @@ depends: [
   "bigstringaf"
   "cmdliner" {with-test & >= "1.1.0"}
   "domain-name" {>= "0.2.0"}
-  "dune" {>= "3.9"}
+  "dune" {>= "3.23.1"}
   "dune-site"
   "ipaddr" {>= "3.0.0"}
   "logs"

--- a/packages/dream/dream.1.0.0~alpha6/opam
+++ b/packages/dream/dream.1.0.0~alpha6/opam
@@ -48,8 +48,8 @@ depends: [
   "base-unix"
   "bigarray-compat"
   "camlp-streams"
-  "caqti" {>= "2.0.0"}
-  "caqti-lwt" {>= "2.0.0"}
+  "caqti" {>= "2.0.0" & < "3.0.0~"}
+  "caqti-lwt" {>= "2.0.0" & < "3.0.0~"}
   ("conf-libev" {os != "win32"} | "ocaml" {os = "win32"})
   "cstruct" {>= "6.0.0"}
   "digestif" {>= "0.7"}  # to_raw_string.

--- a/packages/dream/dream.1.0.0~alpha7/opam
+++ b/packages/dream/dream.1.0.0~alpha7/opam
@@ -50,8 +50,8 @@ depends: [
   "base-unix"
   "bigarray-compat"
   "camlp-streams"
-  "caqti" {>= "2.0.0"}
-  "caqti-lwt" {>= "2.0.0"}
+  "caqti" {>= "2.0.0" & < "3.0.0~"}
+  "caqti-lwt" {>= "2.0.0" & < "3.0.0~"}
   ("conf-libev" {os != "win32"} | "ocaml" {os = "win32"})
   "cstruct" {>= "6.0.0"}
   "digestif" {>= "0.7"}  # to_raw_string.

--- a/packages/dream/dream.1.0.0~alpha8/opam
+++ b/packages/dream/dream.1.0.0~alpha8/opam
@@ -50,8 +50,8 @@ depends: [
   "base-unix"
   "bigarray-compat"
   "camlp-streams"
-  "caqti" {>= "2.0.0"}
-  "caqti-lwt" {>= "2.0.0"}
+  "caqti" {>= "2.0.0" & < "3.0.0~"}
+  "caqti-lwt" {>= "2.0.0" & < "3.0.0~"}
   ("conf-libev" {os != "win32"} | "ocaml" {os = "win32"})
   "cstruct" {>= "6.0.0"}
   "digestif" {>= "0.7"}  # to_raw_string.

--- a/packages/guardian/guardian.0.4.0/opam
+++ b/packages/guardian/guardian.0.4.0/opam
@@ -15,9 +15,9 @@ depends: [
   "dune" {>= "2.9"}
   "alcotest" {with-test & >= "1.9.1"}
   "alcotest-lwt" {with-test}
-  "caqti" {>= "2.2.4"}
-  "caqti-driver-mariadb" {>= "2.0.1"}
-  "caqti-lwt" {>= "2.0.1"}
+  "caqti" {>= "2.2.4" & < "3.0.0~"}
+  "caqti-driver-mariadb" {>= "2.0.1" & < "3.0.0~"}
+  "caqti-lwt" {>= "2.0.1" & < "3.0.0~"}
   "containers" {>= "3.6"}
   "containers-data" {>= "3.6"}
   "dune-release" {with-dev-setup}

--- a/packages/migra/migra.1.0.0/opam
+++ b/packages/migra/migra.1.0.0/opam
@@ -16,9 +16,9 @@ depends: [
   "lwt" {>= "5.6.0"}
   "alcotest" {with-test & >= "1.7.0"}
   "alcotest-lwt" {with-test & >= "1.7.0"}
-  "caqti" {>= "2.0.0"}
-  "caqti-lwt" {>= "2.0.0"}
-  "caqti-dynload" {>= "2.0.0"}
+  "caqti" {>= "2.0.0" & < "3.0.0~"}
+  "caqti-lwt" {>= "2.0.0" & < "3.0.0~"}
+  "caqti-dynload" {>= "2.0.0" & < "3.0.0~"}
   "uri" {>= "4.4.0"}
   "cmdliner" {>= "2.0.0"}
   "logs" {>= "0.7.0"}

--- a/packages/migra/migra.1.0.1/opam
+++ b/packages/migra/migra.1.0.1/opam
@@ -17,9 +17,9 @@ depends: [
   "lwt" {>= "5.6.0"}
   "alcotest" {with-test & >= "1.7.0"}
   "alcotest-lwt" {with-test & >= "1.7.0"}
-  "caqti" {>= "2.0.0"}
-  "caqti-lwt" {>= "2.0.0"}
-  "caqti-dynload" {>= "2.0.0"}
+  "caqti" {>= "2.0.0" & < "3.0.0~"}
+  "caqti-lwt" {>= "2.0.0" & < "3.0.0~"}
+  "caqti-dynload" {>= "2.0.0" & < "3.0.0~"}
   "uri" {>= "4.4.0"}
   "cmdliner" {>= "2.0.0"}
   "logs" {>= "0.7.0"}

--- a/packages/migra/migra.2.0.0/opam
+++ b/packages/migra/migra.2.0.0/opam
@@ -17,9 +17,9 @@ depends: [
   "lwt" {>= "5.6.0"}
   "alcotest" {with-test & >= "1.7.0"}
   "alcotest-lwt" {with-test & >= "1.7.0"}
-  "caqti" {>= "2.0.0"}
-  "caqti-lwt" {>= "2.0.0"}
-  "caqti-dynload" {>= "2.0.0"}
+  "caqti" {>= "2.0.0" & < "3.0.0~"}
+  "caqti-lwt" {>= "2.0.0" & < "3.0.0~"}
+  "caqti-dynload" {>= "2.0.0" & < "3.0.0~"}
   "uri" {>= "4.4.0"}
   "cmdliner" {>= "2.0.0"}
   "logs" {>= "0.7.0"}

--- a/packages/migra/migra.2.1.0/opam
+++ b/packages/migra/migra.2.1.0/opam
@@ -17,9 +17,9 @@ depends: [
   "lwt" {>= "5.6.0"}
   "alcotest" {with-test & >= "1.7.0"}
   "alcotest-lwt" {with-test & >= "1.7.0"}
-  "caqti" {>= "2.0.0"}
-  "caqti-lwt" {>= "2.0.0"}
-  "caqti-dynload" {>= "2.0.0"}
+  "caqti" {>= "2.0.0" & < "3.0.0~"}
+  "caqti-lwt" {>= "2.0.0" & < "3.0.0~"}
+  "caqti-dynload" {>= "2.0.0" & < "3.0.0~"}
   "uri" {>= "4.4.0"}
   "cmdliner" {>= "2.0.0"}
   "logs" {>= "0.7.0"}

--- a/packages/migra/migra.2.1.1/opam
+++ b/packages/migra/migra.2.1.1/opam
@@ -17,9 +17,9 @@ depends: [
   "lwt" {>= "5.6.0"}
   "alcotest" {with-test & >= "1.7.0"}
   "alcotest-lwt" {with-test & >= "1.7.0"}
-  "caqti" {>= "2.0.0"}
-  "caqti-lwt" {>= "2.0.0"}
-  "caqti-dynload" {>= "2.0.0"}
+  "caqti" {>= "2.0.0" & < "3.0.0~"}
+  "caqti-lwt" {>= "2.0.0" & < "3.0.0~"}
+  "caqti-dynload" {>= "2.0.0" & < "3.0.0~"}
   "uri" {>= "4.4.0"}
   "cmdliner" {>= "2.0.0"}
   "logs" {>= "0.7.0"}

--- a/packages/migra/migra.2.2.0/opam
+++ b/packages/migra/migra.2.2.0/opam
@@ -17,9 +17,9 @@ depends: [
   "lwt" {>= "5.6.0"}
   "alcotest" {with-test & >= "1.7.0"}
   "alcotest-lwt" {with-test & >= "1.7.0"}
-  "caqti" {>= "2.0.0"}
-  "caqti-lwt" {>= "2.0.0"}
-  "caqti-dynload" {>= "2.0.0"}
+  "caqti" {>= "2.0.0" & < "3.0.0~"}
+  "caqti-lwt" {>= "2.0.0" & < "3.0.0~"}
+  "caqti-dynload" {>= "2.0.0" & < "3.0.0~"}
   "uri" {>= "4.4.0"}
   "cmdliner" {>= "2.0.0"}
   "logs" {>= "0.7.0"}

--- a/packages/petrol/petrol.1.0.0/opam
+++ b/packages/petrol/petrol.1.0.0/opam
@@ -14,9 +14,9 @@ depends: [
   "ocaml" {>= "4.12"}
   "dune" {>= "3.3"}
   "lwt" {>= "5.5"}
-  "caqti" {>= "1.8.0"}
-  "caqti-lwt" {>= "1.8.0"}
-  "caqti-driver-sqlite3" {>= "1.8.0"}
+  "caqti" {>= "1.8.0" & < "3.0.0~"}
+  "caqti-lwt" {>= "1.8.0" & < "3.0.0~"}
+  "caqti-driver-sqlite3" {>= "1.8.0" & < "3.0.0~"}
   "caqti-lwt" {with-test & < "2.0.0~"}
   "odoc" {with-doc}
 ]

--- a/packages/petrol/petrol.1.2.0/opam
+++ b/packages/petrol/petrol.1.2.0/opam
@@ -14,8 +14,8 @@ depends: [
   "ocaml" {>= "4.12"}
   "dune" {>= "3.3" & >= "3.3"}
   "lwt" {>= "5.5"}
-  "caqti" {>= "1.8.0"}
-  "caqti-lwt" {>= "1.8.0"}
+  "caqti" {>= "1.8.0" & < "3.0.0~"}
+  "caqti-lwt" {>= "1.8.0" & < "3.0.0~"}
   "caqti-driver-sqlite3" {with-test & >= "1.8.0"}
   "caqti-driver-postgresql" {with-test & >= "1.8.0"}
   "odoc" {with-doc}

--- a/packages/simple_httpd_caqti/simple_httpd_caqti.1.0.1/opam
+++ b/packages/simple_httpd_caqti/simple_httpd_caqti.1.0.1/opam
@@ -9,7 +9,7 @@ doc: "https://raffalli.eu/simple_httpd/simple_httpd"
 bug-reports: "https://github.com/craff/simple_httpd/issues"
 depends: [
   "dune" {>= "3.0"}
-  "caqti" {>= "2.2.3"}
+  "caqti" {>= "2.2.3" & < "3.0.0~"}
   "ipaddr"
   "simple_httpd" {= version}
   "logs" {>= "0.10.0"}

--- a/packages/simple_httpd_caqti/simple_httpd_caqti.1.0/opam
+++ b/packages/simple_httpd_caqti/simple_httpd_caqti.1.0/opam
@@ -9,7 +9,7 @@ doc: "https://raffalli.eu/simple_httpd/simple_httpd"
 bug-reports: "https://github.com/craff/simple_httpd/issues"
 depends: [
   "dune" {>= "3.0"}
-  "caqti" {>= "2.2.3"}
+  "caqti" {>= "2.2.3" & < "3.0.0~"}
   "ipaddr"
   "simple_httpd" {= version}
   "logs" {>= "0.10.0"}

--- a/packages/vif/vif.0.0.1~beta3/opam
+++ b/packages/vif/vif.0.0.1~beta3/opam
@@ -30,7 +30,7 @@ depends: [
   "tyxml" {>= "4.6.0"}
   "hurl" {>= "0.0.1~beta2" & with-test}
   "jws" {with-test}
-  "caqti" {with-test & >= "2.3.0"}
+  "caqti" {with-test & >= "2.3.0" & < "3.0.0~"}
   "caqti-miou" {with-test}
   "caqti-driver-sqlite3" {with-test}
   "brr" {with-test}


### PR DESCRIPTION
This major release includes all packages.

Changes:

  - The `caqti` library now holds the Caqti 3 API and `caqti.classic`
    contains a Caqti 2 compatibility wrapper.  Users of the Caqti 2 API must
    now add `caqti.classic` to their link lines.  Early adopters of the
    Caqti 3 API must replace `caqti.template` with `caqti` and adjust some
    module paths.  Switching to the new API is recommended, but may be done
    incrementally for existing applications.

  - Fixed initial comma when formatting rows, affecting
    `Caqti_type.pp_value` (Caqti 2) and `Caqti.Template.Row.pp` (Caqti 3).

  - Put on hold deprecation of the `caqti-dynload` package due to
    [issue #140](https://github.com/paurkedal/ocaml-caqti/issues/140).

  - Foreign key constraints are now enabled for SQLite by default.
