### PR TITLE
Use v-prefix in oktree.0.2.{2,4} core* package bounds (5/n)

### DIFF
--- a/packages/oktree/oktree.0.2.2/opam
+++ b/packages/oktree/oktree.0.2.2/opam
@@ -17,8 +17,8 @@ depends: [
   "ocamlformat" {with-dev-setup}
   "ocp-indent" {with-dev-setup}
   "opam-publish" {with-dev-setup}
-  "core_bench" {with-dev-setup & >= "0.15.0"}
-  "core_unix" {with-dev-setup & >= "0.15.0"}
+  "core_bench" {with-dev-setup & >= "v0.15.0"}
+  "core_unix" {with-dev-setup & >= "v0.15.0"}
   "utop" {with-dev-setup}
   "odoc" {with-doc}
 ]

--- a/packages/oktree/oktree.0.2.4/opam
+++ b/packages/oktree/oktree.0.2.4/opam
@@ -21,8 +21,8 @@ depends: [
   "ocp-indent" {with-dev-setup}
   "opam-publish" {with-dev-setup}
   "ocaml-lsp-server" {with-dev-setup}
-  "core_bench" {with-dev-setup & >= "0.15.0"}
-  "core_unix" {with-dev-setup & >= "0.15.0"}
+  "core_bench" {with-dev-setup & >= "v0.15.0"}
+  "core_unix" {with-dev-setup & >= "v0.15.0"}
   "landmarks" {with-dev-setup}
   "landmarks-ppx" {with-dev-setup}
   "utop" {with-dev-setup}


### PR DESCRIPTION
Some existing packages (base, core, re2, ...) use a v-prefix in their versioning scheme, making for a common tripwire.

This PR corrects oktree's `core_bench` and `core_unix` bounds.

CC: @anentropic