### PR TITLE
Use v-prefix in guardian, jupyter, slugline, soteria, and virtfs package bounds (7/7)

### DIFF
--- a/packages/guardian/guardian.0.4.0/opam
+++ b/packages/guardian/guardian.0.4.0/opam
@@ -33,7 +33,7 @@ depends: [
   "odoc" {with-doc}
   "ppx_deriving" {>= "5.2.1"}
   "ppx_deriving_yojson" {>= "3.6.1"}
-  "ppx_sexp_conv" {>= "0.15.1"}
+  "ppx_sexp_conv" {>= "v0.15.1"}
   "ppx_string"
   "result" {>= "1.5"}
   "sexplib0"

--- a/packages/jupyter/jupyter.3.0.1/opam
+++ b/packages/jupyter/jupyter.3.0.1/opam
@@ -29,7 +29,7 @@ depends: [
   "zmq" {>= "5.0.0"}
   "zmq-lwt" {>= "5.0.0"}
   "yojson" {>="1.6.0"}
-  "ppx_yojson_conv" {>= "0.14.0"}
+  "ppx_yojson_conv" {>= "v0.14.0"}
   "ppx_deriving" {>= "5.2.1"}
   "cryptokit" {>= "1.12"}
   "dune" {>= "1.0.0"}

--- a/packages/slugline/slugline.1.0.0/opam
+++ b/packages/slugline/slugline.1.0.0/opam
@@ -21,7 +21,7 @@ bug-reports: "https://github.com/cargocut/slugline/issues"
 depends: [
   "dune" {>= "3.20"}
   "ocaml" {>= "5.0.0"}
-  "ppx_expect" {with-test & >= "0.17.3"}
+  "ppx_expect" {with-test & >= "v0.17.3"}
   "mdx" {with-test & >= "2.5.1"}
   "utop" {with-dev-setup}
   "ocamlformat" {with-dev-setup}

--- a/packages/soteria/soteria.0.1.0/opam
+++ b/packages/soteria/soteria.0.1.0/opam
@@ -18,7 +18,7 @@ depends: [
   "iter"
   "patricia-tree"
   "cmdliner" {>= "2.0.0"}
-  "ppx_expect" {>= "0.17.0"}
+  "ppx_expect" {>= "v0.17.0"}
   "ppx_blob" {>= "0.9.0"}
   "ppx_subliner" {>= "0.2.1"}
   "ppx_deriving"

--- a/packages/virtfs/virtfs.1.0.0/opam
+++ b/packages/virtfs/virtfs.1.0.0/opam
@@ -22,7 +22,7 @@ bug-reports: "https://github.com/cargocut/virtfs/issues"
 depends: [
   "dune" {>= "3.20"}
   "ocaml" {>= "5.0.0"}
-  "ppx_expect" {with-test & >= "0.17.3"}
+  "ppx_expect" {with-test & >= "v0.17.3"}
   "mdx" {with-test & >= "2.5.1"}
   "utop" {with-dev-setup}
   "ocamlformat" {with-dev-setup}


### PR DESCRIPTION
Some existing packages (base, core, re2, ...) use a v-prefix in their versioning scheme, making for a common tripwire.

This PR corrects the remaining 5 occurrences I found this time around, which have been lumped together in one PR:
- guardian.0.4.0's ppx_sexp_conv package bound
- jupyter.3.0.1's ppx_yojson_conv package bound
- slugline.1.0.0's ppx_expect package bound
- soteria.0.1.0's ppx_expect package bound
- virtfs.1.0.0's ppx_expect package bound

CC: 
- @mabiede for guardian, 
- @zhelih for jupyter
- @xvw for slugline and virtfs
- @N1ark for soteria