### PR TITLE
[new release] ocamlgrep (2 packages) (0.1.1)

### DIFF
--- a/packages/ocamlgrep-lib/ocamlgrep-lib.0.1.1/opam
+++ b/packages/ocamlgrep-lib/ocamlgrep-lib.0.1.1/opam
@@ -9,7 +9,7 @@ depends: [
   "ocaml" {>= "4.14"}
   "dune" {>= "3.18" & >= "3.18"}
   "cppo"
-  "csexp"
+  "csexp" {>= "1.4.0"}
   "fpath"
   "yojson" {>= "3.0.0"}
   "odoc" {with-doc}

--- a/packages/ocamlgrep-lib/ocamlgrep-lib.0.1.1/opam
+++ b/packages/ocamlgrep-lib/ocamlgrep-lib.0.1.1/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+synopsis: "OCaml structural grep library"
+maintainer: ["Martin Jambon <martin@mjambon.com>"]
+authors: ["Edwin Ansari" "Nicolás Ojeda Bär" "Martin Jambon"]
+license: "MIT"
+homepage: "https://github.com/LexiFi/ocamlgrep"
+bug-reports: "https://github.com/LexiFi/ocamlgrep/issues"
+depends: [
+  "ocaml" {>= "4.14"}
+  "dune" {>= "3.18" & >= "3.18"}
+  "cppo"
+  "csexp"
+  "fpath"
+  "yojson"
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/LexiFi/ocamlgrep.git"
+x-maintenance-intent: ["(latest)"]
+url {
+  src:
+    "https://github.com/LexiFi/ocamlgrep/releases/download/0.1.1/ocamlgrep-0.1.1.tbz"
+  checksum: [
+    "sha256=4444a8c53217f81b63d8de0c5a34cbd4c01a2e06d97e14f8969996a75104cc7d"
+    "sha512=7d48fd2e882cc5ab775d26cf0a8d450ba268949d9a08e91f541ec851b0bc91a6a9d36e60ec75b52aabfe947f7b32e2a7afa50a7aa21e5a4a026710791ed9ca0c"
+  ]
+}
+x-commit-hash: "221636188920afa23fc022ef3c726a45ee4ca462"

--- a/packages/ocamlgrep-lib/ocamlgrep-lib.0.1.1/opam
+++ b/packages/ocamlgrep-lib/ocamlgrep-lib.0.1.1/opam
@@ -7,7 +7,7 @@ homepage: "https://github.com/LexiFi/ocamlgrep"
 bug-reports: "https://github.com/LexiFi/ocamlgrep/issues"
 depends: [
   "ocaml" {>= "4.14"}
-  "dune" {>= "3.18" & >= "3.18"}
+  "dune" {>= "3.18"}
   "cppo"
   "csexp" {>= "1.4.0"}
   "fpath"

--- a/packages/ocamlgrep-lib/ocamlgrep-lib.0.1.1/opam
+++ b/packages/ocamlgrep-lib/ocamlgrep-lib.0.1.1/opam
@@ -11,8 +11,9 @@ depends: [
   "cppo"
   "csexp"
   "fpath"
-  "yojson"
+  "yojson" {>= "3.0.0"}
   "odoc" {with-doc}
+  "testo" {>= "0.5.0" & with-test}
 ]
 build: [
   ["dune" "subst"] {dev}

--- a/packages/ocamlgrep/ocamlgrep.0.1.1/opam
+++ b/packages/ocamlgrep/ocamlgrep.0.1.1/opam
@@ -7,7 +7,7 @@ homepage: "https://github.com/LexiFi/ocamlgrep"
 bug-reports: "https://github.com/LexiFi/ocamlgrep/issues"
 depends: [
   "ocaml"
-  "dune" {>= "3.18" & >= "3.18"}
+  "dune" {>= "3.18"}
   "cmdliner" {>= "1.1.0"}
   "ocamlgrep-lib" {= version}
   "menhir" {with-test}

--- a/packages/ocamlgrep/ocamlgrep.0.1.1/opam
+++ b/packages/ocamlgrep/ocamlgrep.0.1.1/opam
@@ -1,0 +1,42 @@
+opam-version: "2.0"
+synopsis: "OCaml structural grep tool"
+maintainer: ["Martin Jambon <martin@mjambon.com>"]
+authors: ["Edwin Ansari" "Nicolás Ojeda Bär" "Martin Jambon"]
+license: "MIT"
+homepage: "https://github.com/LexiFi/ocamlgrep"
+bug-reports: "https://github.com/LexiFi/ocamlgrep/issues"
+depends: [
+  "ocaml"
+  "dune" {>= "3.18" & >= "3.18"}
+  "cmdliner" {>= "1.1.0"}
+  "ocamlgrep-lib" {= version}
+  "menhir" {with-test}
+  "ppx_deriving" {with-test}
+  "testo" {with-test}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/LexiFi/ocamlgrep.git"
+x-maintenance-intent: ["(latest)"]
+url {
+  src:
+    "https://github.com/LexiFi/ocamlgrep/releases/download/0.1.1/ocamlgrep-0.1.1.tbz"
+  checksum: [
+    "sha256=4444a8c53217f81b63d8de0c5a34cbd4c01a2e06d97e14f8969996a75104cc7d"
+    "sha512=7d48fd2e882cc5ab775d26cf0a8d450ba268949d9a08e91f541ec851b0bc91a6a9d36e60ec75b52aabfe947f7b32e2a7afa50a7aa21e5a4a026710791ed9ca0c"
+  ]
+}
+x-commit-hash: "221636188920afa23fc022ef3c726a45ee4ca462"


### PR DESCRIPTION
OCaml structural grep tool

- Project page: <a href="https://github.com/LexiFi/ocamlgrep">https://github.com/LexiFi/ocamlgrep</a>

##### CHANGES:

* Fix the build so as to not require test-only dependencies for the
  main build ([LexiFi/ocamlgrep#20](https://github.com/LexiFi/ocamlgrep/pull/20)).
* Add a `--dune-root` option that allows running ocamlgrep on a Dune
  project built with `--root` such as a test project within
  another Dune project ([LexiFi/ocamlgrep#20](https://github.com/LexiFi/ocamlgrep/pull/20)).
