### PR TITLE
Package ordma.0.0.6

### DIFF
--- a/packages/ordma/ordma.0.0.6/opam
+++ b/packages/ordma/ordma.0.0.6/opam
@@ -1,0 +1,33 @@
+opam-version: "2.0"
+synopsis: "RDMA capabilities for OCaml via rsocket"
+maintainer: "Romain Slootmaekers <toolslive@yahoo.com>"
+authors: "Romain Slootmaekers <romain.slootmaekers@openvstorage.com>"
+license: "MIT"
+homepage: "https://github.com/toolslive/ordma"
+bug-reports: "https://github.com/toolslive/ordma/issues"
+depends: [
+  "ocaml" {>= "4.02.0"}
+  "dune" {build}
+  "lwt" {>= "2.5.1"}
+  "lwt_log"
+  "cmdliner" {with-test}
+]
+available: os = "linux"
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "build" "@test" "-j" jobs] {with-test}
+]
+depexts: [
+  ["libibverbs-dev" "librdmacm-dev"] {os-distribution = "ubuntu"}
+  ["libibverbs-dev" "librdmacm-dev"] {os-distribution = "debian"}
+  ["libibverbs-devel" "librdmacm-devel"] {os-distribution = "centos"}
+]
+dev-repo: "git+https://github.com/toolslive/ordma.git"
+url {
+  src: "https://github.com/toolslive/ordma/archive/refs/tags/0.0.6.tar.gz"
+  checksum: [
+    "md5=e6b63c58694604962790423a73e0d88d"
+    "sha512=637a190f1f12090f05aacb57e2d1f58562e0b4fbd508451777ac09f89692d7605f50a145e84731f817275bb831ec9d38d4fb6ba463b78e0f3c550505ac16e926"
+  ]
+}


### PR DESCRIPTION
### `ordma.0.0.6`
RDMA capabilities for OCaml via rsocket



---
* Homepage: https://github.com/toolslive/ordma
* Source repo: git+https://github.com/toolslive/ordma.git
* Bug tracker: https://github.com/toolslive/ordma/issues

---
:camel: Pull-request generated by opam-publish v3.0.0