### PR TITLE
some lwt not compatible with cygwin

### DIFF
--- a/packages/lwt/lwt.5.10.0/opam
+++ b/packages/lwt/lwt.5.10.0/opam
@@ -54,6 +54,7 @@ build: [
     "@doc" {with-doc}
   ]
 ]
+available: [ os != "cygwin" ]
 x-maintenance-intent:[ "(latest)" ]
 url {
   src: "https://github.com/ocsigen/lwt/archive/refs/tags/5.10.0.tar.gz"

--- a/packages/lwt/lwt.5.10.1/opam
+++ b/packages/lwt/lwt.5.10.1/opam
@@ -54,6 +54,7 @@ build: [
     "@doc" {with-doc}
   ]
 ]
+available: [ os != "cygwin" ]
 x-maintenance-intent:[ "(latest)" ]
 url {
   src: "https://github.com/ocsigen/lwt/archive/refs/tags/5.10.1.tar.gz"

--- a/packages/lwt/lwt.5.9.2/opam
+++ b/packages/lwt/lwt.5.9.2/opam
@@ -54,6 +54,7 @@ build: [
     "@doc" {with-doc}
   ]
 ]
+available: [ os != "cygwin" ]
 x-maintenance-intent:[ "(latest)" ]
 url {
   src: "https://github.com/ocsigen/lwt/archive/refs/tags/5.9.2.tar.gz"


### PR DESCRIPTION
as per https://github.com/ocsigen/lwt/issues/1081, some lwt versions are broken on cygwin

i'm not sure that `os != "cygwin"` covers all cases of lwt being compiled under cygwin, but afaiu all cases where `os` is `"cygwin"` is lwt being compiled under cygwin.

ping @dra27 who knows more about windows