### PR TITLE
[new release] cascade (1.0.0)

### DIFF
--- a/packages/cascade/cascade.1.0.0/opam
+++ b/packages/cascade/cascade.1.0.0/opam
@@ -1,0 +1,57 @@
+opam-version: "2.0"
+synopsis: "CSS generation and manipulation library for OCaml"
+description: """
+Cascade provides a typed CSS AST, parser, pretty-printer, and optimizer.
+   Supports selectors, properties, values, media queries, container queries,
+   @supports, @property, @layer, @keyframes, @font-face, and CSS variables."""
+maintainer: ["Thomas Gazagnaire"]
+authors: ["Thomas Gazagnaire"]
+license: "ISC"
+homepage: "https://github.com/samoht/cascade"
+bug-reports: "https://github.com/samoht/cascade/issues"
+depends: [
+  "ocaml" {>= "5.2"}
+  "dune" {>= "3.21"}
+  "dune-build-info"
+  "alcotest" {with-test}
+  "alcobar" {with-test}
+  "astring" {with-test}
+  "eio" {with-test}
+  "eio_main" {with-test}
+  "lambdasoup"
+  "mdx" {with-test}
+  "re" {with-test}
+  "fmt"
+  "base-unix"
+  "uutf"
+  "psq"
+  "logs"
+  "cmdliner"
+  "memtrace"
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/samoht/cascade.git"
+x-maintenance-intent: ["(latest)"]
+url {
+  src:
+    "https://github.com/samoht/cascade/releases/download/1.0.0/cascade-1.0.0.tbz"
+  checksum: [
+    "sha256=39fe60314260dae061208d72a44f6e564f25a1fa300bf99c0c139252f0d203b8"
+    "sha512=1531c46b762b839941b56e0410914aed9c5a9d599764d6b8d38bed420280edbd71b13f81c77ee0cb3ed41307c8a73bf4158937d709fd51f347c9bdb6917e03e6"
+  ]
+}
+x-commit-hash: "7851673e6a6a4aef12598c618d3e23658630d7ff"

--- a/packages/cascade/cascade.1.0.0/opam
+++ b/packages/cascade/cascade.1.0.0/opam
@@ -26,7 +26,7 @@ depends: [
   "uutf"
   "psq"
   "logs"
-  "cmdliner"
+  "cmdliner" {>= "1.1.0"}
   "memtrace"
   "odoc" {with-doc}
 ]


### PR DESCRIPTION
CSS generation and manipulation library for OCaml

- Project page: <a href="https://github.com/samoht/cascade">https://github.com/samoht/cascade</a>

First public release. Cascade is a standalone CSS command-line tool and a DSL to build and manipulate type-safe CSS documents.
