### PR TITLE
Release OCaml/Unikraft 1.2.0

### DIFF
--- a/packages/ocaml-unikraft-arm64/ocaml-unikraft-arm64.1.2.0/opam
+++ b/packages/ocaml-unikraft-arm64/ocaml-unikraft-arm64.1.2.0/opam
@@ -1,0 +1,44 @@
+opam-version: "2.0"
+maintainer: "samuel@tarides.com"
+homepage: "https://github.com/mirage/ocaml-unikraft/"
+dev-repo: "git+https://github.com/mirage/ocaml-unikraft.git"
+bug-reports: "https://github.com/mirage/ocaml-unikraft/issues"
+tags: "org:mirage"
+synopsis: "OCaml cross compiler to the freestanding Unikraft arm64 backends"
+description:
+  "This package provides an OCaml cross compiler, suitable for linking with a Unikraft arm64 unikernel."
+authors: "Samuel Hym"
+license: ["MIT" "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"]
+depends: [
+  "ocaml" {>= "5.3.0" & <= "5.5.0"}
+  "ocaml-unikraft-toolchain-arm64" {>= "1.2.0" & < "1.2.1"}
+  "ocamlfind"
+  "ocaml-src" {build}
+  "opatch" {build}
+]
+build: [
+  [
+    make
+    "-j%{jobs}%"
+    "prefix=%{prefix}%"
+    "BIN=%{bin}%"
+    "LIB=%{lib}%"
+    "SHARE=%{share}%"
+    "OCUKARCH=arm64"
+    "%{name}%.install"
+  ]
+]
+install: [
+  [make "install-ocaml"]
+]
+conflicts: ["ocaml-option-bytecode-only" "relocatable"]
+# The package is not completely relocatable yet as the ocamlfind toolchain
+# description contains absolute paths
+url {
+  src:
+    "https://github.com/mirage/ocaml-unikraft/archive/refs/tags/v1.2.0.tar.gz"
+  checksum:
+    "sha256=ca18a45ef86791d5ffa18436945fbec850b6f3dd68a6a62753b4cb1b6999b19a"
+}
+available: os = "linux"
+x-maintenance-intent: ["(latest)"]

--- a/packages/ocaml-unikraft-backend-firecracker-arm64/ocaml-unikraft-backend-firecracker-arm64.1.2.0-0.20.0/opam
+++ b/packages/ocaml-unikraft-backend-firecracker-arm64/ocaml-unikraft-backend-firecracker-arm64.1.2.0-0.20.0/opam
@@ -1,0 +1,49 @@
+opam-version: "2.0"
+maintainer: "samuel@tarides.com"
+homepage: "https://github.com/mirage/ocaml-unikraft/"
+dev-repo: "git+https://github.com/mirage/ocaml-unikraft.git"
+bug-reports: "https://github.com/mirage/ocaml-unikraft/issues"
+tags: "org:mirage"
+synopsis: "Firecracker/arm64 Unikraft backend for OCaml"
+authors: ["Samuel Hym" "Unikraft contributors"]
+license: ["MIT" "BSD-3-Clause" "GPL-2.0-only"]
+depends: [
+  "unikraft" {= "0.20.0"}
+  "unikraft-musl" {= "0.20.0"}
+  "conf-aarch64-linux-gnu-gcc" {arch != "arm64"}
+]
+depopts: [
+  "ocaml-unikraft-option-debug"
+  "ocaml-unikraft-option-9pfs"
+  "ocaml-unikraft-custom-configs"
+]
+build: [
+  [
+    make
+    "-j%{jobs}%"
+    "UNIKRAFT=%{unikraft:lib}%"
+    "UNIKRAFTMUSL=%{unikraft-musl:lib}%"
+    "OCUKPLAT=firecracker"
+    "OCUKARCH=arm64"
+    "OCUKEXTLIBS=musl"
+    "OCUKCONFIGOPTS+=debug" {ocaml-unikraft-option-debug:installed}
+    "OCUKCONFIGOPTS+=9pfs" {ocaml-unikraft-option-9pfs:installed}
+    "OCUKCUSTOMCFGDIR=%{ocaml-unikraft-custom-configs:share}%"
+      {ocaml-unikraft-custom-configs:installed}
+    "UK_CFLAGS=-std=gnu11"
+    "%{name}%.install"
+  ]
+]
+x-ci-accept-failures: [
+  "debian-11" "opensuse-15.6"
+  # Unikraft 0.20.0 is incompatible with the version of GCC in those
+  # distributions
+]
+url {
+  src:
+    "https://github.com/mirage/ocaml-unikraft/archive/refs/tags/v1.2.0.tar.gz"
+  checksum:
+    "sha256=ca18a45ef86791d5ffa18436945fbec850b6f3dd68a6a62753b4cb1b6999b19a"
+}
+available: os = "linux"
+x-maintenance-intent: ["(latest)"]

