### PR TITLE
Use v-prefix in hegel core* package bounds (2/n)

### DIFF
--- a/packages/hegel/hegel.0.8.0/opam
+++ b/packages/hegel/hegel.0.8.0/opam
@@ -11,8 +11,8 @@ bug-reports: "https://github.com/hegeldev/hegel-ocaml/issues"
 depends: [
   "dune" {>= "3.16"}
   "ocaml" {>= "5.1"}
-  "core" {>= "0.17"}
-  "core_unix" {>= "0.17"}
+  "core" {>= "v0.17"}
+  "core_unix" {>= "v0.17"}
   "ctypes" {>= "0.20"}
   "ctypes-foreign" {>= "0.20"}
   "dune-site" {>= "3.16"}

--- a/packages/ppx_hegel_generator/ppx_hegel_generator.0.8.0/opam
+++ b/packages/ppx_hegel_generator/ppx_hegel_generator.0.8.0/opam
@@ -17,8 +17,8 @@ depends: [
   "hegel" {= version}
   "ppx_hegel_test" {with-test & = version}
   "alcotest" {with-test & >= "1.7"}
-  "core" {with-test & >= "0.17"}
-  "core_unix" {with-test & >= "0.17"}
+  "core" {with-test & >= "v0.17"}
+  "core_unix" {with-test & >= "v0.17"}
   "odoc" {with-doc}
 ]
 build: [

--- a/packages/ppx_hegel_test/ppx_hegel_test.0.8.0/opam
+++ b/packages/ppx_hegel_test/ppx_hegel_test.0.8.0/opam
@@ -15,8 +15,8 @@ depends: [
   "ppx_hegel_compat" {= version}
   "hegel" {= version}
   "alcotest" {with-test & >= "1.7"}
-  "core" {with-test & >= "0.17"}
-  "core_unix" {with-test & >= "0.17"}
+  "core" {with-test & >= "v0.17"}
+  "core_unix" {with-test & >= "v0.17"}
   "yojson" {with-test & >= "1.7"}
   "odoc" {with-doc}
 ]


### PR DESCRIPTION
Some existing packages (base, core, re2, ...) use a v-prefix in their versioning scheme, making for a common tripwire.

This PR corrects hegel's `core` and `core_unix` bounds.

I missed this in #30185 but just spotted it in #30223

CC: @echoumcp1
