### PR TITLE
[new release] uring (2.15.0)

### DIFF
--- a/packages/uring/uring.2.15.0/opam
+++ b/packages/uring/uring.2.15.0/opam
@@ -1,0 +1,57 @@
+opam-version: "2.0"
+synopsis: "OCaml bindings for Linux io_uring"
+description:
+  "Bindings to the Linux io_uring kernel IO interfaces. See https://github.com/ocaml-multicore/eio for a higher-level API using this."
+maintainer: ["anil@recoil.org"]
+authors: ["Anil Madhavapeddy" "Sadiq Jaffer" "Thomas Leonard"]
+homepage: "https://github.com/ocaml-multicore/ocaml-uring"
+doc: "https://ocaml-multicore.github.io/ocaml-uring/"
+bug-reports: "https://github.com/ocaml-multicore/ocaml-uring/issues"
+depends: [
+  "dune" {>= "3.0"}
+  "cstruct" {>= "6.0.1"}
+  "ocaml" {>= "5.2.0"}
+  "dune-configurator"
+  "lwt" {with-test & >= "5.0.0"}
+  "bechamel" {>= "0.1.0" & with-test}
+  "logs" {with-test & >= "0.5.0"}
+  "cmdliner" {with-test & >= "1.1.0"}
+  "fmt" {>= "0.8.10"}
+  "optint" {>= "0.1.0"}
+  "mdx" {>= "2.1.0" & with-test}
+  "lintcstubs-arity" {with-test}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/ocaml-multicore/ocaml-uring.git"
+depexts: [
+  ["linux-headers"] {os-distribution = "alpine"}
+]
+available: [os = "linux"]
+license: ["ISC" "MIT"]
+x-ci-accept-failures: [
+  "centos-7" # default C compiler does not support stdatomic.h
+  "oraclelinux-7" # default C compiler does not support stdatomic.h
+]
+url {
+  src:
+    "https://github.com/ocaml-multicore/ocaml-uring/releases/download/v2.15.0/uring-2.15.0.tbz"
+  checksum: [
+    "sha256=30ad45e6d4dbbd94f9324c99af3dbcfa78f8f98a3c5717710810c782151d3186"
+    "sha512=0f101c1a68f8de1f4d05614d1284beb0755cffa82605c48df6e9b7a336249f614d0eb46f9626063ac96fca5345b248abf4cb193a9d00047bd1edb3c1aa714c7c"
+  ]
+}
+x-commit-hash: "bc4c85c3fe07c9372cc181cbda546e3ee3cc557e"


### PR DESCRIPTION
OCaml bindings for Linux io_uring

- Project page: <a href="https://github.com/ocaml-multicore/ocaml-uring">https://github.com/ocaml-multicore/ocaml-uring</a>
- Documentation: <a href="https://ocaml-multicore.github.io/ocaml-uring/">https://ocaml-multicore.github.io/ocaml-uring/</a>

##### CHANGES:

Breaking changes:

- Require OCaml >= 5.2 (@talex5 @avsm ocaml-multicore/ocaml-uring#144).

Other new features:

- Update to liburing 2.15 (@avsm ocaml-multicore/ocaml-uring#157).

- Add `shutdown`, `socket`, `renameat` and `symlinkat` ops (@avsm ocaml-multicore/ocaml-uring#147).

- Add `fallocate` and `ftruncate` ops (@avsm ocaml-multicore/ocaml-uring#149).

- Allow setting socket flags on socket creation, and default the
  `socket` binding to set `CLOEXEC` by default (@avsm ocaml-multicore/ocaml-uring#151).

- Add per-operation `RWF` flags to `read`/`write` submissions (@avsm ocaml-multicore/ocaml-uring#154).

- Add bindings for vectored `readv`/`writev` on fixed buffers (@avsm ocaml-multicore/ocaml-uring#155).

Bug fixes:

- Fix inverted mask check in `Statx.Attr.check` (@avsm @talex5 ocaml-multicore/ocaml-uring#142 ocaml-multicore/ocaml-uring#159).

- Fix `dio_offset_align` statx getter returning the wrong field (@avsm ocaml-multicore/ocaml-uring#141).

- Give `caml_uring_wait_cqe` the same null-cqe check as the timeout
  variant and reuse the OCaml runtime's socket table. (@avsm ocaml-multicore/ocaml-uring#148).

- Report errors from `io_uring_submit` rather than ignoring them (@talex5 ocaml-multicore/ocaml-uring#144).

- Add a bounds check to `Region.init` and simplify the slot calculation
  (@dra27 ocaml-multicore/ocaml-uring#128, @avsm ocaml-multicore/ocaml-uring#145).

- Fix `URING_DEBUG` format-string warnings (@avsm ocaml-multicore/ocaml-uring#146).

- Hardcode rename flags for compat with older musl versions (@avsm ocaml-multicore/ocaml-uring#147).

Build and tests:

- Don't use `/tmp` in the configure test, to work with sandboxed opam builds
  (@talex5 ocaml-multicore/ocaml-uring#158).

- Regenerate primops and make `lintcstubs-arity` a test dependency
  (@avsm ocaml-multicore/ocaml-uring#143, based on @dra27 in ocaml-multicore/ocaml-uring#128).
