### PR TITLE
ocgtk 0.1-preview2: fix install

### DIFF
--- a/packages/ocgtk/ocgtk.0.1~preview2/opam
+++ b/packages/ocgtk/ocgtk.0.1~preview2/opam
@@ -29,6 +29,9 @@ build: [
     "@doc" {with-doc}
   ]
 ]
+install: [
+  ["dune" "install" "-p" name "--prefix" "%{prefix}%" "--libdir" "%{lib}%"]
+]
 x-commit-hash: "42ca3a6346b84123f86a34f84b82f33bd20fdaf7"
 url {
   src:


### PR DESCRIPTION
I just realised that my ocgtk.0.1-preview2 release is not working because of the way my release tarball is structured internally, with the ocgtk dune-project at a subdirectory level. This causes the .install file not to be generated at the root of the project where opam expects it.

This is a patch to correct it to use dune to complete the install for this version. I'll restructure my project and create separate release tarballs for the next release.

