### PR TITLE
core, core_unix: port v0.15.2 alpine guard to v0.14.1 and v0.15.0/1

### DIFF
--- a/packages/core/core.v0.14.1/opam
+++ b/packages/core/core.v0.14.1/opam
@@ -34,4 +34,4 @@ url {
     "md5=b11f58205953d84cedb0003efcdab231"
   ]
 }
-available: [ !(os = "freebsd" & os-version >= "14") ]
+available: [ !(os = "freebsd" & os-version >= "14") & (os-distribution != "alpine" | os-version < "3.21") ]

--- a/packages/core_unix/core_unix.v0.15.0/opam
+++ b/packages/core_unix/core_unix.v0.15.0/opam
@@ -29,7 +29,7 @@ description: "
 Unix-specific extensions to some of the modules defined in [core] and [core_kernel].
 "
 depexts: ["linux-headers"] {os-family = "alpine"}
-available: [ !(os = "freebsd" & os-version >= "14") ]
+available: [ !(os = "freebsd" & os-version >= "14") & (os-distribution != "alpine" | os-version < "3.21") ]
 url {
 src: "https://ocaml.janestreet.com/ocaml-core/v0.15/files/core_unix-v0.15.0.tar.gz"
 checksum: "sha256=0af9d2c0d2029a80858c730171e0bd70a1981b3e7021f8c31cd8dc54925da02d"

--- a/packages/core_unix/core_unix.v0.15.1/opam
+++ b/packages/core_unix/core_unix.v0.15.1/opam
@@ -29,7 +29,7 @@ description: "
 Unix-specific extensions to some of the modules defined in [core] and [core_kernel].
 "
 depexts: ["linux-headers"] {os-family = "alpine"}
-available: [ !(os = "freebsd" & os-version >= "14") ]
+available: [ !(os = "freebsd" & os-version >= "14") & (os-distribution != "alpine" | os-version < "3.21") ]
 url {
 src: "https://github.com/ocaml/opam-source-archives/raw/main/core_unix-v0.15.1.tar.gz"
 checksum: "sha256=b467c7c64616d5cc88f42f9660b447247e7a848148336e0ad0de6bd35edce9b3"


### PR DESCRIPTION
Their unix C stubs do not build on alpine >= 3.21; mark them unavailable there, matching core_unix.v0.15.2 and v0.16.0.