### PR TITLE
[new release] ochre and ochre-cli (1.1.0)

### DIFF
--- a/packages/ochre-cli/ochre-cli.1.1.0/opam
+++ b/packages/ochre-cli/ochre-cli.1.1.0/opam
@@ -11,7 +11,7 @@ bug-reports: "https://github.com/davesnx/ochre/issues"
 depends: [
   "dune" {>= "3.22"}
   "ocaml" {>= "4.14.0"}
-  "ochre"
+  "ochre" {= version}
   "tm-grammars" {>= "2.0.0"}
   "cmdliner" {>= "1.1.0"}
   "dune-build-info"

--- a/packages/ochre-cli/ochre-cli.1.1.0/opam
+++ b/packages/ochre-cli/ochre-cli.1.1.0/opam
@@ -1,0 +1,46 @@
+opam-version: "2.0"
+synopsis: "Command-line interface for ochre syntax highlighter"
+description:
+  "CLI tool for highlighting source code using TextMate grammars and themes."
+maintainer: ["David Sancho"]
+authors: ["David Sancho"]
+license: "MIT"
+homepage: "https://github.com/davesnx/ochre"
+doc: "https://davesnx.github.io/ochre/odoc/"
+bug-reports: "https://github.com/davesnx/ochre/issues"
+depends: [
+  "dune" {>= "3.22"}
+  "ocaml" {>= "4.14.0"}
+  "ochre"
+  "tm-grammars" {>= "2.0.0"}
+  "cmdliner" {>= "1.1.0"}
+  "dune-build-info"
+  "ezjsonm" {with-test}
+  "alcotest" {with-test}
+  "odoc" {>= "3.1.0" & with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/davesnx/ochre.git"
+x-maintenance-intent: ["(latest)"]
+url {
+  src:
+    "https://github.com/davesnx/ochre/releases/download/1.1.0/ochre-1.1.0.tbz"
+  checksum: [
+    "sha256=a8e38fbcd22fbb68b0f7d93b36a2ba1670e8bd061b43a0177226738307183a32"
+    "sha512=7b344c3812be283b0101078564e564732f878ad226c7ce0212c9e9139fb41a291e4d31ad52c949f2978c48e04240d4d22b5b4ae63808e15a21c44a2fbeed8a22"
+  ]
+}
+x-commit-hash: "d9140721475044da694630b1dc17a84e428a3df2"

--- a/packages/ochre/ochre.1.1.0/opam
+++ b/packages/ochre/ochre.1.1.0/opam
@@ -13,7 +13,7 @@ depends: [
   "ocaml" {>= "4.14.0"}
   "yojson" {>= "2.0.0"}
   "melange-json-native" {>= "2.0.0"}
-  "conf-oniguruma" {= "1"}
+  "conf-oniguruma"
   "dune-configurator" {>= "2.9" & build}
   "plist-xml" {>= "0.5.0"}
   "ezjsonm" {with-test}
@@ -53,3 +53,4 @@ url {
   ]
 }
 x-commit-hash: "d9140721475044da694630b1dc17a84e428a3df2"
+x-ci-accept-failures: ["centos-9"]

--- a/packages/ochre/ochre.1.1.0/opam
+++ b/packages/ochre/ochre.1.1.0/opam
@@ -1,0 +1,55 @@
+opam-version: "2.0"
+synopsis: "Syntax highlighter using TextMate grammars and themes"
+description:
+  "ochre is a syntax highlighter inspired by Shiki, using TextMate grammars and themes. It supports HTML output (inline styles or CSS classes), ANSI terminal colors, LaTeX, SVG, and raw token output."
+maintainer: ["David Sancho"]
+authors: ["David Sancho"]
+license: "MIT"
+homepage: "https://github.com/davesnx/ochre"
+doc: "https://davesnx.github.io/ochre/odoc/"
+bug-reports: "https://github.com/davesnx/ochre/issues"
+depends: [
+  "dune" {>= "3.22"}
+  "ocaml" {>= "4.14.0"}
+  "yojson" {>= "2.0.0"}
+  "melange-json-native" {>= "2.0.0"}
+  "conf-oniguruma" {= "1"}
+  "dune-configurator" {>= "2.9" & build}
+  "plist-xml" {>= "0.5.0"}
+  "ezjsonm" {with-test}
+  "html_of_jsx" {>= "0.0.9" & with-test}
+  "tiny_httpd" {with-test}
+  "odoc" {>= "3.1.0" & with-doc}
+  "tm-grammars" {>= "2.0.0" & with-test}
+  "alcotest" {with-test}
+  "mlx" {with-test}
+  "ocaml-lsp-server" {with-dev-setup}
+  "ocamlmerlin-mlx" {with-dev-setup}
+  "ocamlformat-mlx" {with-dev-setup}
+  "ocamlformat" {= "0.29.0" & with-dev-setup}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/davesnx/ochre.git"
+x-maintenance-intent: ["(latest)"]
+url {
+  src:
+    "https://github.com/davesnx/ochre/releases/download/1.1.0/ochre-1.1.0.tbz"
+  checksum: [
+    "sha256=a8e38fbcd22fbb68b0f7d93b36a2ba1670e8bd061b43a0177226738307183a32"
+    "sha512=7b344c3812be283b0101078564e564732f878ad226c7ce0212c9e9139fb41a291e4d31ad52c949f2978c48e04240d4d22b5b4ae63808e15a21c44a2fbeed8a22"
+  ]
+}
+x-commit-hash: "d9140721475044da694630b1dc17a84e428a3df2"


### PR DESCRIPTION
Syntax highlighter using TextMate grammars and themes

- Project page: <a href="https://github.com/davesnx/ochre">https://github.com/davesnx/ochre</a>
- Documentation: <a href="https://davesnx.github.io/ochre/odoc/">https://davesnx.github.io/ochre/odoc/</a>

##### CHANGES:

- Add built-in `plaintext`/`text`/`txt` languages that produce unstyled tokens without a grammar, in both the library and the CLI.
- Add `?options` and `?extra_themes` to `Ochre.to_string`, giving the runtime-format API the same HTML capabilities as `Ochre.to_html`.
- Report the real package version from `ochre --version` instead of a hardcoded string.
- Preserve source line endings across tokenization, CLI input, and rendered output.
- Reject multi-theme transforms that produce incompatible token structures.
- Count decoration positions as Unicode scalar values instead of UTF-8 bytes.
- Report CLI input and theme loading failures without uncaught exceptions.
- Document all CLI flags, bundled grammars, and dual-theme HTML output in the CLI reference.
- Deploy API documentation and dual-theme/ANSI/tokens previews to GitHub Pages.