--- a/packages/ocaml-unikraft-backend-firecracker-x86_64/ocaml-unikraft-backend-firecracker-x86_64.1.2.0-0.20.0/opam
+++ b/packages/ocaml-unikraft-backend-firecracker-x86_64/ocaml-unikraft-backend-firecracker-x86_64.1.2.0-0.20.0/opam
@@ -1,0 +1,49 @@
+opam-version: "2.0"
+maintainer: "samuel@tarides.com"
+homepage: "https://github.com/mirage/ocaml-unikraft/"
+dev-repo: "git+https://github.com/mirage/ocaml-unikraft.git"
+bug-reports: "https://github.com/mirage/ocaml-unikraft/issues"
+tags: "org:mirage"
+synopsis: "Firecracker/x86_64 Unikraft backend for OCaml"
+authors: ["Samuel Hym" "Unikraft contributors"]
+license: ["MIT" "BSD-3-Clause" "GPL-2.0-only"]
+depends: [
+  "unikraft" {= "0.20.0"}
+  "unikraft-musl" {= "0.20.0"}
+  "conf-x86_64-linux-gnu-gcc" {arch != "x86_64"}
+]
+depopts: [
+  "ocaml-unikraft-option-debug"
+  "ocaml-unikraft-option-9pfs"
+  "ocaml-unikraft-custom-configs"
+]
+build: [
+  [
+    make
+    "-j%{jobs}%"
+    "UNIKRAFT=%{unikraft:lib}%"
+    "UNIKRAFTMUSL=%{unikraft-musl:lib}%"
+    "OCUKPLAT=firecracker"
+    "OCUKARCH=x86_64"
+    "OCUKEXTLIBS=musl"
+    "OCUKCONFIGOPTS+=debug" {ocaml-unikraft-option-debug:installed}
+    "OCUKCONFIGOPTS+=9pfs" {ocaml-unikraft-option-9pfs:installed}
+    "OCUKCUSTOMCFGDIR=%{ocaml-unikraft-custom-configs:share}%"
+      {ocaml-unikraft-custom-configs:installed}
+    "UK_CFLAGS=-std=gnu11"
+    "%{name}%.install"
+  ]
+]
+x-ci-accept-failures: [
+  "debian-11" "opensuse-15.6"
+  # Unikraft 0.20.0 is incompatible with the version of GCC in those
+  # distributions
+]
+url {
+  src:
+    "https://github.com/mirage/ocaml-unikraft/archive/refs/tags/v1.2.0.tar.gz"
+  checksum:
+    "sha256=ca18a45ef86791d5ffa18436945fbec850b6f3dd68a6a62753b4cb1b6999b19a"
+}
+available: os = "linux"
+x-maintenance-intent: ["(latest)"]

