### PR TITLE
Use v-prefix in caisar.{5,6}.0 ppx package bounds (3/n)

### DIFF
--- a/packages/caisar/caisar.5.0/opam
+++ b/packages/caisar/caisar.5.0/opam
@@ -29,7 +29,7 @@ depends: [
   "stdio" {>= "v0.14.0"}
   "ocamlgraph" {>= "1.8.8"}
   "ppx_deriving" {>= "5.1"}
-  "ppx_inline_test" {>= "0.12.0"}
+  "ppx_inline_test" {>= "v0.12.0"}
   "conf-jq" {>= "1" & with-test}
   "conf-texlive" {>= "1" & with-test}
   "conf-python-3" {>= "9.0.0" & with-test}

--- a/packages/caisar/caisar.6.0/opam
+++ b/packages/caisar/caisar.6.0/opam
@@ -28,14 +28,14 @@ depends: [
   "stdio" {>= "v0.14.0"}
   "ocamlgraph" {>= "1.8.8"}
   "ppx_deriving" {>= "5.1"}
-  "ppx_inline_test" {>= "0.12.0"}
+  "ppx_inline_test" {>= "v0.12.0"}
   "conf-jq" {>= "1" & with-test}
   "conf-texlive" {>= "1" & with-test}
   "conf-python-3" {>= "9.0.0" & with-test}
   "ppx_deriving_yojson" {>= "3.6.1"}
   "ppx_deriving_yaml" {>= "0.3.0"}
   "ppx_deriving_jsonschema" {>= "0.0.4" & < "0.0.5"}
-  "ppx_variants_conv" {>= "0.18"}
+  "ppx_variants_conv" {>= "v0.18"}
   "why3find" {>= "1.2.0" & with-doc}
   "odoc" {with-doc}
 ]


### PR DESCRIPTION
Some existing packages (base, core, re2, ...) use a v-prefix in their versioning scheme, making for a common tripwire.

This PR corrects caisar's  ppx_inline_test and ppx_variants_conv bounds.

CC: @caisar-platform 