### PR TITLE
[new release] ppx_deriving_variant_string (1.1.0)

### DIFF
--- a/packages/ppx_deriving_variant_string/ppx_deriving_variant_string.1.1.0/opam
+++ b/packages/ppx_deriving_variant_string/ppx_deriving_variant_string.1.1.0/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+synopsis: "OCaml PPX deriver that generates converters between variants and strings"
+description: "OCaml PPX deriver that generates converters between regular or polymorphic variants and strings. Supports both OCaml and Reason casing."
+maintainer: [
+  "Javier Chávarri <javier.chavarri@ahrefs.com>"
+]
+authors: [
+  "Javier Chávarri <javier.chavarri@ahrefs.com>"
+]
+tags: ["syntax" "org:ahrefs"]
+license: "MIT"
+homepage: "https://github.com/ahrefs/ppx_deriving_variant_string"
+bug-reports: "https://github.com/ahrefs/ppx_deriving_variant_string/issues"
+dev-repo: "git+https://github.com/ahrefs/ppx_deriving_variant_string.git"
+depends: [
+  "ocaml"
+  "dune" {>= "3.8"}
+  "ppxlib" {>= "0.23.0"}
+  "ounit" {with-test}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+  ]
+]
+url {
+  src:
+    "https://github.com/ahrefs/ppx_deriving_variant_string/releases/download/1.1.0/ppx_deriving_variant_string-1.1.0.tbz"
+  checksum: [
+    "sha256=db89b9de2c061db45f4f3c6200dd39e42277ccbcd9e12ca5d968b6f140e54c14"
+    "sha512=a7f9752e7beb9eb22a60dd0fdd5200c6e6cfed03945c0049cf618d91f31fb0d1c9fc5fca83cf4895be95c975cb56b7374a1868b0730b0604fe2b8a81e2a2d909"
+  ]
+}
+x-commit-hash: "62203ec0bec4e6d9d754d03ab0ee0918fc044617"


### PR DESCRIPTION
OCaml PPX deriver that generates converters between variants and strings

- Project page: <a href="https://github.com/ahrefs/ppx_deriving_variant_string">https://github.com/ahrefs/ppx_deriving_variant_string</a>

##### CHANGES:

- Import upstream deriver improvements:
  - add `[@name]` as an alias for `[@as]`
  - generate `fromStringExn` and `of_string_exn`
  - support polymorphic variant inheritance
  - add payload-constructor opt-ins with `[@no_args]`, `[@no_string_exn]`, and
    polymorphic-variant-only `[@no_string]`
