### PR TITLE
[new release] chatoyant (0.12.2)

### DIFF
--- a/packages/chatoyant/chatoyant.0.12.2/opam
+++ b/packages/chatoyant/chatoyant.0.12.2/opam
@@ -1,0 +1,67 @@
+opam-version: "2.0"
+synopsis: "OCaml-first LLM SDK with Melange-generated JavaScript"
+description:
+  "Chatoyant is an OCaml-first SDK for LLM providers. It exposes an Eio native API, typed JSON Schema and tool definitions, raw provider clients for OpenAI/Anthropic/xAI/OpenRouter/local inference, and a Melange-generated JavaScript package."
+maintainer: ["Anonyfox <max@anonyfox.com>"]
+authors: ["Anonyfox <max@anonyfox.com>"]
+license: "MIT"
+tags: [
+  "llm"
+  "ai"
+  "openai"
+  "anthropic"
+  "xai"
+  "openrouter"
+  "json-schema"
+  "eio"
+  "melange"
+  "typesafe"
+]
+homepage: "https://github.com/Anonyfox/chatoyant"
+doc: "https://anonyfox.github.io/chatoyant"
+bug-reports: "https://github.com/Anonyfox/chatoyant/issues"
+depends: [
+  "ocaml" {>= "5.3"}
+  "dune" {>= "3.23"}
+  "melange" {>= "6.0.0"}
+  "ca-certs" {>= "1.0.0"}
+  "base64"
+  "cohttp-eio" {>= "6.0.0"}
+  "digestif"
+  "domain-name"
+  "eio" {>= "1.0"}
+  "eio_main" {with-test}
+  "http" {>= "6.0.0"}
+  "mirage-crypto-rng" {>= "1.0.0"}
+  "ppxlib" {build}
+  "tls" {>= "1.0.0"}
+  "tls-eio" {>= "1.0.0"}
+  "uri"
+  "x509" {>= "1.0.0"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/Anonyfox/chatoyant.git"
+x-maintenance-intent: ["(latest)"]
+url {
+  src:
+    "https://github.com/Anonyfox/chatoyant/releases/download/v0.12.2/chatoyant-v0.12.2.tbz"
+  checksum: [
+    "sha256=a885dcf4b3c6ede268e2027bedf6955a5c889f7ed01c40b719f8369655957d47"
+    "sha512=0bb8dfa12157ba2e482927717c2242c1ea914dce1427801e405987811550afbd6d6b11f07d1e1379259360d17f4ca43ff81963bf407cddb7bedd0dfbb93a55ee"
+  ]
+}
+x-commit-hash: "3506d379ab3cc751e9dd819e05a5f39b5fa9031c"


### PR DESCRIPTION
Release of **chatoyant** 0.12.2: an OCaml-first SDK for LLM providers
(OpenAI, Anthropic, xAI, OpenRouter, local OpenAI-compatible servers) with an
Eio native API, typed tools and structured outputs, streaming, and token/cost
accounting.

- Sources: https://github.com/Anonyfox/chatoyant
- Changes: https://github.com/Anonyfox/chatoyant/blob/main/CHANGELOG.md
- Tests run offline (`with-test` needs no network or API keys).

🤖 Generated with [Claude Code](https://claude.com/claude-code)