### PR TITLE
micro_httpd.0.20.1: Replace unstable archive by stable one

### DIFF
--- a/packages/micro_httpd/micro_httpd.0.20.1-1/opam
+++ b/packages/micro_httpd/micro_httpd.0.20.1-1/opam
@@ -12,9 +12,9 @@ depends: [
 build: ["dune" "build" "-p" name "-j" jobs]
 dev-repo: "git+https://codeberg.org/kit-ty-kate/micro_httpd.git"
 url {
-  src: "https://codeberg.org/kit-ty-kate/micro_httpd/archive/0.20.1.tar.gz"
+  src: "https://codeberg.org/kit-ty-kate/micro_httpd/releases/download/0.20.1/micro_httpd-0.20.1.tar.gz"
   checksum: [
-    "md5=2b2c9eb94de9b946887c7ba962214779"
-    "sha512=12b7e40f45b16ddce2dc77f91de8e97fdee7e5e615c511f1559f1abba13101449230f8a30c08681be987af44f3c4ddf6e8d2cd0e308765d4861da32005037bcc"
+    "md5=38a0a8c91a5ed2a6cb50aba5f6e60ba5"
+    "sha512=c807361408610f5a29c31965f71ae2e5837001f5edd2b01feb60598a603c1d0b21de5d656b2bd33eba8c5900aa89784c4d964aee2032503b16dbac1e360e35ef"
   ]
 }


### PR DESCRIPTION
Sadly i couldn't find the original archive generated by codeberg in any of the opam caches so i have to replace the archive by another one (same content, just tar.gz metadata and root directory name difference i'm guessing)