### PR TITLE
[new release] dap (1.1.0)

### DIFF
--- a/packages/dap/dap.1.1.0/opam
+++ b/packages/dap/dap.1.1.0/opam
@@ -1,0 +1,45 @@
+opam-version: "2.0"
+synopsis: "Debug adapter protocol"
+description: """
+The Debug Adapter Protocol defines the protocol used between an editor or IDE and a debugger or runtime.
+"""
+maintainer: "文宇祥 <hackwaly@qq.com>"
+authors: "文宇祥 <hackwaly@qq.com>"
+license: "MIT"
+homepage: "https://github.com/hackwaly/ocaml-dap"
+bug-reports: "https://github.com/hackwaly/ocaml-dap/issues"
+dev-repo: "git+https://github.com/hackwaly/ocaml-dap.git"
+doc: "https://hackwaly.github.io/ocaml-dap/"
+depends: [
+  "ocaml" {>= "4.08"}
+  "dune" {>= "2.7"}
+  "yojson"
+  "ppx_here"
+  "ppx_deriving"
+  "ppx_deriving_yojson"
+  "ppx_expect" {with-test & >= "v0.16"}
+  "lwt"
+  "lwt_ppx" {>= "2.0.1"}
+  "lwt_react"
+  "react"
+  "angstrom"
+  "angstrom-lwt-unix"
+  "logs"
+  "fmt" {with-test}
+]
+conflicts: [
+  "result" {< "1.5"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+url {
+  src:
+    "https://github.com/hackwaly/ocaml-dap/releases/download/1.1.0/dap-1.1.0.tbz"
+  checksum: [
+    "sha256=0b4cdef2ec61b98f73b686a6cb9cde8dde14404097f52a9367c55f1667441712"
+    "sha512=ba1897e3afa66b34ad65911dee0b433c48756a5c81467b6277cc2fc1f4360533af7c707744b87707afa9891886dcdb0f7fa7e1653807903f5bd2c1d36a4d92d0"
+  ]
+}
+x-commit-hash: "ca76090bf46b501213109b42ddb7d4cb323ab9e6"

--- a/packages/earlybird/earlybird.1.3.5/opam
+++ b/packages/earlybird/earlybird.1.3.5/opam
@@ -25,7 +25,7 @@ depends: [
   "sexplib" {>= "v0.14.0"}
   "csexp" {>= "1.3.2"}
   "lru" {>= "0.3.0"}
-  "dap" {>= "1.0.6"}
+  "dap" {>= "1.0.6" & < "1.1.0"}
   "odoc" {with-doc}
 ]
 build: [

--- a/packages/earlybird/earlybird.1.3.6/opam
+++ b/packages/earlybird/earlybird.1.3.6/opam
@@ -25,7 +25,7 @@ depends: [
   "sexplib" {>= "v0.14.0"}
   "csexp" {>= "1.3.2"}
   "lru" {>= "0.3.0"}
-  "dap" {>= "1.0.6"}
+  "dap" {>= "1.0.6" & < "1.1.0"}
   "odoc" {with-doc}
 ]
 build: [


### PR DESCRIPTION
Debug adapter protocol

- Project page: <a href="https://github.com/hackwaly/ocaml-dap">https://github.com/hackwaly/ocaml-dap</a>
- Documentation: <a href="https://hackwaly.github.io/ocaml-dap/">https://hackwaly.github.io/ocaml-dap/</a>

##### CHANGES:

### Added

- Updated the bundled schema to the latest Debug Adapter Protocol snapshot
  (spec 1.71). Adds the `outputPresentation` field on `StartDebugging` and
  refreshes documentation across the generated types. Builds on the schema
  update and generator consolidation from hackwaly/ocaml-dap#3.
- Generated the `arguments` field on the `restart` request
  (`Restart_command.Arguments`) so it carries the latest launch/attach
  configuration instead of an empty object.
- Added Error_with_message exception.
