### PR TITLE
disable tests for ppx_minidebug.2.{3,4}.0

### DIFF
--- a/packages/ppx_minidebug/ppx_minidebug.2.3.0/opam
+++ b/packages/ppx_minidebug/ppx_minidebug.2.3.0/opam
@@ -12,7 +12,7 @@ doc: "https://lukstafi.github.io/ppx_minidebug/ppx_minidebug"
 bug-reports: "https://github.com/lukstafi/ppx_minidebug/issues"
 depends: [
   "ocaml" {>= "5.3.0"}
-  "dune" {>= "3.10"}
+  "dune" {>= "3.10" & < "3.24"} # test
   "ppx_deriving"
   "ppx_sexp_conv" {>= "v0.17.1"}
   "ppxlib" {>= "0.36.0"}

--- a/packages/ppx_minidebug/ppx_minidebug.2.3.0/opam
+++ b/packages/ppx_minidebug/ppx_minidebug.2.3.0/opam
@@ -12,7 +12,7 @@ doc: "https://lukstafi.github.io/ppx_minidebug/ppx_minidebug"
 bug-reports: "https://github.com/lukstafi/ppx_minidebug/issues"
 depends: [
   "ocaml" {>= "5.3.0"}
-  "dune" {>= "3.10" & < "3.24"} # test
+  "dune" {>= "3.10"}
   "ppx_deriving"
   "ppx_sexp_conv" {>= "v0.17.1"}
   "ppxlib" {>= "0.36.0"}
@@ -39,7 +39,6 @@ build: [
     "-j"
     jobs
     "@install"
-    "@runtest" {with-test}
     "@doc" {with-doc}
   ]
 ]

--- a/packages/ppx_minidebug/ppx_minidebug.2.4.0/opam
+++ b/packages/ppx_minidebug/ppx_minidebug.2.4.0/opam
@@ -12,7 +12,7 @@ doc: "https://lukstafi.github.io/ppx_minidebug/ppx_minidebug"
 bug-reports: "https://github.com/lukstafi/ppx_minidebug/issues"
 depends: [
   "ocaml" {>= "5.3.0"}
-  "dune" {>= "3.10"}
+  "dune" {>= "3.10" & < "3.24"} # test
   "ppx_deriving"
   "ppx_sexp_conv" {>= "v0.17.1"}
   "ppxlib" {>= "0.36.0" & != "0.36.2"}

--- a/packages/ppx_minidebug/ppx_minidebug.2.4.0/opam
+++ b/packages/ppx_minidebug/ppx_minidebug.2.4.0/opam
@@ -12,7 +12,7 @@ doc: "https://lukstafi.github.io/ppx_minidebug/ppx_minidebug"
 bug-reports: "https://github.com/lukstafi/ppx_minidebug/issues"
 depends: [
   "ocaml" {>= "5.3.0"}
-  "dune" {>= "3.10" & < "3.24"} # test
+  "dune" {>= "3.10"}
   "ppx_deriving"
   "ppx_sexp_conv" {>= "v0.17.1"}
   "ppxlib" {>= "0.36.0" & != "0.36.2"}
@@ -39,7 +39,6 @@ build: [
     "-j"
     jobs
     "@install"
-    "@runtest" {with-test}
     "@doc" {with-doc}
   ]
 ]


### PR DESCRIPTION
There is reason to believe these are failing due to brittle text fixtures, creating noise in revdeps runs for other packages.

See the discussion in https://github.com/ocaml/opam-repository/pull/30157#issuecomment-4869638367 and preceding.

The CI results in the initial commit https://github.com/ocaml/opam-repository/pull/30183/commits/c6c567d6087e231c7275ad0de9fe63bef911abf7 show that the tests for these package versions fail due to unsatisfied expectations in the test expectations, such as

```
#=== ERROR while compiling ppx_minidebug.2.4.0 ================================#
# context              2.5.1 | linux/x86_64 | ocaml-base-compiler.5.4.1 | pinned(https://github.com/lukstafi/ppx_minidebug/archive/refs/tags/2.4.0.6.tar.gz)
# path                 ~/.opam/5.4/.opam-switch/build/ppx_minidebug.2.4.0
# command              ~/.opam/opam-init/hooks/sandbox.sh build dune build -p ppx_minidebug -j 71 @install @runtest
# exit-code            1
# env-file             ~/.opam/log/ppx_minidebug-7-7a4b62.env
# output-file          ~/.opam/log/ppx_minidebug-7-7a4b62.out
### output ###
# File "test/test_debug_log_nothing.expected.ml", line 1, characters 0-0:
# /usr/bin/git --no-pager diff --no-index --color=always -u _build/default/test/test_debug_log_nothing.expected.ml _build/default/test/test_debug_log_nothing.actual.ml
# diff --git a/_build/default/test/test_debug_log_nothing.expected.ml b/_build/default/test/test_debug_log_nothing.actual.ml
# index 6c38ebb..69024dd 100644
# --- a/_build/default/test/test_debug_log_nothing.expected.ml
# +++ b/_build/default/test/test_debug_log_nothing.actual.ml
# @@ -2,10 +2,10 @@ module Debug_runtime = (val
#    Minidebug_runtime.debug_flushing ~filename:"debugger_show_log_nothing" ())
#  ;;()
#  let rec loop_exceeded (x : int) =
# -  (let z = (); (x - 1) / 2 in
# +  (let z : int = (); (x - 1) / 2 in
#     if x <= 0 then 0 else z + (loop_exceeded (z + (x / 2))) : int)
#  let () =
#    try print_endline @@ (Int.to_string @@ (loop_exceeded 17))
#    with | _ -> print_endline "Raised exception."
# -let bar () = (for i = 0 to 100 do let _baz = i * 2 in () done : unit)
# +let bar () = (for i = 0 to 100 do let _baz : int = i * 2 in () done : unit)
#  let () = try bar () with | _ -> print_endline "Raised exception."
# File "test/test_debug_pp.expected.ml", line 1, characters 0-0:
# /usr/bin/git --no-pager diff --no-index --color=always -u _build/default/test/test_debug_pp.expected.ml _build/default/test/test_debug_pp.actual.ml
# diff --git a/_build/default/test/test_debug_pp.expected.ml b/_build/default/test/test_debug_pp.actual.ml
# index 315c5bb..dd128a7 100644
# --- a/_build/default/test/test_debug_pp.expected.ml
# +++ b/_build/default/test/test_debug_pp.actual.ml
# @@ -13,7 +13,7 @@ let bar (x : t) =
#          ~entry_id:__entry_id ~log_level:1 `Debug;
#        Debug_runtime.log_value_pp ?descr:(Some "x") ~entry_id:__entry_id
#          ~log_level:1 ~pp ~is_result:false (lazy x));
# -     (match let y =
# +     (match let y : num =
#                let __entry_id = Debug_runtime.get_entry_id () in
#                ();
#                Debug_runtime.open_log ~fname:"test_debug_pp.ml" ~start_lnum:8
# @@ -55,7 +55,7 @@ let baz (x : t) =
#          ~entry_id:__entry_id ~log_level:1 `Debug;
#        Debug_runtime.log_value_pp ?descr:(Some "x") ~entry_id:__entry_id
#          ~log_level:1 ~pp ~is_result:false (lazy x));
# -     (match let { first = y; second = z } as _yz =
# +     (match let ({ first = y; second = z } as _yz) : t =
#                let __entry_id = Debug_runtime.get_entry_id () in
#                ();
#                Debug_runtime.open_log ~fname:"test_debug_pp.ml" ~start_lnum:14
# @@ -107,7 +107,7 @@ let rec loop (depth : num) (x : t) =
#                  loop (depth + 1)
#                    { first = (x.second + 1); second = (x.first / 2) }
#                else
# -                (let y =
# +                (let y : num =
#                     let __entry_id = Debug_runtime.get_entry_id () in
#                     ();
#                     Debug_runtime.open_log ~fname:"test_debug_pp.ml"
# @@ -130,7 +130,7 @@ let rec loop (depth : num) (x : t) =
#                          (Debug_runtime.close_log ~fname:"test_debug_pp.ml"
#                             ~start_lnum:23 ~entry_id:__entry_id;
#                           raise e)) in
# -                 let z =
# +                 let z : num =
#                     let __entry_id = Debug_runtime.get_entry_id () in
#                     ();
#                     Debug_runtime.open_log ~fname:"test_debug_pp.ml"
# File "test/test_debug_log_level_consistency.expected.ml", line 1, characters 0-0:
# /usr/bin/git --no-pager diff --no-index --color=always -u _build/default/test/test_debug_log_level_consistency.expected.ml _build/default/test/test_debug_log_level_consistency.actual.ml
# diff --git a/_build/default/test/test_debug_log_level_consistency.expected.ml b/_build/default/test/test_debug_log_level_consistency.actual.ml
# index d984a8e..8ec8f16 100644
# --- a/_build/default/test/test_debug_log_level_consistency.expected.ml
# +++ b/_build/default/test/test_debug_log_level_consistency.actual.ml
# @@ -23,7 +23,7 @@ let foo (x : int) =
#          ~message:"foo" ~entry_id:__entry_id ~log_level:1 `Debug;
#        Debug_runtime.log_value_show ?descr:(Some "x") ~entry_id:__entry_id
#          ~log_level:1 ~is_result:false (lazy (([%show : int]) x)));
# -     (match let y =
# +     (match let y : int =
#                let __entry_id = Debug_runtime.get_entry_id () in
#                ();
#                Debug_runtime.open_log
# File "test/test_debug_interrupts.expected.ml", line 1, characters 0-0:
# /usr/bin/git --no-pager diff --no-index --color=always -u _build/default/test/test_debug_interrupts.expected.ml _build/default/test/test_debug_interrupts.actual.ml
# diff --git a/_build/default/test/test_debug_interrupts.expected.ml b/_build/default/test/test_debug_interrupts.actual.ml
# index 33f9d5c..4395698 100644
# --- a/_build/default/test/test_debug_interrupts.expected.ml
# +++ b/_build/default/test/test_debug_interrupts.actual.ml
# @@ -29,7 +29,7 @@ let rec loop_exceeded (x : int) =
#             ~start_lnum:8 ~entry_id:__entry_id;
#           failwith "ppx_minidebug: max_nesting_depth exceeded")
#        else
# -        (match let z =
# +        (match let z : int =
#                   let __entry_id = Debug_runtime.get_entry_id () in
#                   ();
#                   if Debug_runtime.exceeds_max_children ()
# @@ -141,7 +141,7 @@ let bar () =
#                                failwith
#                                  "ppx_minidebug: max_nesting_depth exceeded")
#                             else
# -                             (match let _baz =
# +                             (match let _baz : int =
#                                        let __entry_id =
#                                          Debug_runtime.get_entry_id () in
#                                        ();
# File "test/test_debug_sexp.expected.ml", line 1, characters 0-0:
# /usr/bin/git --no-pager diff --no-index --color=always -u _build/default/test/test_debug_sexp.expected.ml _build/default/test/test_debug_sexp.actual.ml
# diff --git a/_build/default/test/test_debug_sexp.expected.ml b/_build/default/test/test_debug_sexp.actual.ml
# index 80c432f..bb4c0d5 100644
# --- a/_build/default/test/test_debug_sexp.expected.ml
# +++ b/_build/default/test/test_debug_sexp.actual.ml
# @@ -10,7 +10,7 @@ let foo (x : int) =
#        ~entry_id:__entry_id ~log_level:1 `Debug;
#      Debug_runtime.log_value_sexp ?descr:(Some "x") ~entry_id:__entry_id
#        ~log_level:1 ~is_result:false (lazy (([%sexp_of : int]) x)));
# -   (match let y =
# +   (match let y : int =
#              let __entry_id = Debug_runtime.get_entry_id () in
#              ();
#              Debug_runtime.open_log ~fname:"test_debug_sexp.ml" ~start_lnum:10
# @@ -54,7 +54,7 @@ let bar (x : t) =
#        ~entry_id:__entry_id ~log_level:1 `Debug;
#      Debug_runtime.log_value_sexp ?descr:(Some "x") ~entry_id:__entry_id
#        ~log_level:1 ~is_result:false (lazy (([%sexp_of : t]) x)));
# -   (match let y =
# +   (match let y : int =
#              let __entry_id = Debug_runtime.get_entry_id () in
#              ();
#              Debug_runtime.open_log ~fname:"test_debug_sexp.ml" ~start_lnum:18
# @@ -95,7 +95,7 @@ let baz (x : t) =
#        ~entry_id:__entry_id ~log_level:1 `Debug;
#      Debug_runtime.log_value_sexp ?descr:(Some "x") ~entry_id:__entry_id
#        ~log_level:1 ~is_result:false (lazy (([%sexp_of : t]) x)));
# -   (match let (y, z) as _yz =
# +   (match let ((y, z) as _yz) : (int * int) =
#              let __entry_id = Debug_runtime.get_entry_id () in
#              ();
#              Debug_runtime.open_log ~fname:"test_debug_sexp.ml" ~start_lnum:24
# @@ -114,7 +114,7 @@ let baz (x : t) =
#                   (Debug_runtime.close_log ~fname:"test_debug_sexp.ml"
#                      ~start_lnum:24 ~entry_id:__entry_id;
#                    raise e)) in
# -          let (u, w) as _uw =
# +          let ((u, w) as _uw) : (int * int) =
#              let __entry_id = Debug_runtime.get_entry_id () in
#              ();
#              Debug_runtime.open_log ~fname:"test_debug_sexp.ml" ~start_lnum:25
```

Maybe it's due to changes in the ppxlib or the compiler. In any case, this creates noise in revdeps tests, so the next commit disables the tests.

FYI @lukstafi 