### PR TITLE
Update the `x-ci-accept-failures` for `conf-aarch64-linux-gnu-gcc`

### DIFF
--- a/packages/conf-aarch64-linux-gnu-gcc/conf-aarch64-linux-gnu-gcc.1/opam
+++ b/packages/conf-aarch64-linux-gnu-gcc/conf-aarch64-linux-gnu-gcc.1/opam
@@ -21,11 +21,11 @@ for it for your distribution."""
     {failure}
 x-maintenance-intent: ["(latest)"]
 x-ci-accept-failures: [
-  "alpine-3.22"
+  "alpine-3.23"
   "centos-9"
   "centos-10"
-  "opensuse-15.6"
+  "opensuse-16.0"
   "opensuse-tumbleweed"
-  "freebsd-14.3"
+  "freebsd-15.1"
   "macos-homebrew"
 ]


### PR DESCRIPTION
Follow the opam-ci update of the distributions that do not provide this cross compiler.

This emerged from the CI results in #30209.