--- a/packages/ocaml-unikraft-backend-firecracker/ocaml-unikraft-backend-firecracker.1.2.0-0.20.0/opam
+++ b/packages/ocaml-unikraft-backend-firecracker/ocaml-unikraft-backend-firecracker.1.2.0-0.20.0/opam
@@ -1,0 +1,21 @@
+opam-version: "2.0"
+maintainer: "samuel@tarides.com"
+homepage: "https://github.com/mirage/ocaml-unikraft/"
+dev-repo: "git+https://github.com/mirage/ocaml-unikraft.git"
+bug-reports: "https://github.com/mirage/ocaml-unikraft/issues"
+tags: "org:mirage"
+synopsis:
+  "Virtual package to ensure the Firecracker Unikraft backend is installed for the default cross compiler"
+description:
+  "This virtual package ensures that the Firecracker backend is installed for the default `unikraft` ocamlfind cross toolchain."
+authors: "Samuel Hym"
+license: "MIT"
+depends: [
+  "ocaml-unikraft" {= "1.2.0"}
+  ("ocaml-unikraft-default-x86_64" {= "1.2.0"} &
+    "ocaml-unikraft-backend-firecracker-x86_64" {= version}) |
+  ("ocaml-unikraft-default-arm64" {= "1.2.0"} &
+    "ocaml-unikraft-backend-firecracker-arm64" {= version})
+]
+available: os = "linux"
+x-maintenance-intent: ["(latest)"]

--- a/packages/ocaml-unikraft-backend-qemu-arm64/ocaml-unikraft-backend-qemu-arm64.1.2.0-0.20.0/opam
+++ b/packages/ocaml-unikraft-backend-qemu-arm64/ocaml-unikraft-backend-qemu-arm64.1.2.0-0.20.0/opam
@@ -1,0 +1,49 @@
+opam-version: "2.0"
+maintainer: "samuel@tarides.com"
+homepage: "https://github.com/mirage/ocaml-unikraft/"
+dev-repo: "git+https://github.com/mirage/ocaml-unikraft.git"
+bug-reports: "https://github.com/mirage/ocaml-unikraft/issues"
+tags: "org:mirage"
+synopsis: "QEMU/arm64 Unikraft backend for OCaml"
+authors: ["Samuel Hym" "Unikraft contributors"]
+license: ["MIT" "BSD-3-Clause" "GPL-2.0-only"]
+depends: [
+  "unikraft" {= "0.20.0"}
+  "unikraft-musl" {= "0.20.0"}
+  "conf-aarch64-linux-gnu-gcc" {arch != "arm64"}
+]
+depopts: [
+  "ocaml-unikraft-option-debug"
+  "ocaml-unikraft-option-9pfs"
+  "ocaml-unikraft-custom-configs"
+]
+build: [
+  [
+    make
+    "-j%{jobs}%"
+    "UNIKRAFT=%{unikraft:lib}%"
+    "UNIKRAFTMUSL=%{unikraft-musl:lib}%"
+    "OCUKPLAT=qemu"
+    "OCUKARCH=arm64"
+    "OCUKEXTLIBS=musl"
+    "OCUKCONFIGOPTS+=debug" {ocaml-unikraft-option-debug:installed}
+    "OCUKCONFIGOPTS+=9pfs" {ocaml-unikraft-option-9pfs:installed}
+    "OCUKCUSTOMCFGDIR=%{ocaml-unikraft-custom-configs:share}%"
+      {ocaml-unikraft-custom-configs:installed}
+    "UK_CFLAGS=-std=gnu11"
+    "%{name}%.install"
+  ]
+]
+x-ci-accept-failures: [
+  "debian-11" "opensuse-15.6"
+  # Unikraft 0.20.0 is incompatible with the version of GCC in those
+  # distributions
+]
+url {
+  src:
+    "https://github.com/mirage/ocaml-unikraft/archive/refs/tags/v1.2.0.tar.gz"
+  checksum:
+    "sha256=ca18a45ef86791d5ffa18436945fbec850b6f3dd68a6a62753b4cb1b6999b19a"
+}
+available: os = "linux"
+x-maintenance-intent: ["(latest)"]

