### PR TITLE
[new package] chatoyant (0.12.1)

### DIFF
--- a/packages/chatoyant/chatoyant.0.12.1/opam
+++ b/packages/chatoyant/chatoyant.0.12.1/opam
@@ -1,0 +1,67 @@
+opam-version: "2.0"
+synopsis: "OCaml-first LLM SDK with Melange-generated JavaScript"
+description:
+  "Chatoyant is an OCaml-first SDK for LLM providers. It exposes an Eio native API, typed JSON Schema and tool definitions, raw provider clients for OpenAI/Anthropic/xAI/OpenRouter/local inference, and a Melange-generated JavaScript package."
+maintainer: ["Anonyfox <max@anonyfox.com>"]
+authors: ["Anonyfox <max@anonyfox.com>"]
+license: "MIT"
+tags: [
+  "llm"
+  "ai"
+  "openai"
+  "anthropic"
+  "xai"
+  "openrouter"
+  "json-schema"
+  "eio"
+  "melange"
+  "typesafe"
+]
+homepage: "https://github.com/Anonyfox/chatoyant"
+doc: "https://anonyfox.github.io/chatoyant"
+bug-reports: "https://github.com/Anonyfox/chatoyant/issues"
+depends: [
+  "ocaml" {>= "5.3"}
+  "dune" {>= "3.23"}
+  "melange" {>= "6.0.0"}
+  "ca-certs" {>= "1.0.0"}
+  "base64"
+  "cohttp-eio" {>= "6.0.0"}
+  "digestif"
+  "domain-name"
+  "eio" {>= "1.0"}
+  "eio_main" {with-test}
+  "http" {>= "6.0.0"}
+  "mirage-crypto-rng" {>= "1.0.0"}
+  "ppxlib" {build}
+  "tls" {>= "1.0.0"}
+  "tls-eio" {>= "1.0.0"}
+  "uri"
+  "x509" {>= "1.0.0"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/Anonyfox/chatoyant.git"
+x-maintenance-intent: ["(latest)"]
+url {
+  src:
+    "https://github.com/Anonyfox/chatoyant/releases/download/v0.12.1/chatoyant-v0.12.1.tbz"
+  checksum: [
+    "sha256=72752addb69fe17825f43f5a861f8d0a7817f6a5a711916e722023e10679daff"
+    "sha512=d1a62989e34f8b9173d4c53f8e17c611900855df8a139888e73ee509b445ef1e65105c17bb399bf25712a893a251827513f18ed36d0e2b3fcc908fb00584c6f3"
+  ]
+}
+x-commit-hash: "e034611e8425b6c67fb3b89fc66fd7ed7f08382e"


### PR DESCRIPTION
Release of **chatoyant** 0.12.1: an OCaml-first SDK for LLM providers
(OpenAI, Anthropic, xAI, OpenRouter, local OpenAI-compatible servers) with an
Eio native API, typed tools and structured outputs, streaming, and token/cost
accounting.

- Sources: https://github.com/Anonyfox/chatoyant
- Changes: https://github.com/Anonyfox/chatoyant/blob/main/CHANGELOG.md
- Tests run offline (`with-test` needs no network or API keys).

🤖 Generated with [Claude Code](https://claude.com/claude-code)