### PR TITLE
Use v-prefix in ocaml-ai-sdk's re2 bound (1/n)

### DIFF
--- a/packages/ocaml-ai-sdk/ocaml-ai-sdk.0.2/opam
+++ b/packages/ocaml-ai-sdk/ocaml-ai-sdk.0.2/opam
@@ -20,7 +20,7 @@ depends: [
   "base64" {>= "1.3"}
   "ppx_deriving" {>= "5.2"}
   "lwt_ppx" {>= "5.9"}
-  "re2" {>= "0.16"}
+  "re2" {>= "v0.16"}
   "uuseg" {>= "17.0"}
   "trace" {>= "0.12"}
   "alcotest" {with-test}

--- a/packages/ocaml-ai-sdk/ocaml-ai-sdk.0.3/opam
+++ b/packages/ocaml-ai-sdk/ocaml-ai-sdk.0.3/opam
@@ -20,7 +20,7 @@ depends: [
   "base64" {>= "1.3"}
   "ppx_deriving" {>= "5.2"}
   "lwt_ppx" {>= "5.9"}
-  "re2" {>= "0.16"}
+  "re2" {>= "v0.16"}
   "uuseg" {>= "17.0"}
   "trace" {>= "0.12"}
   "alcotest" {with-test}

--- a/packages/ocaml-ai-sdk/ocaml-ai-sdk.0.4/opam
+++ b/packages/ocaml-ai-sdk/ocaml-ai-sdk.0.4/opam
@@ -20,7 +20,7 @@ depends: [
   "base64" {>= "1.3"}
   "ppx_deriving" {>= "5.2"}
   "lwt_ppx" {>= "5.9"}
-  "re2" {>= "0.16"}
+  "re2" {>= "v0.16"}
   "uuseg" {>= "17.0"}
   "trace" {>= "0.12"}
   "alcotest" {with-test}

--- a/packages/ocaml-ai-sdk/ocaml-ai-sdk.0.5/opam
+++ b/packages/ocaml-ai-sdk/ocaml-ai-sdk.0.5/opam
@@ -20,7 +20,7 @@ depends: [
   "base64" {>= "1.3"}
   "ppx_deriving" {>= "5.2"}
   "lwt_ppx" {>= "5.9"}
-  "re2" {>= "0.16"}
+  "re2" {>= "v0.16"}
   "uuseg" {>= "17.0"}
   "trace" {>= "0.12"}
   "cohttp-lwt" {with-test}


### PR DESCRIPTION
Some existing packages (base, core, re2, ...) use a `v`-prefix in their versioning scheme, making for a common tripwire.

This PR corrects ocaml-ai-sdk's `re2` bound.

CC: @thatportugueseguy