--- a/packages/ocaml-unikraft-backend-qemu-x86_64/ocaml-unikraft-backend-qemu-x86_64.1.2.0-0.20.0/opam
+++ b/packages/ocaml-unikraft-backend-qemu-x86_64/ocaml-unikraft-backend-qemu-x86_64.1.2.0-0.20.0/opam
@@ -1,0 +1,49 @@
+opam-version: "2.0"
+maintainer: "samuel@tarides.com"
+homepage: "https://github.com/mirage/ocaml-unikraft/"
+dev-repo: "git+https://github.com/mirage/ocaml-unikraft.git"
+bug-reports: "https://github.com/mirage/ocaml-unikraft/issues"
+tags: "org:mirage"
+synopsis: "QEMU/x86_64 Unikraft backend for OCaml"
+authors: ["Samuel Hym" "Unikraft contributors"]
+license: ["MIT" "BSD-3-Clause" "GPL-2.0-only"]
+depends: [
+  "unikraft" {= "0.20.0"}
+  "unikraft-musl" {= "0.20.0"}
+  "conf-x86_64-linux-gnu-gcc" {arch != "x86_64"}
+]
+depopts: [
+  "ocaml-unikraft-option-debug"
+  "ocaml-unikraft-option-9pfs"
+  "ocaml-unikraft-custom-configs"
+]
+build: [
+  [
+    make
+    "-j%{jobs}%"
+    "UNIKRAFT=%{unikraft:lib}%"
+    "UNIKRAFTMUSL=%{unikraft-musl:lib}%"
+    "OCUKPLAT=qemu"
+    "OCUKARCH=x86_64"
+    "OCUKEXTLIBS=musl"
+    "OCUKCONFIGOPTS+=debug" {ocaml-unikraft-option-debug:installed}
+    "OCUKCONFIGOPTS+=9pfs" {ocaml-unikraft-option-9pfs:installed}
+    "OCUKCUSTOMCFGDIR=%{ocaml-unikraft-custom-configs:share}%"
+      {ocaml-unikraft-custom-configs:installed}
+    "UK_CFLAGS=-std=gnu11"
+    "%{name}%.install"
+  ]
+]
+x-ci-accept-failures: [
+  "debian-11" "opensuse-15.6"
+  # Unikraft 0.20.0 is incompatible with the version of GCC in those
+  # distributions
+]
+url {
+  src:
+    "https://github.com/mirage/ocaml-unikraft/archive/refs/tags/v1.2.0.tar.gz"
+  checksum:
+    "sha256=ca18a45ef86791d5ffa18436945fbec850b6f3dd68a6a62753b4cb1b6999b19a"
+}
+available: os = "linux"
+x-maintenance-intent: ["(latest)"]

--- a/packages/ocaml-unikraft-backend-qemu/ocaml-unikraft-backend-qemu.1.2.0-0.20.0/opam
+++ b/packages/ocaml-unikraft-backend-qemu/ocaml-unikraft-backend-qemu.1.2.0-0.20.0/opam
@@ -1,0 +1,21 @@
+opam-version: "2.0"
+maintainer: "samuel@tarides.com"
+homepage: "https://github.com/mirage/ocaml-unikraft/"
+dev-repo: "git+https://github.com/mirage/ocaml-unikraft.git"
+bug-reports: "https://github.com/mirage/ocaml-unikraft/issues"
+tags: "org:mirage"
+synopsis:
+  "Virtual package to ensure the QEMU Unikraft backend is installed for the default cross compiler"
+description:
+  "This virtual package ensures that the QEMU backend is installed for the default `unikraft` ocamlfind cross toolchain."
+authors: "Samuel Hym"
+license: "MIT"
+depends: [
+  "ocaml-unikraft" {= "1.2.0"}
+  ("ocaml-unikraft-default-x86_64" {= "1.2.0"} &
+    "ocaml-unikraft-backend-qemu-x86_64" {= version}) |
+  ("ocaml-unikraft-default-arm64" {= "1.2.0"} &
+    "ocaml-unikraft-backend-qemu-arm64" {= version})
+]
+available: os = "linux"
+x-maintenance-intent: ["(latest)"]

