### PR TITLE
Use v-prefix in lunar.1.{0,1}.0 ppx_expect package bounds (4/n)

### DIFF
--- a/packages/lunar/lunar.1.0.0/opam
+++ b/packages/lunar/lunar.1.0.0/opam
@@ -22,7 +22,7 @@ bug-reports: "https://github.com/cargocut/lunar/issues"
 depends: [
   "dune" {>= "3.20"}
   "ocaml" {>= "5.0.0"}
-  "ppx_expect" {with-test & >= "0.17.3"}
+  "ppx_expect" {with-test & >= "v0.17.3"}
   "mdx" {with-test & >= "2.5.1"}
   "utop" {with-dev-setup}
   "ocamlformat" {with-dev-setup}

--- a/packages/lunar/lunar.1.1.0/opam
+++ b/packages/lunar/lunar.1.1.0/opam
@@ -22,7 +22,7 @@ bug-reports: "https://github.com/cargocut/lunar/issues"
 depends: [
   "dune" {>= "3.20"}
   "ocaml" {>= "5.0.0"}
-  "ppx_expect" {with-test & >= "0.17.3"}
+  "ppx_expect" {with-test & >= "v0.17.3"}
   "mdx" {with-test & >= "2.5.1"}
   "utop" {with-dev-setup}
   "ocamlformat" {with-dev-setup}


### PR DESCRIPTION
Some existing packages (base, core, re2, ...) use a v-prefix in their versioning scheme, making for a common tripwire.

This PR corrects lunar's ppx_expect bounds.

CC: @xvw 