### PR TITLE
[new release] ppx_deriving_jsonschema (0.0.8)

### DIFF
--- a/packages/ppx_deriving_jsonschema/ppx_deriving_jsonschema.0.0.8/opam
+++ b/packages/ppx_deriving_jsonschema/ppx_deriving_jsonschema.0.0.8/opam
@@ -1,0 +1,57 @@
+opam-version: "2.0"
+synopsis: "Jsonschema generator for ppx_deriving"
+description:
+  "ppx_deriving_jsonschema is a ppx rewriter that generates jsonschema from ocaml types"
+maintainer: [
+  "Louis Roché <louis.roche@ahrefs.com>"
+  "Koonwen Lee <koonwen.lee@ahrefs.com>"
+  "Ahrefs <github@ahrefs.com>"
+]
+authors: [
+  "Louis Roché <louis.roche@ahrefs.com>" "Ahrefs <github@ahrefs.com>"
+]
+license: "MIT"
+tags: ["jsonschema" "org:ahrefs" "syntax"]
+homepage: "https://github.com/ahrefs/ppx_deriving_jsonschema"
+doc: "https://ahrefs.github.io/ppx_deriving_jsonschema/"
+bug-reports: "https://github.com/ahrefs/ppx_deriving_jsonschema/issues"
+depends: [
+  "ocaml" {>= "5.0.0"}
+  "dune" {>= "3.16"}
+  "ppxlib" {> "0.36.0"}
+  "melange" {>= "4.0.0"}
+  "server-reason-react" {>= "0.4.1"}
+  "melange-json" {>= "2.0.0" & with-test}
+  "melange-json-native" {>= "2.0.0" & with-test}
+  "yojson" {with-test}
+  "conf-npm" {with-test}
+  "conf-python-3" {with-test}
+  "ocamlformat" {= "0.29.0" & with-dev-setup}
+  "ocaml-lsp-server" {with-dev-setup}
+  "odoc-driver" {with-doc}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/ahrefs/ppx_deriving_jsonschema.git"
+url {
+  src:
+    "https://github.com/ahrefs/ppx_deriving_jsonschema/releases/download/0.0.8/ppx_deriving_jsonschema-0.0.8.tbz"
+  checksum: [
+    "sha256=c5a2f8c1d906c1890bcde81aa149cc38e479878eb6c1c45a8455d03a95a07c2e"
+    "sha512=c0e661717244bf62132a21ef975db2720597b1d8013b0221c1d7db5adfc14928caf675c0f2fd89869ee6f4f96527599e556a0c123cd9dc7f65cad8f81de322ef"
+  ]
+}
+x-commit-hash: "09ffcd964bf21f436deb878c2056e71acc56ac3a"


### PR DESCRIPTION
Jsonschema generator for ppx_deriving

- Project page: <a href="https://github.com/ahrefs/ppx_deriving_jsonschema">https://github.com/ahrefs/ppx_deriving_jsonschema</a>
- Documentation: <a href="https://ahrefs.github.io/ppx_deriving_jsonschema/">https://ahrefs.github.io/ppx_deriving_jsonschema/</a>

##### CHANGES:

- add runtime primitive schema modules under `Ppx_deriving_jsonschema_runtime.Primitives` for Yojson and Melange JSON backends; generated code now uses the selected primitive bindings, including backend-specific `int64` handling and Melange JSON `result` schemas
- add `Ppx_deriving_jsonschema_runtime.declassify` and simplify `[@jsonschema.default]` serialization so non-primitive and parametric default values can be converted through their generated `*_to_json` functions
- fix `type nonrec` and other non-recursive type declarations so aliases are not treated as recursive self-references
- add `[@@jsonschema.compact_variants]` support on polymorphic variant type declarations
- document primitive modules, result schemas, `compact_variants`, and the completed `[@jsonschema.attrs]` example in the README
- update GitHub Actions used by build and documentation workflows