--- a/packages/ocaml-unikraft-default-arm64/ocaml-unikraft-default-arm64.1.2.0/opam
+++ b/packages/ocaml-unikraft-default-arm64/ocaml-unikraft-default-arm64.1.2.0/opam
@@ -1,0 +1,29 @@
+opam-version: "2.0"
+maintainer: "samuel@tarides.com"
+homepage: "https://github.com/mirage/ocaml-unikraft/"
+dev-repo: "git+https://github.com/mirage/ocaml-unikraft.git"
+bug-reports: "https://github.com/mirage/ocaml-unikraft/issues"
+tags: "org:mirage"
+synopsis:
+  "OCaml default cross compiler to the freestanding Unikraft arm64 backends"
+description:
+  "This package provides an OCaml cross compiler, suitable for linking with a Unikraft arm64 unikernel, as the default `unikraft` ocamlfind toolchain."
+authors: "Samuel Hym"
+license: "MIT"
+depends: [
+  "ocaml-unikraft-arm64" {= version}
+  "ocamlfind"
+]
+conflict-class: "ocaml-unikraft-default"
+build: [
+  [make "prefix=%{prefix}%" "OCUKARCH=arm64" "%{name}%.install"]
+]
+conflicts: ["relocatable"]
+url {
+  src:
+    "https://github.com/mirage/ocaml-unikraft/archive/refs/tags/v1.2.0.tar.gz"
+  checksum:
+    "sha256=ca18a45ef86791d5ffa18436945fbec850b6f3dd68a6a62753b4cb1b6999b19a"
+}
+available: os = "linux"
+x-maintenance-intent: ["(latest)"]

--- a/packages/ocaml-unikraft-default-x86_64/ocaml-unikraft-default-x86_64.1.2.0/opam
+++ b/packages/ocaml-unikraft-default-x86_64/ocaml-unikraft-default-x86_64.1.2.0/opam
@@ -1,0 +1,29 @@
+opam-version: "2.0"
+maintainer: "samuel@tarides.com"
+homepage: "https://github.com/mirage/ocaml-unikraft/"
+dev-repo: "git+https://github.com/mirage/ocaml-unikraft.git"
+bug-reports: "https://github.com/mirage/ocaml-unikraft/issues"
+tags: "org:mirage"
+synopsis:
+  "OCaml default cross compiler to the freestanding Unikraft x86_64 backends"
+description:
+  "This package provides an OCaml cross compiler, suitable for linking with a Unikraft x86_64 unikernel, as the default `unikraft` ocamlfind toolchain."
+authors: "Samuel Hym"
+license: "MIT"
+depends: [
+  "ocaml-unikraft-x86_64" {= version}
+  "ocamlfind"
+]
+conflict-class: "ocaml-unikraft-default"
+build: [
+  [make "prefix=%{prefix}%" "OCUKARCH=x86_64" "%{name}%.install"]
+]
+conflicts: ["relocatable"]
+url {
+  src:
+    "https://github.com/mirage/ocaml-unikraft/archive/refs/tags/v1.2.0.tar.gz"
+  checksum:
+    "sha256=ca18a45ef86791d5ffa18436945fbec850b6f3dd68a6a62753b4cb1b6999b19a"
+}
+available: os = "linux"
+x-maintenance-intent: ["(latest)"]

--- a/packages/ocaml-unikraft-option-9pfs/ocaml-unikraft-option-9pfs.1.2.0-0.20.0/opam
+++ b/packages/ocaml-unikraft-option-9pfs/ocaml-unikraft-option-9pfs.1.2.0-0.20.0/opam
@@ -1,0 +1,12 @@
+opam-version: "2.0"
+maintainer: "samuel@tarides.com"
+homepage: "https://github.com/mirage/ocaml-unikraft/"
+dev-repo: "git+https://github.com/mirage/ocaml-unikraft.git"
+bug-reports: "https://github.com/mirage/ocaml-unikraft/issues"
+tags: "org:mirage"
+synopsis:
+  "Virtual package to enable 9pfs storage in the Unikraft backends"
+authors: "Samuel Hym"
+license: "MIT"
+available: os = "linux"
+x-maintenance-intent: ["(latest)"]

