### PR TITLE
[new release] melange (7.0.1-{414,51,52,53,54,55})

### DIFF
--- a/packages/melange/melange.7.0.1-414/opam
+++ b/packages/melange/melange.7.0.1-414/opam
@@ -1,0 +1,46 @@
+opam-version: "2.0"
+synopsis: "Toolchain to produce JS from Reason/OCaml"
+maintainer: ["Antonio Nuno Monteiro <anmonteiro@gmail.com>"]
+authors: ["Antonio Nuno Monteiro <anmonteiro@gmail.com>"]
+license: "LGPL-2.1-or-later"
+homepage: "https://github.com/melange-re/melange"
+bug-reports: "https://github.com/melange-re/melange/issues"
+depends: [
+  "dune" {>= "3.21"}
+  "ocaml" {>= "4.14" & < "4.15"}
+  "cmdliner" {>= "1.1.0"}
+  "dune-build-info"
+  "cppo" {build}
+  "alcotest" {with-test}
+  "reason" {with-test}
+  "ppxlib" { >= "0.36.0" }
+  "menhir" {>= "20201214"}
+  "reason-react-ppx" {with-test & post}
+  "merlin" {with-test}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+available: arch != "x86_32" & arch != "arm32"
+dev-repo: "git+https://github.com/melange-re/melange.git"
+x-maintenance-intent: ["(latest)"]
+url {
+  src:
+    "https://github.com/melange-re/melange/releases/download/7.0.1-414/melange-7.0.1-414.tbz"
+  checksum: [
+    "sha256=4cbd885db9801068fb59d13b6e08e13fe3fe091dc14716382a90764ee874a8a7"
+    "sha512=155d448a0e84e81541fd0989d3a7f4b96c625ff288aeeccfadf7e36751f1188bc295c999cc725fda5ad157150eed33ebc5735d81820b9fc45772bdbf0f6d9b29"
+  ]
+}
+x-commit-hash: "dd4b95e58265dc569e7737b0d75131e86ec6b796"

--- a/packages/melange/melange.7.0.1-51/opam
+++ b/packages/melange/melange.7.0.1-51/opam
@@ -1,0 +1,46 @@
+opam-version: "2.0"
+synopsis: "Toolchain to produce JS from Reason/OCaml"
+maintainer: ["Antonio Nuno Monteiro <anmonteiro@gmail.com>"]
+authors: ["Antonio Nuno Monteiro <anmonteiro@gmail.com>"]
+license: "LGPL-2.1-or-later"
+homepage: "https://github.com/melange-re/melange"
+bug-reports: "https://github.com/melange-re/melange/issues"
+depends: [
+  "dune" {>= "3.21"}
+  "ocaml" {>= "5.1" & < "5.2"}
+  "cmdliner" {>= "1.1.0"}
+  "dune-build-info"
+  "cppo" {build}
+  "alcotest" {with-test}
+  "reason" {with-test}
+  "ppxlib" { >= "0.36.0" }
+  "menhir" {>= "20201214"}
+  "reason-react-ppx" {with-test & post}
+  "merlin" {with-test}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+available: arch != "x86_32" & arch != "arm32"
+dev-repo: "git+https://github.com/melange-re/melange.git"
+x-maintenance-intent: ["(latest)"]
+url {
+  src:
+    "https://github.com/melange-re/melange/releases/download/7.0.1-51/melange-7.0.1-51.tbz"
+  checksum: [
+    "sha256=8545aa623cd168307474f9940c955ce3ffff537dc2e8a52bdc22a80098ad83b2"
+    "sha512=c36c2aca4b91244de3ab08dbb8231e9a0fa0296528d5c6c7dddef99d408a64b7264b788999c09b4e0b065cf640138629bc38350f965a2b28d84c3a378869845e"
+  ]
+}
+x-commit-hash: "f46c480e81e6d59111b555d0e62291c893182572"

--- a/packages/melange/melange.7.0.1-52/opam
+++ b/packages/melange/melange.7.0.1-52/opam
@@ -1,0 +1,46 @@
+opam-version: "2.0"
+synopsis: "Toolchain to produce JS from Reason/OCaml"
+maintainer: ["Antonio Nuno Monteiro <anmonteiro@gmail.com>"]
+authors: ["Antonio Nuno Monteiro <anmonteiro@gmail.com>"]
+license: "LGPL-2.1-or-later"
+homepage: "https://github.com/melange-re/melange"
+bug-reports: "https://github.com/melange-re/melange/issues"
+depends: [
+  "dune" {>= "3.21"}
+  "ocaml" {>= "5.2" & < "5.3"}
+  "cmdliner" {>= "1.1.0"}
+  "dune-build-info"
+  "cppo" {build}
+  "alcotest" {with-test}
+  "reason" {with-test}
+  "ppxlib" { >= "0.36.0" }
+  "menhir" {>= "20201214"}
+  "reason-react-ppx" {with-test & post}
+  "merlin" {with-test}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+available: arch != "x86_32" & arch != "arm32"
+dev-repo: "git+https://github.com/melange-re/melange.git"
+x-maintenance-intent: ["(latest)"]
+url {
+  src:
+    "https://github.com/melange-re/melange/releases/download/7.0.1-52/melange-7.0.1-52.tbz"
+  checksum: [
+    "sha256=03d9a0b6f6e8add8025a4dd25cc3c7aa685beefff3d6391cfcd8e3c7217ee822"
+    "sha512=75a4a999995eddac8a1fa9844fd8f8ae885ba77f5a3ea189b49e6030ad470c30dda5ffe5d6eef2693a8080d99f50cd3b03cfa07b40a2f9055aa756308546b9b3"
+  ]
+}
+x-commit-hash: "7252122fdc6c49ba34e298a4829190817a8defe7"

--- a/packages/melange/melange.7.0.1-53/opam
+++ b/packages/melange/melange.7.0.1-53/opam
@@ -1,0 +1,46 @@
+opam-version: "2.0"
+synopsis: "Toolchain to produce JS from Reason/OCaml"
+maintainer: ["Antonio Nuno Monteiro <anmonteiro@gmail.com>"]
+authors: ["Antonio Nuno Monteiro <anmonteiro@gmail.com>"]
+license: "LGPL-2.1-or-later"
+homepage: "https://github.com/melange-re/melange"
+bug-reports: "https://github.com/melange-re/melange/issues"
+depends: [
+  "dune" {>= "3.21"}
+  "ocaml" {>= "5.3" & < "5.4"}
+  "cmdliner" {>= "1.1.0"}
+  "dune-build-info"
+  "cppo" {build}
+  "alcotest" {with-test}
+  "reason" {with-test}
+  "ppxlib" { >= "0.36.0" }
+  "menhir" {>= "20201214"}
+  "reason-react-ppx" {with-test & post}
+  "merlin" {with-test}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+available: arch != "x86_32" & arch != "arm32"
+dev-repo: "git+https://github.com/melange-re/melange.git"
+x-maintenance-intent: ["(latest)"]
+url {
+  src:
+    "https://github.com/melange-re/melange/releases/download/7.0.1-53/melange-7.0.1-53.tbz"
+  checksum: [
+    "sha256=25177453269467832be7b6416f1104132265a3309b9098e6b5185b9c0df05150"
+    "sha512=f49de014f013792413b083772a93d13b2a072a468e29600c19dc8cc54c6de56bbbf03d227e4641dc084e94b70bed202e348860258b0df747da794fa6fce6725d"
+  ]
+}
+x-commit-hash: "ddc1436070616766f45e5000b7822c7156c36515"

--- a/packages/melange/melange.7.0.1-54/opam
+++ b/packages/melange/melange.7.0.1-54/opam
@@ -1,0 +1,46 @@
+opam-version: "2.0"
+synopsis: "Toolchain to produce JS from Reason/OCaml"
+maintainer: ["Antonio Nuno Monteiro <anmonteiro@gmail.com>"]
+authors: ["Antonio Nuno Monteiro <anmonteiro@gmail.com>"]
+license: "LGPL-2.1-or-later"
+homepage: "https://github.com/melange-re/melange"
+bug-reports: "https://github.com/melange-re/melange/issues"
+depends: [
+  "dune" {>= "3.21"}
+  "ocaml" {>= "5.4" & < "5.5"}
+  "cmdliner" {>= "1.1.0"}
+  "dune-build-info"
+  "cppo" {build}
+  "alcotest" {with-test}
+  "reason" {with-test}
+  "ppxlib" { >= "0.36.0" }
+  "menhir" {>= "20201214"}
+  "reason-react-ppx" {with-test & post}
+  "merlin" {with-test}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+available: arch != "x86_32" & arch != "arm32"
+dev-repo: "git+https://github.com/melange-re/melange.git"
+x-maintenance-intent: ["(latest)"]
+url {
+  src:
+    "https://github.com/melange-re/melange/releases/download/7.0.1-54/melange-7.0.1-54.tbz"
+  checksum: [
+    "sha256=49bf9d3dd10d0d7f58abe6755a40c246d36b5fbf6b5e189f2c634c47a9de7f33"
+    "sha512=13061ec3a9e314185175d90f684c725ca3aa7de3f6a64465868112ee79daf08017c616b1410bb582e2e657b84d1281b965ef2af70b7c01ec47dab1d384bb9eef"
+  ]
+}
+x-commit-hash: "dfa8f1f7597f667b9d57e37142c1f52ce613b509"

--- a/packages/melange/melange.7.0.1-55/opam
+++ b/packages/melange/melange.7.0.1-55/opam
@@ -1,0 +1,46 @@
+opam-version: "2.0"
+synopsis: "Toolchain to produce JS from Reason/OCaml"
+maintainer: ["Antonio Nuno Monteiro <anmonteiro@gmail.com>"]
+authors: ["Antonio Nuno Monteiro <anmonteiro@gmail.com>"]
+license: "LGPL-2.1-or-later"
+homepage: "https://github.com/melange-re/melange"
+bug-reports: "https://github.com/melange-re/melange/issues"
+depends: [
+  "dune" {>= "3.21"}
+  "ocaml" {>= "5.5" & < "5.6"}
+  "cmdliner" {>= "1.1.0"}
+  "dune-build-info"
+  "cppo" {build}
+  "alcotest" {with-test}
+  "reason" {with-test}
+  "ppxlib" { >= "0.36.0" }
+  "menhir" {>= "20201214"}
+  "reason-react-ppx" {with-test & post}
+  "merlin" {with-test}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+available: arch != "x86_32" & arch != "arm32"
+dev-repo: "git+https://github.com/melange-re/melange.git"
+x-maintenance-intent: ["(latest)"]
+url {
+  src:
+    "https://github.com/melange-re/melange/releases/download/7.0.1-55/melange-7.0.1-55.tbz"
+  checksum: [
+    "sha256=8377c0860da82528ebde16a0133f270c1a03de35036bd44bbd8cfb87070a7afb"
+    "sha512=a33c1979f9928c9189d519cbc367b40cc9c0735f29735ef0f1ee5e66c204cf73b8a418ed85cb39442637a3369d3287a8c712a9e747c22bb7d0ac3daae59e6bd8"
+  ]
+}
+x-commit-hash: "08cd3ca8fcc9ec2a75ebacb5f86f336467cd2e6c"


### PR DESCRIPTION
7.0.1-55 2026-07-12
---------------

- fix: avoid relocating relative `mel.module` externals when inlining  ([#1799](https://github.com/melange-re/melange/pull/1799),  [#1800](https://github.com/melange-re/melange/pull/1800))

