### PR TITLE
disable ppx_factory.0.2.0 tests

### DIFF
--- a/packages/ppx_factory/ppx_factory.0.2.0/opam
+++ b/packages/ppx_factory/ppx_factory.0.2.0/opam
@@ -12,11 +12,8 @@ doc: "https://cryptosense.github.io/ppx_factory/doc"
 build: [
   [ "dune" "build" "-p" name "-j" jobs ]
 ]
-run-test: [
-  [ "dune" "runtest" "-p" name "-j" jobs ]
-]
 depends: [
-  "dune" {>= "1.1" & < "3.24"} # test
+  "dune" {>= "1.1"}
   "ocaml" {>= "4.07.0"}
   "ounit" {with-test & >= "2.0.0"}
   "ppxlib" {>= "0.14.0"}

--- a/packages/ppx_factory/ppx_factory.0.2.0/opam
+++ b/packages/ppx_factory/ppx_factory.0.2.0/opam
@@ -16,7 +16,7 @@ run-test: [
   [ "dune" "runtest" "-p" name "-j" jobs ]
 ]
 depends: [
-  "dune" {>= "1.1"}
+  "dune" {>= "1.1" & < "3.24"} # test
   "ocaml" {>= "4.07.0"}
   "ounit" {with-test & >= "2.0.0"}
   "ppxlib" {>= "0.14.0"}


### PR DESCRIPTION
These tests are failing currently due to brittle test fixtures on all platforms.

The errors can be seen on the first commit, https://github.com/ocaml/opam-repository/pull/30187/commits/4b3a7b162dea0d3cbbc259360eba85438236a204

```
#=== ERROR while compiling ppx_factory.0.2.0 ==================================#
# context              2.5.1 | linux/x86_64 | ocaml-base-compiler.4.11.2 | pinned(https://github.com/cryptosense/ppx_factory/releases/download/0.2.0/ppx_factory-0.2.0.tbz)
# path                 ~/.opam/4.11/.opam-switch/build/ppx_factory.0.2.0
# command              ~/.opam/opam-init/hooks/sandbox.sh build dune runtest -p ppx_factory -j 255
# exit-code            1
# env-file             ~/.opam/log/ppx_factory-7-d6ccea.env
# output-file          ~/.opam/log/ppx_factory-7-d6ccea.out
### output ###
# File "test/deriver/pp_factory.expected.ml", line 1, characters 0-0:
# /usr/bin/git --no-pager diff --no-index --color=always -u _build/default/test/deriver/pp_factory.expected.ml _build/default/test/deriver/pp_factory.actual.ml
# diff --git a/_build/default/test/deriver/pp_factory.expected.ml b/_build/default/test/deriver/pp_factory.actual.ml
# index 04c1268..f6b1c20 100644
# --- a/_build/default/test/deriver/pp_factory.expected.ml
# +++ b/_build/default/test/deriver/pp_factory.actual.ml
# @@ -70,8 +70,8 @@ module Types :
#        other_field: A.B.t }[@@deriving factory]
#      include
#        struct
# -        let simple_record_factory ?(int_field= 0)  ?(string_field= "") 
# -          ?(other_field= A.B.default)  () =
# +        let simple_record_factory ?(int_field= 0) ?(string_field= "")
# +          ?(other_field= A.B.default) () =
#            { int_field; string_field; other_field }
#        end[@@ocaml.doc "@inline"][@@merlin.hide ]
#      type simple_variant =
# @@ -84,11 +84,11 @@ module Types :
#      include
#        struct
#          let simple_variant_a_factory () = A
# -        let simple_variant_b_factory ?(tup0= 0)  () = B tup0
# -        let simple_variant_c_factory ?(tup0= 0)  ?(tup1= "")  () =
# +        let simple_variant_b_factory ?(tup0= 0) () = B tup0
# +        let simple_variant_c_factory ?(tup0= 0) ?(tup1= "") () =
#            C (tup0, tup1)
# -        let simple_variant_d_factory ?(int_field= 0)  ?(string_field= "")  ()
# -          = D { int_field; string_field }
# +        let simple_variant_d_factory ?(int_field= 0) ?(string_field= "") () =
# +          D { int_field; string_field }
#        end[@@ocaml.doc "@inline"][@@merlin.hide ]
#      type record_with_options =
#        {
# @@ -97,15 +97,15 @@ module Types :
#        nested: int option option }[@@deriving factory]
#      include
#        struct
# -        let record_with_options_factory ?(non_optional= 0)  ?optional 
# -          ?nested  () = { non_optional; optional; nested }
# +        let record_with_options_factory ?(non_optional= 0) ?optional ?nested
# +          () = { non_optional; optional; nested }
#        end[@@ocaml.doc "@inline"][@@merlin.hide ]
#      type 'a parametrized = {
#        param: 'a option ;
#        non_paramed: string }[@@deriving factory]
#      include
#        struct
# -        let parametrized_factory ?param  ?(non_paramed= "")  () =
# +        let parametrized_factory ?param ?(non_paramed= "") () =
#            { param; non_paramed }
#        end[@@ocaml.doc "@inline"][@@merlin.hide ]
#      type copied = simple_record =
# @@ -115,8 +115,7 @@ module Types :
#        other_field: A.B.t }[@@deriving factory]
#      include
#        struct
# -        let copied_factory ?(int_field= 0)  ?(string_field= "") 
# -          ?(other_field= A.B.default)  () =
# -          { int_field; string_field; other_field }
# +        let copied_factory ?(int_field= 0) ?(string_field= "") ?(other_field=
# +          A.B.default) () = { int_field; string_field; other_field }
#        end[@@ocaml.doc "@inline"][@@merlin.hide ]
#    end 
# (cd _build/default/test/lib && ./test_ppx_factory_lib.exe)
# ...................
# Ran: 19 tests in: 0.12 seconds.
# OK
```

This second commit disables the tests.