--- a/packages/ocaml-unikraft-option-debug/ocaml-unikraft-option-debug.1.2.0-0.20.0/opam
+++ b/packages/ocaml-unikraft-option-debug/ocaml-unikraft-option-debug.1.2.0-0.20.0/opam
@@ -1,0 +1,12 @@
+opam-version: "2.0"
+maintainer: "samuel@tarides.com"
+homepage: "https://github.com/mirage/ocaml-unikraft/"
+dev-repo: "git+https://github.com/mirage/ocaml-unikraft.git"
+bug-reports: "https://github.com/mirage/ocaml-unikraft/issues"
+tags: "org:mirage"
+synopsis:
+  "Virtual package to enable debugging in the Unikraft backends"
+authors: "Samuel Hym"
+license: "MIT"
+available: os = "linux"
+x-maintenance-intent: ["(latest)"]

--- a/packages/ocaml-unikraft-toolchain-arm64/ocaml-unikraft-toolchain-arm64.1.2.0-0.20.0/opam
+++ b/packages/ocaml-unikraft-toolchain-arm64/ocaml-unikraft-toolchain-arm64.1.2.0-0.20.0/opam
@@ -1,0 +1,34 @@
+opam-version: "2.0"
+maintainer: "samuel@tarides.com"
+homepage: "https://github.com/mirage/ocaml-unikraft/"
+dev-repo: "git+https://github.com/mirage/ocaml-unikraft.git"
+bug-reports: "https://github.com/mirage/ocaml-unikraft/issues"
+tags: "org:mirage"
+synopsis:
+  "C toolchain to build an OCaml cross compiler to the freestanding Unikraft arm64 backends"
+description:
+  "This package provides a C toolchain to build an OCaml cross compiler, suitable for linking with a Unikraft arm64 unikernel."
+authors: "Samuel Hym"
+license: "MIT"
+depends: [
+  "ocaml-unikraft-backend-qemu-arm64" {= version} |
+  "ocaml-unikraft-backend-firecracker-arm64" {= version}
+]
+build: [
+  [
+    make
+    "-j%{jobs}%"
+    "LIB=%{lib}%"
+    "SHARE=%{share}%"
+    "OCUKARCH=arm64"
+    "%{name}%.install"
+  ]
+]
+url {
+  src:
+    "https://github.com/mirage/ocaml-unikraft/archive/refs/tags/v1.2.0.tar.gz"
+  checksum:
+    "sha256=ca18a45ef86791d5ffa18436945fbec850b6f3dd68a6a62753b4cb1b6999b19a"
+}
+available: os = "linux"
+x-maintenance-intent: ["(latest)"]

--- a/packages/ocaml-unikraft-toolchain-x86_64/ocaml-unikraft-toolchain-x86_64.1.2.0-0.20.0/opam
+++ b/packages/ocaml-unikraft-toolchain-x86_64/ocaml-unikraft-toolchain-x86_64.1.2.0-0.20.0/opam
@@ -1,0 +1,34 @@
+opam-version: "2.0"
+maintainer: "samuel@tarides.com"
+homepage: "https://github.com/mirage/ocaml-unikraft/"
+dev-repo: "git+https://github.com/mirage/ocaml-unikraft.git"
+bug-reports: "https://github.com/mirage/ocaml-unikraft/issues"
+tags: "org:mirage"
+synopsis:
+  "C toolchain to build an OCaml cross compiler to the freestanding Unikraft x86_64 backends"
+description:
+  "This package provides a C toolchain to build an OCaml cross compiler, suitable for linking with a Unikraft x86_64 unikernel."
+authors: "Samuel Hym"
+license: "MIT"
+depends: [
+  "ocaml-unikraft-backend-qemu-x86_64" {= version} |
+  "ocaml-unikraft-backend-firecracker-x86_64" {= version}
+]
+build: [
+  [
+    make
+    "-j%{jobs}%"
+    "LIB=%{lib}%"
+    "SHARE=%{share}%"
+    "OCUKARCH=x86_64"
+    "%{name}%.install"
+  ]
+]
+url {
+  src:
+    "https://github.com/mirage/ocaml-unikraft/archive/refs/tags/v1.2.0.tar.gz"
+  checksum:
+    "sha256=ca18a45ef86791d5ffa18436945fbec850b6f3dd68a6a62753b4cb1b6999b19a"
+}
+available: os = "linux"
+x-maintenance-intent: ["(latest)"]

