### PR TITLE
Add a version-bound on ochre-cli.1.0.0

### DIFF
--- a/packages/ochre-cli/ochre-cli.1.0.0/opam
+++ b/packages/ochre-cli/ochre-cli.1.0.0/opam
@@ -10,7 +10,7 @@ bug-reports: "https://github.com/davesnx/ochre/issues"
 depends: [
   "dune" {>= "3.22"}
   "ocaml" {>= "4.14.0"}
-  "ochre"
+  "ochre" {= version}
   "tm-grammars" {>= "2.0.0"}
   "cmdliner" {>= "1.1.0"}
   "ezjsonm" {with-test}


### PR DESCRIPTION
My version bound suggestion for `ochre-cli` in #30265 is on point, going forward.
It however needs to be added to `ochre-cli.1.0.0` to prevent its combination with `ochre.1.1.0`,
which is causing the revdeps failures:

[ochre-cli.1.0.0 (failed: The compilation of ochre-cli.1.0.0 failed at "dune build -p ochre-cli -j 71 @install @runtest".)](https://opam.ci.ocaml.org/github/ocaml/opam-repository/commit/0ec7497efb59877d08b973cd51d259c17ae45dca/variant/compilers,4.14,ochre.1.1.0,revdeps,ochre-cli.1.0.0)

This PR therefore adds that bound