### PR TITLE
Package lmdb.1.1.2

### DIFF
--- a/packages/lmdb/lmdb.1.1.2/opam
+++ b/packages/lmdb/lmdb.1.1.2/opam
@@ -1,0 +1,52 @@
+opam-version: "2.0"
+maintainer: "Gabriel Radanne <drupyog@zoho.com>"
+synopsis: "Bindings for LMDB, a fast in-file database with ACID transactions"
+authors: [
+  "Gabriel Radanne <drupyog@zoho.com>"
+  "Christopher Zimmermann <christopher@gmerlin.de>"
+]
+license: "MIT"
+homepage: "https://github.com/Drup/ocaml-lmdb"
+bug-reports: "https://github.com/Drup/ocaml-lmdb/issues"
+dev-repo: "git+https://github.com/Drup/ocaml-lmdb.git"
+doc: "https://drup.github.io/ocaml-lmdb/dev/lmdb/Lmdb/index.html"
+tags: [ "clib:lmdb" "database" ]
+build: [
+  ["ocamlbuild" "build"]
+  ["ocamlbuild" "src/lmdb.docdir/index.html"] { with-doc }
+]
+install: [
+  ["ocamlbuild" "install"]
+]
+run-test: [
+  ["ocamlbuild" "test"]
+]
+depends: [
+  "ocaml" {>= "4.07"}
+  "ocamlbuild" {>= "0.16.1"}
+  "ocamlfind"
+  "alcotest" {with-test}
+  "conf-pkg-config" {build}
+]
+
+depexts: [
+  ["liblmdb-dev"] {os-family = "debian" | os-family = "ubuntu"}
+  ["lmdb"] {os-family = "bsd"}
+#  ["lmdb"] {os-family = "homebrew"}
+#  ["lmdb"] {os-family = "macports"}
+  ["lmdb"] {os-family = "archlinux"}
+  ["lmdb"] {os-family = "gentoo"}
+  ["lmdb"] {os-distribution = "nixos"}
+  ["lmdb-dev"] {os-family = "alpine"}
+  ["lmdb-devel"] {os-family = "centos"}
+  ["lmdb-devel"] {os-family = "fedora"}
+  ["lmdb-devel"] {os-family = "suse" | os-family = "opensuse"}
+  ["liblmdb-devel"] {os-family = "mageia"}
+]
+url {
+  src: "https://github.com/Drup/ocaml-lmdb/archive/aa64578f9fb11f6f73c5e011f0859daa0cd91a28.tar.gz"
+  checksum: [
+    "md5=76e69bc2275e5d8974559c5893a5665e"
+    "sha512=36b6123bbfea30d48e936431e2dd5dda29cd310407e7db53b087c7dc06a305073a84eca78ec4f7ac5fe9673f546f253afce4ed8d61bf4b6f7d055da677254ad9"
+  ]
+}

