### PR TITLE
[new package] chatoyant (0.12.0)

### DIFF
--- a/packages/chatoyant/chatoyant.0.12.0/opam
+++ b/packages/chatoyant/chatoyant.0.12.0/opam
@@ -1,0 +1,67 @@
+opam-version: "2.0"
+synopsis: "OCaml-first LLM SDK with Melange-generated JavaScript"
+description:
+  "Chatoyant is an OCaml-first SDK for LLM providers. It exposes an Eio native API, typed JSON Schema and tool definitions, raw provider clients for OpenAI/Anthropic/xAI/OpenRouter/local inference, and a Melange-generated JavaScript package."
+maintainer: ["Anonyfox <max@anonyfox.com>"]
+authors: ["Anonyfox <max@anonyfox.com>"]
+license: "MIT"
+tags: [
+  "llm"
+  "ai"
+  "openai"
+  "anthropic"
+  "xai"
+  "openrouter"
+  "json-schema"
+  "eio"
+  "melange"
+  "typesafe"
+]
+homepage: "https://github.com/Anonyfox/chatoyant"
+doc: "https://anonyfox.github.io/chatoyant"
+bug-reports: "https://github.com/Anonyfox/chatoyant/issues"
+depends: [
+  "ocaml" {>= "5.3"}
+  "dune" {>= "3.23"}
+  "melange" {>= "6.0.0"}
+  "ca-certs"
+  "base64"
+  "cohttp-eio"
+  "digestif"
+  "domain-name"
+  "eio" {>= "1.0"}
+  "eio_main" {with-test}
+  "http"
+  "mirage-crypto-rng"
+  "ppxlib" {build}
+  "tls"
+  "tls-eio"
+  "uri"
+  "x509"
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/Anonyfox/chatoyant.git"
+x-maintenance-intent: ["(latest)"]
+url {
+  src:
+    "https://github.com/Anonyfox/chatoyant/releases/download/v0.12.0/chatoyant-v0.12.0.tbz"
+  checksum: [
+    "sha256=b921b52378f9f3c762932abb1bf60e60a1afc39b5f5e2dd0c8063d7731872622"
+    "sha512=4b6d1ee5d223e5cf29aae37e18b2c8fe9f87b004c9af89dfed2380cd3b22d5b4fae778299fe28be52f2ad040d286f07aa4ae51f329cde05209b404654dde00d0"
+  ]
+}
+x-commit-hash: "70e361723598af3884ad941b294f1de535b8de13"


### PR DESCRIPTION
First release of **chatoyant**: an OCaml-first SDK for LLM providers.

It exposes an Eio native API with typed provider clients for OpenAI, Anthropic, xAI, OpenRouter, and local OpenAI-compatible servers, plus structured outputs via a standalone Draft 2020-12 JSON Schema parser/validator, typed tool definitions (`module%tool` PPX and `[@@deriving chatoyant]`), streaming, and token/cost accounting. The same sources also generate the `chatoyant` npm package via Melange.

- Homepage / sources: https://github.com/Anonyfox/chatoyant
- Documentation: https://anonyfox.github.io/chatoyant
- Tarball: attached to the [v0.12.0 release](https://github.com/Anonyfox/chatoyant/releases/tag/v0.12.0); checksums generated by dune-release.
- Supports OCaml >= 5.3 (eio >= 1.0, melange >= 6). Tests run offline (`with-test` needs no network or API keys).

🤖 Generated with [Claude Code](https://claude.com/claude-code)