### PR TITLE
[new release] digestif (1.3.1)

### DIFF
--- a/packages/digestif/digestif.1.3.1/opam
+++ b/packages/digestif/digestif.1.3.1/opam
@@ -1,0 +1,67 @@
+opam-version: "2.0"
+maintainer:   [ "Eyyüb Sari <eyyub.sari@epitech.eu>"
+                "Romain Calascibetta <romain.calascibetta@gmail.com>" ]
+authors:      [ "Eyyüb Sari <eyyub.sari@epitech.eu>"
+                "Romain Calascibetta <romain.calascibetta@gmail.com>" ]
+homepage:     "https://github.com/mirage/digestif"
+bug-reports:  "https://github.com/mirage/digestif/issues"
+dev-repo:     "git+https://github.com/mirage/digestif.git"
+doc:          "https://mirage.github.io/digestif/"
+license:      "MIT"
+synopsis:     "Hashes implementations (SHA*, RIPEMD160, BLAKE2* and MD5)"
+description: """
+Digestif is a toolbox to provide hashes implementations in C and OCaml.
+
+It uses the linking trick and user can decide at the end to use the C implementation or the OCaml implementation.
+
+We provides implementation of:
+ * MD5
+ * SHA1
+ * SHA224
+ * SHA256
+ * SHA384
+ * SHA512
+ * SHA3
+ * Keccak-256
+ * WHIRLPOOL
+ * BLAKE2B
+ * BLAKE2S
+ * RIPEMD160
+"""
+
+build: [
+  [ "dune" "build" "-p" name "-j" jobs ]
+  [ "dune" "runtest" "-p" name "-j" jobs ] {with-test}
+]
+install:  [
+  [ "dune" "install" "-p" name ] {with-test}
+]
+
+depends: [
+  "ocaml"           {>= "4.08.0"}
+  "dune"            {>= "2.6.0"}
+  "eqaf"
+  "fmt"             {with-test & >= "0.8.7"}
+  "alcotest"        {with-test}
+  "bos"             {with-test}
+  "astring"         {with-test}
+  "fpath"           {with-test}
+  "rresult"         {with-test}
+  "ocamlfind"       {with-test}
+  "crowbar"         {with-test}
+]
+
+conflicts: [
+  "mirage-xen" {< "6.0.0"}
+  "ocaml-freestanding"
+]
+x-maintenance-intent: [ "(latest)" ]
+url {
+  src:
+    "https://github.com/mirage/digestif/releases/download/v1.3.1/digestif-1.3.1.tbz"
+  checksum: [
+    "sha256=3927949a56d435ac2106cdb8394400bff989d44567eba9038e47db266cc88466"
+    "sha512=436dcd82081aa03b6d3424629950dbc64212c6281e241dad5e39812d58f2e5ddd52e0138840ad92e172baffbae81d1d34df8f5d893b83c734ac53cd95cad2707"
+  ]
+}
+x-commit-hash: "533b235c39a77d7994f76cf697ee5c45210128ca"


### PR DESCRIPTION
Hashes implementations (SHA*, RIPEMD160, BLAKE2* and MD5)

- Project page: <a href="https://github.com/mirage/digestif">https://github.com/mirage/digestif</a>
- Documentation: <a href="https://mirage.github.io/digestif/">https://mirage.github.io/digestif/</a>

##### CHANGES:

- Remove DKML CI (@jonahbeckford, @dinosaure, mirage/digestif#159, mirage/digestif#160, mirage/digestif#161)
- Fix documentation (@kit-ty-kate, @dinosaure, mirage/digestif#162)
- Reject bad digest size for BLAKE2 implementation (@samoht, @dinosaure, mirage/digestif#166)
- Delete old artifact for MirageOS 3.0 (@dinosaure, @vbgl, mirage/digestif#165, mirage/digestif#168)
- Be safe aligned on ARM architecture (@dinosaure, @hannesm, mirage/digestif#169)
