### PR TITLE
[new release] chatoyant (0.12.4)

### DIFF
--- a/packages/chatoyant/chatoyant.0.12.4/opam
+++ b/packages/chatoyant/chatoyant.0.12.4/opam
@@ -1,0 +1,67 @@
+opam-version: "2.0"
+synopsis: "OCaml-first LLM SDK with Melange-generated JavaScript"
+description:
+  "Chatoyant is an OCaml-first SDK for LLM providers. It exposes an Eio native API, typed JSON Schema and tool definitions, raw provider clients for OpenAI/Anthropic/xAI/OpenRouter/local inference, and a Melange-generated JavaScript package."
+maintainer: ["Anonyfox <max@anonyfox.com>"]
+authors: ["Anonyfox <max@anonyfox.com>"]
+license: "MIT"
+tags: [
+  "llm"
+  "ai"
+  "openai"
+  "anthropic"
+  "xai"
+  "openrouter"
+  "json-schema"
+  "eio"
+  "melange"
+  "typesafe"
+]
+homepage: "https://github.com/Anonyfox/chatoyant"
+doc: "https://anonyfox.github.io/chatoyant"
+bug-reports: "https://github.com/Anonyfox/chatoyant/issues"
+depends: [
+  "ocaml" {>= "5.3"}
+  "dune" {>= "3.23"}
+  "melange" {>= "6.0.0"}
+  "ca-certs" {>= "1.0.0"}
+  "base64"
+  "cohttp-eio" {>= "6.0.0"}
+  "digestif"
+  "domain-name"
+  "eio" {>= "1.0"}
+  "eio_main" {with-test}
+  "http" {>= "6.0.0"}
+  "mirage-crypto-rng" {>= "1.0.0"}
+  "ppxlib" {build}
+  "tls" {>= "1.0.0"}
+  "tls-eio" {>= "1.0.0"}
+  "uri"
+  "x509" {>= "1.0.0"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/Anonyfox/chatoyant.git"
+x-maintenance-intent: ["(latest)"]
+url {
+  src:
+    "https://github.com/Anonyfox/chatoyant/releases/download/v0.12.4/chatoyant-v0.12.4.tbz"
+  checksum: [
+    "sha256=fbf19dea0d39482e0263812504d94c682a9f3a6e93f68fe0c57b2d38ed4166b3"
+    "sha512=4e01be9c0ec9c16880f98360dec4ef5e0dddd9192e2113991b154e891b3bdaefb614051c2cb63afa0b714efa0e4cc4fd8054528fdc1995f3a4858fe2fcd50256"
+  ]
+}
+x-commit-hash: "b6797cbaa59e3700f1e1fa960cf2c5d6817c8b97"


### PR DESCRIPTION
Release of **chatoyant** 0.12.4: an OCaml-first SDK for LLM providers
(OpenAI, Anthropic, xAI, OpenRouter, local OpenAI-compatible servers) with an
Eio native API, typed tools and structured outputs, streaming, and token/cost
accounting.

- Sources: https://github.com/Anonyfox/chatoyant
- Changes: https://github.com/Anonyfox/chatoyant/blob/main/CHANGELOG.md
- Tests run offline (`with-test` needs no network or API keys).

🤖 Generated with [Claude Code](https://claude.com/claude-code)