### PR TITLE
Mark riot as non-maintaned

### DIFF
--- a/packages/riot/riot.0.0.2/opam
+++ b/packages/riot/riot.0.0.2/opam
@@ -44,3 +44,4 @@ url {
 }
 x-commit-hash: "3a46b02dab5953c8003826306b4ca0048a64f054"
 x-maintenance-intent: ["(none)"]
+available: false

--- a/packages/riot/riot.0.0.2/opam
+++ b/packages/riot/riot.0.0.2/opam
@@ -36,7 +36,7 @@ build: [
 dev-repo: "git+https://github.com/leostera/riot.git"
 url {
   src:
-    "https://github.com/leostera/riot/releases/download/0.0.2/riot-0.0.2.tbz"
+    "https://github.com/ocaml/opam-source-archives/raw/main/riot-0.0.2.tbz"
   checksum: [
     "sha256=724fedaf9a349ca17858d8233ce0c7835fed95a2afd49b6e620a987c8219efc4"
     "sha512=c83a6c51f89583d0b171901618d81894b38376b8ad2bea901de4d9ab4511b8008cca76302278a69a202157e9c379f2802392c4e17046d0ec2843052dc0610b3e"

--- a/packages/riot/riot.0.0.2/opam
+++ b/packages/riot/riot.0.0.2/opam
@@ -43,3 +43,4 @@ url {
   ]
 }
 x-commit-hash: "3a46b02dab5953c8003826306b4ca0048a64f054"
+x-maintenance-intent: ["(none)"]

--- a/packages/riot/riot.0.0.3/opam
+++ b/packages/riot/riot.0.0.3/opam
@@ -42,3 +42,4 @@ url {
   ]
 }
 x-commit-hash: "8f6c100541ca46a7a42ef0ff0d5ec2e6ff6afc6e"
+x-maintenance-intent: ["(none)"]

--- a/packages/riot/riot.0.0.3/opam
+++ b/packages/riot/riot.0.0.3/opam
@@ -43,3 +43,4 @@ url {
 }
 x-commit-hash: "8f6c100541ca46a7a42ef0ff0d5ec2e6ff6afc6e"
 x-maintenance-intent: ["(none)"]
+available: false

--- a/packages/riot/riot.0.0.3/opam
+++ b/packages/riot/riot.0.0.3/opam
@@ -35,7 +35,7 @@ build: [
 dev-repo: "git+https://github.com/leostera/riot.git"
 url {
   src:
-    "https://github.com/leostera/riot/releases/download/0.0.3/riot-0.0.3.tbz"
+    "https://github.com/ocaml/opam-source-archives/raw/main/riot-0.0.3.tbz"
   checksum: [
     "sha256=6201ce27997ec1c4b4509782c6be2fa2bf102b804b11dcbf9ebdb49a123c19c3"
     "sha512=ad70a67601a892700e461efe57484d109b1d08e30d15464ad8611e71dd568c934d3f948afd645e096e4f97ad1935aaeaf5d9b6d9d59c52a82eeb5c4995421646"

--- a/packages/riot/riot.0.0.4/opam
+++ b/packages/riot/riot.0.0.4/opam
@@ -35,7 +35,7 @@ build: [
 dev-repo: "git+https://github.com/leostera/riot.git"
 url {
   src:
-    "https://github.com/leostera/riot/releases/download/0.0.4/riot-0.0.4.tbz"
+    "https://github.com/ocaml/opam-source-archives/raw/main/riot-0.0.4.tbz"
   checksum: [
     "sha256=bd196369f74bbc42f23d262030d5fa04c03f5f00c46bf944f0dcbc193745976f"
     "sha512=f1ca69e05b57e83a1bd173efe51b745d331355a83381e6068743a7626e45dcf515cdd8947180051bddfe9f5727c2732aa0f01a093b04cf33fa4081d32f24fd65"

--- a/packages/riot/riot.0.0.4/opam
+++ b/packages/riot/riot.0.0.4/opam
@@ -42,3 +42,4 @@ url {
   ]
 }
 x-commit-hash: "6c862bf5376f9ea465faec6a7ba6bebf1e6d791d"
+x-maintenance-intent: ["(none)"]

--- a/packages/riot/riot.0.0.4/opam
+++ b/packages/riot/riot.0.0.4/opam
@@ -43,3 +43,4 @@ url {
 }
 x-commit-hash: "6c862bf5376f9ea465faec6a7ba6bebf1e6d791d"
 x-maintenance-intent: ["(none)"]
+available: false

--- a/packages/riot/riot.0.0.5/opam
+++ b/packages/riot/riot.0.0.5/opam
@@ -42,3 +42,4 @@ url {
   ]
 }
 x-commit-hash: "98855655048893413233afff6e7c47df2702041a"
+x-maintenance-intent: ["(none)"]

--- a/packages/riot/riot.0.0.5/opam
+++ b/packages/riot/riot.0.0.5/opam
@@ -35,7 +35,7 @@ build: [
 dev-repo: "git+https://github.com/leostera/riot.git"
 url {
   src:
-    "https://github.com/leostera/riot/releases/download/0.0.5/riot-0.0.5.tbz"
+    "https://github.com/ocaml/opam-source-archives/raw/main/riot-0.0.5.tbz"
   checksum: [
     "sha256=01b7b82ccc656b12b7315960d9df17eb4682b8f1af68e9fee33171fee1f9cf88"
     "sha512=d8831d8a75fe43a7e8d16d2c0bb7d27f6d975133e17c5dd89ef7e575039c59d27c1ab74fbadcca81ddfbc0c74d1e46c35baba35ef825b36ac6c4e49d7a41d0c2"

--- a/packages/riot/riot.0.0.5/opam
+++ b/packages/riot/riot.0.0.5/opam
@@ -43,3 +43,4 @@ url {
 }
 x-commit-hash: "98855655048893413233afff6e7c47df2702041a"
 x-maintenance-intent: ["(none)"]
+available: false

--- a/packages/riot/riot.0.0.7/opam
+++ b/packages/riot/riot.0.0.7/opam
@@ -43,3 +43,4 @@ url {
   ]
 }
 x-commit-hash: "7dc78950b5dc172aef74bacee977abd2011005d2"
+x-maintenance-intent: ["(none)"]

--- a/packages/riot/riot.0.0.7/opam
+++ b/packages/riot/riot.0.0.7/opam
@@ -36,7 +36,7 @@ build: [
 dev-repo: "git+https://github.com/leostera/riot.git"
 url {
   src:
-    "https://github.com/leostera/riot/releases/download/0.0.7/riot-0.0.7.tbz"
+    "https://github.com/ocaml/opam-source-archives/raw/main/riot-0.0.7.tbz"
   checksum: [
     "sha256=b7e3cc061e2b6578bcd9d5258efde72f3657e68d626a005b43d15f1a7aff769e"
     "sha512=00dcd34cce21058137cca15229a81e0e2c898f9877f22db6903288c8f757847a65965cfe791f84fe251df342f90e7e4aefe04f2fbb6ba282ad45b1a3b979e6cf"

--- a/packages/riot/riot.0.0.7/opam
+++ b/packages/riot/riot.0.0.7/opam
@@ -44,3 +44,4 @@ url {
 }
 x-commit-hash: "7dc78950b5dc172aef74bacee977abd2011005d2"
 x-maintenance-intent: ["(none)"]
+available: false

--- a/packages/riot/riot.0.0.8/opam
+++ b/packages/riot/riot.0.0.8/opam
@@ -53,3 +53,4 @@ url {
   ]
 }
 x-commit-hash: "a9201dee30ae4a38c429d374fd04b5fd0a610b8c"
+x-maintenance-intent: ["(none)"]

--- a/packages/riot/riot.0.0.9/opam
+++ b/packages/riot/riot.0.0.9/opam
@@ -52,3 +52,4 @@ url {
   ]
 }
 x-commit-hash: "89ab4b9de3f289e36559637deb9ef9d4c0150d7c"
+x-maintenance-intent: ["(none)"]


### PR DESCRIPTION
1st commit should be OK

2nd:
```
    Mark versions of riot with bad checksum as unavailable #30242

    Ideally we want to find riight tarball and put it into opam-archives
    but the library is not maintained and new version is availalbe, so
    maybe we can skip doing extra work
```    
if somebody has time to search for right tarball, we can revert 2nd one