### PR TITLE
[new release] libdash (0.4.1)

### DIFF
--- a/packages/libdash/libdash.0.4.1/opam
+++ b/packages/libdash/libdash.0.4.1/opam
@@ -1,0 +1,43 @@
+opam-version: "2.0"
+synopsis: "Bindings to the dash shell's parser"
+maintainer: ["michael@greenberg.science"]
+authors: ["Michael Greenberg"]
+license: "BSD-3-Clause"
+homepage: "https://github.com/mgree/libdash"
+bug-reports: "https://github.com/mgree/libdash/issues"
+depends: [
+  "dune" {>= "3.12"}
+  "ctypes" {>= "0.21.1"}
+  "ctypes-foreign" {>= "0.21.1"}
+  "atdgen" {>= "2.15.0"}
+  "atdgen-runtime" {>= "2.15.0"}
+  "conf-autoconf" {>= "0.1"}
+  "conf-aclocal" {>= "2"}
+  "conf-automake" {>= "1"}
+  "conf-libtool" {>= "1"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/mgree/libdash.git"
+url {
+  src:
+    "https://github.com/binpash/libdash/releases/download/v0.4.1/libdash-0.4.1.tbz"
+  checksum: [
+    "sha256=e9b24177c322665ecc2e75a66aa887ee3913e376ed81c25f8e4dd265982b5c5b"
+    "sha512=21cc603c811895016d69c41950e76f1f04d5e73800a49b8546526df51b8ca3284ad94643ad0074febad366090b95ece9c9676d7260c02593d06e650b39942e56"
+  ]
+}
+x-commit-hash: "d2d00fc7e868395f9686d3027eaee048694cd59b"


### PR DESCRIPTION
Bindings to the dash shell's parser

- Project page: <a href="https://github.com/mgree/libdash">https://github.com/mgree/libdash</a>

##### v0.4.1 fixes the build on macOS, drops unnecessary OCaml Ctypes functions, and rewrites git history to align with dash upstream