### PR TITLE
[new release] wayland (2.3)

### DIFF
--- a/packages/wayland/wayland.2.3/opam
+++ b/packages/wayland/wayland.2.3/opam
@@ -1,0 +1,47 @@
+opam-version: "2.0"
+synopsis: "Pure OCaml Wayland protocol library"
+description:
+  "Wayland is a communications protocol intended for use between processes on a single computer. It is mainly used by graphical applications (clients) to talk to display servers, but nothing about the protocol is specific to graphics and it could be used for other things. This library can be used to write Wayland clients, servers and proxies."
+maintainer: ["talex5@gmail.com"]
+authors: ["talex5@gmail.com"]
+license: "Apache-2.0 AND LicenseRef-various-licenses-for-the-schema-files"
+homepage: "https://github.com/talex5/ocaml-wayland"
+doc: "https://talex5.github.io/ocaml-wayland/"
+bug-reports: "https://github.com/talex5/ocaml-wayland/issues"
+depends: [
+  "dune" {>= "2.8"}
+  "alcotest" {>= "1.2.3" & with-test}
+  "ocaml" {>= "5.0"}
+  "xmlm" {>= "1.3.0"}
+  "logs" {>= "0.7.0"}
+  "fmt" {>= "0.8.9"}
+  "cstruct" {>= "6.0.0"}
+  "eio" {>= "0.12"}
+  "eio_main" {>= "0.12" & with-test}
+  "cmdliner" {>= "1.1.1"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/talex5/ocaml-wayland.git"
+url {
+  src:
+    "https://github.com/talex5/ocaml-wayland/releases/download/v2.3/wayland-2.3.tbz"
+  checksum: [
+    "sha256=10627a94f4cef97147991528fcd246f8f27ccbf3026eafdece995b53ee9468a0"
+    "sha512=8e319dc236d04cc9084bf81782497899dca12a392d649a2ac7bd1d5edc1101ebe2bc266a033e23ab9ed46a8b692018bc47005036d10872f7825f4aa4009ab825"
+  ]
+}
+x-commit-hash: "f2cec05dbbc88f86e9b04fee285d3283b492a0ea"


### PR DESCRIPTION
Pure OCaml Wayland protocol library

- Project page: <a href="https://github.com/talex5/ocaml-wayland">https://github.com/talex5/ocaml-wayland</a>
- Documentation: <a href="https://talex5.github.io/ocaml-wayland/">https://talex5.github.io/ocaml-wayland/</a>

##### CHANGES:

- Update protocols (@alyssais talex5/ocaml-wayland#57).
  This also updates the scanner to handle the new `deprecated-since` and
  `frozen` attributes, though they don't affect the generated code currently.

- Mangle reserved keyword `new` to `new_` (@3L0C talex5/ocaml-wayland#55).

- Replace `@<id>` with `#<id>` in logs (@talex5 talex5/ocaml-wayland#54).
  We previously used `@` to match the C libwayland, but that has now switched to `#`
  (to avoid confusion with email addresses when anonymizing logs from users).
