### PR TITLE
Fix cloning on macOS and build on Windows

### DIFF
--- a/packages/ocaml-compiler/ocaml-compiler.5.5.0/opam
+++ b/packages/ocaml-compiler/ocaml-compiler.5.5.0/opam
@@ -58,11 +58,13 @@ depends: [
   "flexdll" {>= "0.44" & os = "win32"}
 ]
 build-env: [
+  [OCAMLTOP_INCLUDE_PATH = ""]
   [MSYS2_ARG_CONV_EXCL = "*"]
   [LSAN_OPTIONS = "detect_leaks=0,exitcode=0"]
   [ASAN_OPTIONS = "detect_leaks=0,exitcode=0"]
 ]
 build: [
+  [ "mv" "-f" "process.sh" "generate.ml" "tools/opam/" ] {os = "macos"}
   [
     "sh" "tools/opam/process.sh" make "-j%{jobs}%" _:build-id _:name compiler-cloning:version
     "--host=x86_64-pc-windows"  {system-msvc:installed & arch-x86_64:installed}
@@ -105,6 +107,22 @@ install: ["sh" "tools/opam/process.sh" make "install" _:build-id _:name prefix]
 url {
   src: "https://github.com/ocaml/ocaml/releases/download/5.5.0/ocaml-5.5.0.tar.gz"
   checksum: "sha256=c018052c8264a3791a8f54f84179e6bcc78ed82eb889bacc2773df445259aed3"
+}
+extra-source "generate.ml" {
+  src:
+    "https://raw.githubusercontent.com/ocaml/ocaml/7d0416cce03eaab10918bb10401a617e9321c582/tools/opam/generate.ml"
+  checksum: [
+    "sha512=d05f51b1f419353f22855f934cdbc9fe92c8a1ea4fcb214d34a06f9b03c14befc5018c34d8f87dfc528e0fe280c6678ab15e3228670ae1a688f7f44ab43c7601"
+    "sha256=092668b0180282fc5ae3de184048845b04ad38254acb100576e162a4513a31ab"
+  ]
+}
+extra-source "process.sh" {
+  src:
+    "https://raw.githubusercontent.com/ocaml/ocaml/7d0416cce03eaab10918bb10401a617e9321c582/tools/opam/process.sh"
+  checksum: [
+    "sha512=dd6ef9616825042381058d737383f867d29010b38e1a9f84ec8b473c067e539272f60f17dd268b06c6b00a4bd352fbbe89954c69e2cc2f49b941f87b322dd76d"
+    "sha256=7a5c434733b2bc5aa3516c1a425f38ccf655839f3073b21cd21ac2607b223d60"
+  ]
 }
 depopts: [
   "ocaml-option-32bit"


### PR DESCRIPTION
This is a pair of fixes for #29496 and ocaml/ocaml#14871 for OCaml 5.5.0. It's draft, because the `process.sh` and `generate.ml` should be taken after https://github.com/ocaml/ocaml/pull/14923 is merged, using the merge commit of the PR on trunk instead.

Two important things to note:
1. This doesn't in any way alter the compiler itself - the files installed will be identical (on Windows) and the only difference on macOS is the `share/ocaml/clone` script (i.e. the script which duplicates the compiler, which is not morally part of it).
2. Changing the `opam` file changes the build ID, which means that previously installed copies of OCaml 5.5.0 would not be considered for cloning by this revised opam file. Existing switches will detect a change in the compiler; the first one to be upgraded will recompile OCaml - any subsequent ones will then clone it as normal.

The `build-env` change mitigates https://github.com/ocaml/opam/issues/6456 on Windows. I've tested it by manually setting `OCAMLTOP_INCLUDE_PATH` to a directory triggering the Windows kernel bug identified in https://github.com/ocaml/ocaml/pull/14919. It is a somewhat pyrrhic victory, because it simply moves the build failure from `ocaml-compiler` to `ocaml`, but it does have the considerable benefit that the compiler is correctly built, which means that having _fixed_ the environment variable, you don't have to wait for a complete rebuild.

The macOS change simply adopts the new script generator from https://github.com/ocaml/ocaml/pull/14923 (which should be part of OCaml 5.5.1).