### PR TITLE
[new package] union-find-lattice v0.1.0

### DIFF
--- a/packages/union-find-lattice/union-find-lattice.0.1.0/opam
+++ b/packages/union-find-lattice/union-find-lattice.0.1.0/opam
@@ -1,0 +1,54 @@
+opam-version: "2.0"
+synopsis:
+  "Persistent union-find data-structures with lattice operations (order, meet, join)"
+maintainer: [
+  "Dorian Lesbre <dorian.lesbre@cea.fr>"
+  "Matthieu Lemerre <matthieu.lemerre@cea.fr>"
+]
+authors: [
+  "Dorian Lesbre <dorian.lesbre@cea.fr>"
+  "Matthieu Lemerre <matthieu.lemerre@cea.fr>"
+]
+license: "lgpl-2.1-or-later"
+tags: ["union-find" "persistent" "lattice" "join" "meet"]
+homepage: "https://codex.top/api/union-find-lattice"
+doc: "https://codex.top/api/union-find-lattice"
+bug-reports:
+  "https://github.com/codex-semantics-library/union-find-lattice/issues"
+depends: [
+  "dune" {>= "3.21"}
+  "ocaml"
+  "patricia-tree"
+  "qcheck" {> "0.90.0" & with-test}
+  "mdx" {with-test}
+  "zarith" {with-test}
+  "csv" {with-dev-setup}
+  "ISO8601" {with-dev-setup}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo:
+  "git+https://github.com/codex-semantics-library/union-find-lattice.git"
+x-maintenance-intent: ["(latest)"]
+url {
+  src:
+    "https://github.com/codex-semantics-library/union-find-lattice/releases/download/v0.1.0/union-find-lattice-0.1.0.tbz"
+  checksum: [
+    "sha256=1be8dd819367abb5a6ee830fe5f077013f45d2d5e2416eadf7eb620efa2e3ccb"
+    "sha512=74649cd6f6441468ba66a966f38f96496bbd87a14a0d972d83b0033eea95a918f185871f30a1510cbb24e4b261088c21adc7a03d4619cd36fc9b60ed93d5917e"
+  ]
+}
+x-commit-hash: "97f4ede597853051819bd0ab0adb3e5cf0c3cff5"

--- a/packages/union-find-lattice/union-find-lattice.0.1.0/opam
+++ b/packages/union-find-lattice/union-find-lattice.0.1.0/opam
@@ -47,8 +47,8 @@ url {
   src:
     "https://github.com/codex-semantics-library/union-find-lattice/releases/download/v0.1.0/union-find-lattice-0.1.0.tbz"
   checksum: [
-    "sha256=5a184c20d5ee329b8e2b8c61aad4c645aa25596d9057ba44b1d06a43bdd89071"
-    "sha512=68d44fb110f4fd43d7c03738e8cc610af4b669accad420c2a36f8eac6f317d91f92458c2f25f96bc5337b706848eac00e159e15a4ded1e9c9d019b7ae281010c"
+    "sha256=ecaf1444cd0e9d21174d854da0d2eea56d685180cc1e098016e2c66bc809f8ab"
+    "sha512=f12612357504879f78094ffa623bf44ec87c7f7adeeea1809c0b74fdf41e51a88958634d51d3f8bd8881c577a635ef81beaff91d0361195f9a65a5724ce096a9"
   ]
 }
-x-commit-hash: "38bac16680499ae9a9f9ccdbdb1cadd896c0cef1"
+x-commit-hash: "59934ba190af6a28f361129dbdfebcf614faefee"

--- a/packages/union-find-lattice/union-find-lattice.0.1.0/opam
+++ b/packages/union-find-lattice/union-find-lattice.0.1.0/opam
@@ -18,7 +18,7 @@ bug-reports:
 depends: [
   "dune" {>= "3.21"}
   "ocaml"
-  "patricia-tree"
+  "patricia-tree" {>= "0.14.0"}
   "qcheck" {> "0.90.0" & with-test}
   "mdx" {with-test}
   "zarith" {with-test}
@@ -47,8 +47,8 @@ url {
   src:
     "https://github.com/codex-semantics-library/union-find-lattice/releases/download/v0.1.0/union-find-lattice-0.1.0.tbz"
   checksum: [
-    "sha256=1be8dd819367abb5a6ee830fe5f077013f45d2d5e2416eadf7eb620efa2e3ccb"
-    "sha512=74649cd6f6441468ba66a966f38f96496bbd87a14a0d972d83b0033eea95a918f185871f30a1510cbb24e4b261088c21adc7a03d4619cd36fc9b60ed93d5917e"
+    "sha256=5a184c20d5ee329b8e2b8c61aad4c645aa25596d9057ba44b1d06a43bdd89071"
+    "sha512=68d44fb110f4fd43d7c03738e8cc610af4b669accad420c2a36f8eac6f317d91f92458c2f25f96bc5337b706848eac00e159e15a4ded1e9c9d019b7ae281010c"
   ]
 }
-x-commit-hash: "97f4ede597853051819bd0ab0adb3e5cf0c3cff5"
+x-commit-hash: "38bac16680499ae9a9f9ccdbdb1cadd896c0cef1"


### PR DESCRIPTION
Release a new library that provides a persistent union-find data-structure with lattice operations. These are described in the documentation, and in more detail, in our SAS 2026 paper (to be published by october), Lesbre & Lemerre, *A Lattice of Union-finds*.

- Repository: https://github.com/codex-semantics-library/union-find-lattice
- Documentation: https://codex.top/api/union-find-lattice/

CHANGES:
- initial release of this library.