### PR TITLE
[new release] ocamlformat-mlx and ocamlformat-mlx-lib (0.29.0.0)

### DIFF
--- a/packages/ocamlformat-mlx-lib/ocamlformat-mlx-lib.0.29.0.0/opam
+++ b/packages/ocamlformat-mlx-lib/ocamlformat-mlx-lib.0.29.0.0/opam
@@ -1,0 +1,66 @@
+opam-version: "2.0"
+synopsis: "OCaml .mlx Code Formatter"
+description:
+  "OCamlFormat is a tool to automatically format OCaml .mlx code in a uniform style."
+maintainer: [
+  "Andrey Popp <me@andreypopp.com>" "David Sancho <dsnxmoreno@gmail.com>"
+]
+authors: [
+  "Andrey Popp <me@andreypopp.com>"
+  "Josh Berdine <jjb@fb.com>"
+  "Hugo Heuzard <hugo.heuzard@gmail.com>"
+  "Etienne Millon <etienne@tarides.com>"
+  "Guillaume Petiot <guillaume@tarides.com>"
+  "Jules Aguillon <jules@j3s.fr>"
+]
+homepage: "https://github.com/ocaml-mlx/ocamlformat-mlx"
+bug-reports: "https://github.com/ocaml-mlx/ocamlformat-mlx/issues"
+depends: [
+  "ocaml" {>= "4.14"}
+  "alcotest" {with-test & >= "1.3.0"}
+  "base" {>= "v0.12.0"}
+  "cmdliner" {>= "1.1.0"}
+  "dune" {>= "2.8"}
+  "dune-build-info"
+  "either"
+  "fix"
+  "fpath" {>= "0.7.3"}
+  "menhir" {>= "20201216"}
+  "menhirLib" {>= "20201216"}
+  "menhirSdk" {>= "20201216"}
+  "ocaml-version" {>= "3.5.0"}
+  "ocp-indent" {with-test = "false" & >= "1.8.0" | with-test & >= "1.8.1"}
+  "stdio"
+  "uuseg" {>= "10.0.0"}
+  "uutf" {>= "1.0.1"}
+  "csexp" {>= "1.4.0"}
+  "astring"
+  "camlp-streams"
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/ocaml-mlx/ocamlformat-mlx.git"
+# OCamlFormat is distributed under the MIT license. Parts of the OCaml library are vendored for OCamlFormat and distributed under their original LGPL 2.1 license
+license: ["MIT" "LGPL-2.1-only WITH OCaml-LGPL-linking-exception"]
+url {
+  src:
+    "https://github.com/ocaml-mlx/ocamlformat-mlx/releases/download/0.29.0.0/ocamlformat-mlx-0.29.0.0.tbz"
+  checksum: [
+    "sha256=9c5a6721d16d980e7730274543a0151c920715ce447946a3f833d4e2568e3a68"
+    "sha512=a0552cf055b6e061ab2bb0341aa9ddea860ded6e6522d2188e2a6697c18dc14ebbb01935b535695850b72f9880c4b2fa2a821a20be75c992fcbaf9b3f3a127b7"
+  ]
+}
+x-commit-hash: "6db9769795330343a252121230a782e62cae7210"

--- a/packages/ocamlformat-mlx/ocamlformat-mlx.0.29.0.0/opam
+++ b/packages/ocamlformat-mlx/ocamlformat-mlx.0.29.0.0/opam
@@ -1,0 +1,57 @@
+opam-version: "2.0"
+synopsis: "Auto-formatter for OCaml .mlx code"
+description: """
+**ocamlformat** is a code formatter for OCaml. It comes with opinionated default settings but is also fully customizable to suit your coding style.
+
+- **Profiles:** ocamlformat offers profiles we predefined formatting configurations. Profiles include `default`, `ocamlformat`, `janestreet`.
+- **Configurable:** Users can change the formatting profile and configure every option in their `.ocamlformat` configuration file.
+- **Format Comments:** ocamlformat can format comments, docstrings, and even code blocks in your comments.
+- **RPC:** ocamlformat provides an RPC server that can be used by other tools to easily format OCaml Code."""
+maintainer: [
+  "Andrey Popp <me@andreypopp.com>" "David Sancho <dsnxmoreno@gmail.com>"
+]
+authors: [
+  "Andrey Popp <me@andreypopp.com>"
+  "Josh Berdine <jjb@fb.com>"
+  "Hugo Heuzard <hugo.heuzard@gmail.com>"
+  "Etienne Millon <etienne@tarides.com>"
+  "Guillaume Petiot <guillaume@tarides.com>"
+  "Jules Aguillon <jules@j3s.fr>"
+]
+homepage: "https://github.com/ocaml-mlx/ocamlformat-mlx"
+bug-reports: "https://github.com/ocaml-mlx/ocamlformat-mlx/issues"
+depends: [
+  "ocaml" {>= "4.08"}
+  "cmdliner" {with-test = "false" & >= "1.1.0" | with-test & >= "1.2.0"}
+  "csexp" {>= "1.4.0"}
+  "dune" {>= "2.8"}
+  "ocamlformat-mlx-lib" {= version}
+  "re" {>= "1.10.3"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/ocaml-mlx/ocamlformat-mlx.git"
+# OCamlFormat is distributed under the MIT license. Parts of the OCaml library are vendored for OCamlFormat and distributed under their original LGPL 2.1 license
+license: ["MIT" "LGPL-2.1-only WITH OCaml-LGPL-linking-exception"]
+url {
+  src:
+    "https://github.com/ocaml-mlx/ocamlformat-mlx/releases/download/0.29.0.0/ocamlformat-mlx-0.29.0.0.tbz"
+  checksum: [
+    "sha256=9c5a6721d16d980e7730274543a0151c920715ce447946a3f833d4e2568e3a68"
+    "sha512=a0552cf055b6e061ab2bb0341aa9ddea860ded6e6522d2188e2a6697c18dc14ebbb01935b535695850b72f9880c4b2fa2a821a20be75c992fcbaf9b3f3a127b7"
+  ]
+}
+x-commit-hash: "6db9769795330343a252121230a782e62cae7210"


### PR DESCRIPTION
Auto-formatter for OCaml .mlx code

- Project page: <a href="https://github.com/ocaml-mlx/ocamlformat-mlx">https://github.com/ocaml-mlx/ocamlformat-mlx</a>

##### CHANGES:

### Highlight

- \* Support OCaml 5.5 syntax
  (ocaml-mlx/ocamlformat-mlx#2772, ocaml-mlx/ocamlformat-mlx#2774, ocaml-mlx/ocamlformat-mlx#2775, ocaml-mlx/ocamlformat-mlx#2777, ocaml-mlx/ocamlformat-mlx#2780, ocaml-mlx/ocamlformat-mlx#2781, ocaml-mlx/ocamlformat-mlx#2782, ocaml-mlx/ocamlformat-mlx#2783, @Julow)
  The update brings several tiny changes, they are listed below.

- \* Update Odoc's parser to 3.0 (ocaml-mlx/ocamlformat-mlx#2757, @Julow)
  The indentation of code-blocks containing OCaml code is reduced by 2 to avoid
  changing the generated documentation. The indentation within code-blocks is
  now significative in Odoc and shows up in generated documentation.

### Added

- Added option `letop-punning` (ocaml-mlx/ocamlformat-mlx#2746, @WardBrian) to control whether
  punning is used in extended binding operators.
  For example, the code `let+ x = x in ...` can be formatted as
  `let+ x in ...` when `letop-punning=always`. With `letop-punning=never`, it
  becomes `let+ x = x in ...`. The default is `preserve`, which will
  only use punning when it exists in the source.
  This also applies to `let%ext` bindings (ocaml-mlx/ocamlformat-mlx#2747, @WardBrian).

- Support the unnamed functor parameters syntax in module types
  (ocaml-mlx/ocamlformat-mlx#2755, ocaml-mlx/ocamlformat-mlx#2759, @Julow)
  ```ocaml
  module type F = ARG -> S
  ```
  The following lines are now formatted as they are in the source file:
  ```ocaml
  module M : (_ : S) -> (_ : S) -> S = N
  module M : S -> S -> S = N
  (* The preceding two lines are no longer turned into this: *)
  module M : (_ : S) (_ : S) -> S = N
  ```

### Fixed

- Fix dropped comment in `(function _ -> x (* cmt *))` (ocaml-mlx/ocamlformat-mlx#2739, @Julow)

- \* `cases-matching-exp-indent=compact` does not impact `begin end` nodes that
  don't have a match inside. (ocaml-mlx/ocamlformat-mlx#2742, @EmileTrotignon)
  ```ocaml
  (* before *)
  begin match () with
  | () -> begin
    f x
  end
  end
  (* after *)
  begin match () with
  | () -> begin
      f x
    end
  end
  ```

- `Ast_mapper` now iterates on *all* locations inside of Longident.t,
  instead of only some.
  (ocaml-mlx/ocamlformat-mlx#2737, @v-gb)

- Remove line break in `M with module N = N (* cmt *)` (ocaml-mlx/ocamlformat-mlx#2779, @Julow)

### Internal

- Added information on writing tests to `CONTRIBUTING.md` (ocaml-mlx/ocamlformat-mlx#2838, @WardBrian)

### Changed

- indentation of the `end` keyword in a match-case is now always at least 2. (ocaml-mlx/ocamlformat-mlx#2742, @EmileTrotignon)
  ```ocaml
  (* before *)
  begin match () with
  | () -> begin
    match () with
    | () -> ()
  end
  end
  (* after *)
  begin match () with
  | () -> begin
    match () with
    | () -> ()

- \* use shortcut `begin end` in `match` cases and `if then else` body. (ocaml-mlx/ocamlformat-mlx#2744, @EmileTrotignon)
  ```ocaml
  (* before *)
  match () with
  | () -> begin
      match () with
      | () ->
    end
  end
  (* after *)
  match () with
  | () ->
    begin match () with
      | () ->
    end
  end
  ```

- \* Set the `ocaml-version` to `5.4` by default (ocaml-mlx/ocamlformat-mlx#2750, @EmileTrotignon)
  The main difference is that the `effect` keyword is recognized without having
  to add `ocaml-version=5.3` to the configuration.
  In exchange, code that use `effect` as an identifier must use
  `ocaml-version=5.2`.

- The work to support OCaml 5.5 come with several improvements:
  + Improve the indentation of `let structure-item` with the
    `[@ocamlformat "disable"]` attribute.
    `let structure-item` means `let module`, `let open`, `let include` and
    `let exception`.
  + `(let open M in e)[@a]` is turned into `let[@a] open M in e`.
  + Long `let open ... in` no longer exceed the margin.
  + Improve indentation of `let structure-item` within parentheses:
    ```ocaml
    (* before *)
    (let module M = M in
    M.foo)
    (* after *)
    (let module M = M in
     M.foo)
    ```