--- a/packages/ocaml-unikraft-x86_64/ocaml-unikraft-x86_64.1.2.0/opam
+++ b/packages/ocaml-unikraft-x86_64/ocaml-unikraft-x86_64.1.2.0/opam
@@ -1,0 +1,44 @@
+opam-version: "2.0"
+maintainer: "samuel@tarides.com"
+homepage: "https://github.com/mirage/ocaml-unikraft/"
+dev-repo: "git+https://github.com/mirage/ocaml-unikraft.git"
+bug-reports: "https://github.com/mirage/ocaml-unikraft/issues"
+tags: "org:mirage"
+synopsis: "OCaml cross compiler to the freestanding Unikraft x86_64 backends"
+description:
+  "This package provides an OCaml cross compiler, suitable for linking with a Unikraft x86_64 unikernel."
+authors: "Samuel Hym"
+license: ["MIT" "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"]
+depends: [
+  "ocaml" {>= "5.3.0" & <= "5.5.0"}
+  "ocaml-unikraft-toolchain-x86_64" {>= "1.2.0" & < "1.2.1"}
+  "ocamlfind"
+  "ocaml-src" {build}
+  "opatch" {build}
+]
+build: [
+  [
+    make
+    "-j%{jobs}%"
+    "prefix=%{prefix}%"
+    "BIN=%{bin}%"
+    "LIB=%{lib}%"
+    "SHARE=%{share}%"
+    "OCUKARCH=x86_64"
+    "%{name}%.install"
+  ]
+]
+install: [
+  [make "install-ocaml"]
+]
+conflicts: ["ocaml-option-bytecode-only" "relocatable"]
+# The package is not completely relocatable yet as the ocamlfind toolchain
+# description contains absolute paths
+url {
+  src:
+    "https://github.com/mirage/ocaml-unikraft/archive/refs/tags/v1.2.0.tar.gz"
+  checksum:
+    "sha256=ca18a45ef86791d5ffa18436945fbec850b6f3dd68a6a62753b4cb1b6999b19a"
+}
+available: os = "linux"
+x-maintenance-intent: ["(latest)"]

--- a/packages/ocaml-unikraft/ocaml-unikraft.1.2.0/opam
+++ b/packages/ocaml-unikraft/ocaml-unikraft.1.2.0/opam
@@ -1,0 +1,18 @@
+opam-version: "2.0"
+maintainer: "samuel@tarides.com"
+homepage: "https://github.com/mirage/ocaml-unikraft/"
+dev-repo: "git+https://github.com/mirage/ocaml-unikraft.git"
+bug-reports: "https://github.com/mirage/ocaml-unikraft/issues"
+tags: "org:mirage"
+synopsis:
+  "Virtual package to install one of the OCaml default cross compilers to the freestanding Unikraft backends"
+description:
+  "This virtual package ensures that an OCaml cross compiler is available for linking with a Unikraft unikernel as the default `unikraft` ocamlfind toolchain. Explicitly choose one among the ocaml-unikraft-default-* packages to control which one is actually installed."
+authors: "Samuel Hym"
+license: "MIT"
+depends: [
+  "ocaml-unikraft-default-x86_64" {= version} |
+  "ocaml-unikraft-default-arm64" {= version}
+]
+available: os = "linux"
+x-maintenance-intent: ["(latest)"]


### PR DESCRIPTION
Main changes in OCaml/Unikraft:

- Support for OCaml 5.4.1 and 5.5.0
- Build a relocatable cross compiler with OCaml 5.5.0 (but note that the ocamlfind toolchain description always contains absolute paths)
- Add an option to support the 9pfs filesystem
- Add support for custom Unikraft configurations
- Apply patches, when required, using `opatch` for portability
- Increase the default stack size as OCaml application really commonly need more than just 64KB

Changes in the packaging:

- Use tighter dependencies to prevent untested combinations
- Adopt the OCaml/Unikraft version (1.2.0) also for the backend packages, combining it with the Unikraft version (ending up with version numbers 1.2.0-0.20.0), following the scheme used by Merlin