### PR TITLE
[new release] chatoyant (0.12.3)

### DIFF
--- a/packages/chatoyant/chatoyant.0.12.3/opam
+++ b/packages/chatoyant/chatoyant.0.12.3/opam
@@ -1,0 +1,67 @@
+opam-version: "2.0"
+synopsis: "OCaml-first LLM SDK with Melange-generated JavaScript"
+description:
+  "Chatoyant is an OCaml-first SDK for LLM providers. It exposes an Eio native API, typed JSON Schema and tool definitions, raw provider clients for OpenAI/Anthropic/xAI/OpenRouter/local inference, and a Melange-generated JavaScript package."
+maintainer: ["Anonyfox <max@anonyfox.com>"]
+authors: ["Anonyfox <max@anonyfox.com>"]
+license: "MIT"
+tags: [
+  "llm"
+  "ai"
+  "openai"
+  "anthropic"
+  "xai"
+  "openrouter"
+  "json-schema"
+  "eio"
+  "melange"
+  "typesafe"
+]
+homepage: "https://github.com/Anonyfox/chatoyant"
+doc: "https://anonyfox.github.io/chatoyant"
+bug-reports: "https://github.com/Anonyfox/chatoyant/issues"
+depends: [
+  "ocaml" {>= "5.3"}
+  "dune" {>= "3.23"}
+  "melange" {>= "6.0.0"}
+  "ca-certs" {>= "1.0.0"}
+  "base64"
+  "cohttp-eio" {>= "6.0.0"}
+  "digestif"
+  "domain-name"
+  "eio" {>= "1.0"}
+  "eio_main" {with-test}
+  "http" {>= "6.0.0"}
+  "mirage-crypto-rng" {>= "1.0.0"}
+  "ppxlib" {build}
+  "tls" {>= "1.0.0"}
+  "tls-eio" {>= "1.0.0"}
+  "uri"
+  "x509" {>= "1.0.0"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/Anonyfox/chatoyant.git"
+x-maintenance-intent: ["(latest)"]
+url {
+  src:
+    "https://github.com/Anonyfox/chatoyant/releases/download/v0.12.3/chatoyant-v0.12.3.tbz"
+  checksum: [
+    "sha256=887035464d9d15f2dc74f8936ba4b30cd5d885fefe45da8eb04bfde784e239d9"
+    "sha512=8b8cc63337f0002b4d86faf159406c65ca2d278ed3d51dc1394f09b21ede29836be38b447e659098bdea9a1846850e8980372fd7dc0da05143c30faf78b38190"
+  ]
+}
+x-commit-hash: "4debff6dd0bc8f9009b739b5695d4fb00315dc85"


### PR DESCRIPTION
Release of **chatoyant** 0.12.3: an OCaml-first SDK for LLM providers
(OpenAI, Anthropic, xAI, OpenRouter, local OpenAI-compatible servers) with an
Eio native API, typed tools and structured outputs, streaming, and token/cost
accounting.

- Sources: https://github.com/Anonyfox/chatoyant
- Changes: https://github.com/Anonyfox/chatoyant/blob/main/CHANGELOG.md
- Tests run offline (`with-test` needs no network or API keys).

🤖 Generated with [Claude Code](https://claude.com/claude-code)