### PR TITLE
core, core_unix: mark v0.14.1 and v0.15.0-v0.16.0 unavailable on openbsd

### DIFF
--- a/packages/core/core.v0.14.1/opam
+++ b/packages/core/core.v0.14.1/opam
@@ -34,4 +34,4 @@ url {
     "md5=b11f58205953d84cedb0003efcdab231"
   ]
 }
-available: [ !(os = "freebsd" & os-version >= "14") & (os-distribution != "alpine" | os-version < "3.21") ]
+available: [ !(os = "freebsd" & os-version >= "14") & (os-distribution != "alpine" | os-version < "3.21") & os != "openbsd" ]

--- a/packages/core_unix/core_unix.v0.15.0/opam
+++ b/packages/core_unix/core_unix.v0.15.0/opam
@@ -29,7 +29,7 @@ description: "
 Unix-specific extensions to some of the modules defined in [core] and [core_kernel].
 "
 depexts: ["linux-headers"] {os-family = "alpine"}
-available: [ !(os = "freebsd" & os-version >= "14") & (os-distribution != "alpine" | os-version < "3.21") ]
+available: [ !(os = "freebsd" & os-version >= "14") & (os-distribution != "alpine" | os-version < "3.21") & os != "openbsd" ]
 url {
 src: "https://ocaml.janestreet.com/ocaml-core/v0.15/files/core_unix-v0.15.0.tar.gz"
 checksum: "sha256=0af9d2c0d2029a80858c730171e0bd70a1981b3e7021f8c31cd8dc54925da02d"

--- a/packages/core_unix/core_unix.v0.15.1/opam
+++ b/packages/core_unix/core_unix.v0.15.1/opam
@@ -29,7 +29,7 @@ description: "
 Unix-specific extensions to some of the modules defined in [core] and [core_kernel].
 "
 depexts: ["linux-headers"] {os-family = "alpine"}
-available: [ !(os = "freebsd" & os-version >= "14") & (os-distribution != "alpine" | os-version < "3.21") ]
+available: [ !(os = "freebsd" & os-version >= "14") & (os-distribution != "alpine" | os-version < "3.21") & os != "openbsd" ]
 url {
 src: "https://github.com/ocaml/opam-source-archives/raw/main/core_unix-v0.15.1.tar.gz"
 checksum: "sha256=b467c7c64616d5cc88f42f9660b447247e7a848148336e0ad0de6bd35edce9b3"

--- a/packages/core_unix/core_unix.v0.15.2/opam
+++ b/packages/core_unix/core_unix.v0.15.2/opam
@@ -29,7 +29,7 @@ description: "
 Unix-specific extensions to some of the modules defined in [core] and [core_kernel].
 "
 depexts: ["linux-headers"] {os-family = "alpine"}
-available: [ !(os = "freebsd" & os-version >= "14") & (os-distribution != "alpine" | os-version < "3.21") ]
+available: [ !(os = "freebsd" & os-version >= "14") & (os-distribution != "alpine" | os-version < "3.21") & os != "openbsd" ]
 url {
 src: "https://github.com/janestreet/core_unix/archive/refs/tags/v0.15.2.tar.gz"
 checksum: "sha256=486d0e954603960fa081b3fd23e3cc3e50ac0892544acd35f9c2919c4bf5f67b"

--- a/packages/core_unix/core_unix.v0.16.0/opam
+++ b/packages/core_unix/core_unix.v0.16.0/opam
@@ -29,7 +29,7 @@ synopsis: "Unix-specific portions of Core"
 description: "
 Unix-specific extensions to some of the modules defined in [core] and [core_kernel].
 "
-available: [ !(os = "freebsd" & os-version >= "14") & (os-distribution != "alpine" | os-version < "3.21") ]
+available: [ !(os = "freebsd" & os-version >= "14") & (os-distribution != "alpine" | os-version < "3.21") & os != "openbsd" ]
 url {
 src: "https://ocaml.janestreet.com/ocaml-core/v0.16/files/core_unix-v0.16.0.tar.gz"
 checksum: "sha256=4f70a9d3a761799d00c0a207942b4abd9f1a144bbcb19df98021d9fb7bfa9e5f"


### PR DESCRIPTION
Their unix stubs use Linux-only `recvmmsg`/`struct mmsghdr`, which do not build on openbsd. Mark them unavailable there, alongside the existing freebsd and alpine guards.