--- a/packages/lmdb/lmdb.1.1.2/opam
+++ b/packages/lmdb/lmdb.1.1.2/opam
@@ -32,8 +32,8 @@ depends: [
 depexts: [
   ["liblmdb-dev"] {os-family = "debian" | os-family = "ubuntu"}
   ["lmdb"] {os-family = "bsd"}
-#  ["lmdb"] {os-family = "homebrew"}
-#  ["lmdb"] {os-family = "macports"}
+  ["lmdb"] {os-family = "homebrew"}
+  ["lmdb"] {os-family = "macports"}
   ["lmdb"] {os-family = "archlinux"}
   ["lmdb"] {os-family = "gentoo"}
   ["lmdb"] {os-distribution = "nixos"}

--- a/packages/lmdb/lmdb.1.1.2/opam
+++ b/packages/lmdb/lmdb.1.1.2/opam
@@ -44,9 +44,9 @@ depexts: [
   ["liblmdb-devel"] {os-family = "mageia"}
 ]
 url {
-  src: "https://github.com/Drup/ocaml-lmdb/archive/aa64578f9fb11f6f73c5e011f0859daa0cd91a28.tar.gz"
+  src: "https://github.com/Drup/ocaml-lmdb/archive/refs/tags/1.1.2.tar.gz"
   checksum: [
-    "md5=76e69bc2275e5d8974559c5893a5665e"
-    "sha512=36b6123bbfea30d48e936431e2dd5dda29cd310407e7db53b087c7dc06a305073a84eca78ec4f7ac5fe9673f546f253afce4ed8d61bf4b6f7d055da677254ad9"
+    "md5=d7f70c6ddf0c78d57553eb56d1ece44a"
+    "sha512=220a9ff943673671be002f1c26f5dd0ababaae6e8e2b55e5f83c41bbab47c5007e8a150016fc1266f5a8c1fc6cda4230c343fe7304e40ff94e63069a21980b7b"
   ]
 }

--- a/packages/lmdb/lmdb.1.1.3/opam
+++ b/packages/lmdb/lmdb.1.1.3/opam
@@ -1,0 +1,51 @@
+opam-version: "2.0"
+maintainer: "Gabriel Radanne <drupyog@zoho.com>"
+synopsis: "Bindings for LMDB, a fast in-file database with ACID transactions"
+authors: [
+  "Gabriel Radanne <drupyog@zoho.com>"
+  "Christopher Zimmermann <christopher@gmerlin.de>"
+]
+license: "MIT"
+homepage: "https://github.com/Drup/ocaml-lmdb"
+bug-reports: "https://github.com/Drup/ocaml-lmdb/issues"
+dev-repo: "git+https://github.com/Drup/ocaml-lmdb.git"
+doc: "https://drup.github.io/ocaml-lmdb/dev/lmdb/Lmdb/index.html"
+tags: [ "clib:lmdb" "database" ]
+build: [
+  ["ocamlbuild" "build"]
+  ["ocamlbuild" "src/lmdb.docdir/index.html"] { with-doc }
+]
+install: [
+  ["ocamlbuild" "install"]
+]
+run-test: [
+  ["ocamlbuild" "test"]
+]
+depends: [
+  "ocaml" {>= "4.07"}
+  "ocamlbuild" {>= "0.16.1"}
+  "ocamlfind"
+  "alcotest" {with-test}
+  "conf-pkg-config" {build}
+]
+
+depexts: [
+  ["liblmdb-dev"] {os-family = "debian" | os-family = "ubuntu"}
+  ["lmdb"] {os-family = "bsd"}
+  ["lmdb"] {os-family = "homebrew"}
+  ["lmdb"] {os-family = "macports"}
+  ["lmdb"] {os-family = "archlinux"}
+  ["lmdb"] {os-family = "gentoo"}
+  ["lmdb"] {os-distribution = "nixos"}
+  ["lmdb-dev"] {os-family = "alpine"}
+  ["lmdb-devel"] {os-family = "centos"}
+  ["lmdb-devel"] {os-family = "fedora"}
+  ["lmdb-devel"] {os-family = "suse" | os-family = "opensuse"}
+  ["liblmdb-devel"] {os-family = "mageia"}
+]
+url {
+  src: "https://github.com/Drup/ocaml-lmdb/archive/refs/tags/1.1.3.tar.gz"
+  checksum: [
+    "sha512=aeae2d5c686ce327b2c862aef618eed1bf5b54b2f7bf356eed39c6cf92858a2d7f5cd3ac8d47ce511de157dd62dc1b078a72bcb458e308bfb654c37bf92e396e"
+  ]
+}


### PR DESCRIPTION
- Switch to build system to ocamlbuild
  - Configuration is now done in `myocamlbuild.ml`: finding lmdb backend, fallback to shipped backend
  - hopefully more reliable on windows and OSX
- remove dependency on `bigstringaf`
- upgrade shipped backend to 1.0.0
- add two phase commits and rollback