### PR TITLE
Package rocq-vellvm.main

### DIFF
--- a/packages/rocq-vellvm/rocq-vellvm.main/opam
+++ b/packages/rocq-vellvm/rocq-vellvm.main/opam
@@ -1,0 +1,52 @@
+opam-version: "2.0"
+maintainer: "stevez@cis.upenn.edu"
+synopsis: "Rocq library implementing (executable) semantics for LLVM IR"
+
+homepage: "https://vellvm.github.io/vellvm/"
+dev-repo: "git+https://github.com/vellvm/vellvm.git"
+bug-reports: "https://github.com/vellvm/vellvm/issues"
+authors: [
+  "Steve Zdancewic <stevez@cis.upenn.edu>"
+  "Yannick Zakowski <yannick.zakowski@inria.fr>"
+  "Calvin Beck <hobbes@seas.upenn.edu>"
+  "Irene Yoon <euisuny@cis.upenn.edu>"
+  "Gary (Hanxi) Chen <hanxic@seas.upenn.edu>"
+]
+license: "MIT"
+
+build: [make "-C" "src" "all" "-j%{jobs}%"]
+install: [make "-C" "src" "install"]
+    
+depends: [
+  "ocaml" {>= "4.14.0"}
+  "dune" {>= "3.14.0"}
+  "menhir"
+  "rocq-core" {>= "9.0.0" & < "9.2~"}
+  "rocq-stdlib" {>= "9.0.0" & < "9.2~"}
+  "coq-ext-lib" {>= "0.13.0" & < "0.14~"}
+  "coq-paco"  {>= "4.2.3" & < "4.3~"}
+  "coq-flocq" {>= "4.2.0"}
+  "coq-itree" {>= "5.2.1" & < "5.3~"}
+]
+
+tags: [
+  "date:2026-07-06"
+
+  "category:Computer Science/Programming Languages/Formal Definitions and Theory"
+  "category:Computer Science/Semantics and Compilation/Compilation"
+  "category:Computer Science/Semantics and Compilation/Semantics"
+
+  "keyword:semantics"
+  "keyword:interpreter"
+  "keyword:LLVM"
+
+  "logpath:Vellvm"
+]
+url {
+  src:
+    "https://github.com/vellvm/vellvm/archive/refs/tags/3.0.20260707.tar.gz"
+  checksum: [
+    "md5=5d13d77b4fd342f03caff5c9f46e3a41"
+    "sha512=2cc215d0b8fa90de29e3405dfc4a5430863c361300a90781c3b25c4644e33b5ce6d10f5f3891ef5d1884ad9385d7e1e7118d61137622626923ca240ad7526038"
+  ]
+}


### PR DESCRIPTION
### `rocq-vellvm.main`
Rocq library implementing (executable) semantics for LLVM IR



---
* Homepage: https://vellvm.github.io/vellvm/
* Source repo: git+https://github.com/vellvm/vellvm.git
* Bug tracker: https://github.com/vellvm/vellvm/issues

---
:camel: Pull-request generated by opam-publish v3.0.0