### PR TITLE
[new release] wax (2 packages) (0.1.0)

### DIFF
--- a/packages/wax-lib/wax-lib.0.1.0/opam
+++ b/packages/wax-lib/wax-lib.0.1.0/opam
@@ -11,7 +11,7 @@ bug-reports: "https://github.com/ocsigen/wax/issues"
 depends: [
   "dune" {>= "3.20"}
   "ocaml" {>= "4.14"}
-  "sedlex" {>= "2.0"}
+  "sedlex" {>= "3.3"}
   "menhir" {build & >= "20220210"}
   "menhirLib" {>= "20220210"}
   "re" {>= "1.10.0"}

--- a/packages/wax-lib/wax-lib.0.1.0/opam
+++ b/packages/wax-lib/wax-lib.0.1.0/opam
@@ -1,0 +1,46 @@
+opam-version: "2.0"
+synopsis: "Libraries for Wax, a Rust-like syntax for WebAssembly"
+description:
+  "The parsing, type-checking and format-conversion libraries behind the Wax toolchain (bidirectional Wax <-> Wasm Text <-> Wasm Binary)."
+maintainer: ["Jérôme Vouillon"]
+authors: ["Jérôme Vouillon"]
+license: "Apache-2.0"
+homepage: "https://github.com/ocsigen/wax"
+doc: "https://ocsigen.org/wax/"
+bug-reports: "https://github.com/ocsigen/wax/issues"
+depends: [
+  "dune" {>= "3.20"}
+  "ocaml" {>= "4.14"}
+  "sedlex" {>= "2.0"}
+  "menhir" {build & >= "20220210"}
+  "menhirLib" {>= "20220210"}
+  "re" {>= "1.10.0"}
+  "yojson" {>= "2.0.0"}
+  "uucp" {with-dev-setup & >= "16.0.0"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/ocsigen/wax.git"
+x-maintenance-intent: ["(latest)"]
+url {
+  src:
+    "https://github.com/ocsigen/wax/releases/download/v0.1.0/wax-v0.1.0.tbz"
+  checksum: [
+    "sha256=695b24f38fb459a16eef209acdc9a6a33b67cc9663573354f6cdb0d18019a619"
+    "sha512=018592ec3beb0fbb040878cbb7475f0ae25bced68d96987780008798d5719190609a968403c6d3e85619245d93d1c07a55b55e3df08ca166dbc85bb89912270b"
+  ]
+}
+x-commit-hash: "2e420957ad07fac4ee77e978e3e193e1695077f0"

--- a/packages/wax-lib/wax-lib.0.1.0/opam
+++ b/packages/wax-lib/wax-lib.0.1.0/opam
@@ -37,10 +37,10 @@ dev-repo: "git+https://github.com/ocsigen/wax.git"
 x-maintenance-intent: ["(latest)"]
 url {
   src:
-    "https://github.com/ocsigen/wax/releases/download/v0.1.0/wax-v0.1.0.tbz"
+    "https://github.com/ocsigen/wax/releases/download/v0.1.0/wax-0.1.0.tbz"
   checksum: [
-    "sha256=695b24f38fb459a16eef209acdc9a6a33b67cc9663573354f6cdb0d18019a619"
-    "sha512=018592ec3beb0fbb040878cbb7475f0ae25bced68d96987780008798d5719190609a968403c6d3e85619245d93d1c07a55b55e3df08ca166dbc85bb89912270b"
+    "sha256=41b580846af8d41bdf6c3f005f62e38feda3e60fe2e9e4aa440db34ce515a153"
+    "sha512=4b3a181fcc7d743194a8647260870fb5190770066a197bcc48104c2b77fd40c643228b795c2bcd6b29a120820e969eb42a37a9bcec98b3f608d13f152d9f6579"
   ]
 }
-x-commit-hash: "2e420957ad07fac4ee77e978e3e193e1695077f0"
+x-commit-hash: "af9daa62d6fd141a00c6721b407ae6bc9181cea4"

--- a/packages/wax/wax.0.1.0/opam
+++ b/packages/wax/wax.0.1.0/opam
@@ -1,0 +1,46 @@
+opam-version: "2.0"
+synopsis: "A compiler toolchain for Wax, a Rust-like syntax for WebAssembly"
+description:
+  "A compiler toolchain for Wax, a Rust-like syntax for WebAssembly. Capabilities: Formatting, Type Checking, Syntax Conversion (Wax <-> Wasm Text <-> Wasm Binary)."
+maintainer: ["Jérôme Vouillon"]
+authors: ["Jérôme Vouillon"]
+license: "Apache-2.0"
+homepage: "https://github.com/ocsigen/wax"
+doc: "https://ocsigen.org/wax/"
+bug-reports: "https://github.com/ocsigen/wax/issues"
+depends: [
+  "dune" {>= "3.20"}
+  "ocaml" {>= "4.14"}
+  "wax-lib" {= version}
+  "yojson" {>= "2.0.0"}
+  "cmdliner" {>= "2.0.0"}
+  "lsp" {>= "1.17.0"}
+  "jsonrpc" {>= "1.17.0"}
+  "dune-build-info" {>= "3.0.0"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/ocsigen/wax.git"
+x-maintenance-intent: ["(latest)"]
+url {
+  src:
+    "https://github.com/ocsigen/wax/releases/download/v0.1.0/wax-v0.1.0.tbz"
+  checksum: [
+    "sha256=695b24f38fb459a16eef209acdc9a6a33b67cc9663573354f6cdb0d18019a619"
+    "sha512=018592ec3beb0fbb040878cbb7475f0ae25bced68d96987780008798d5719190609a968403c6d3e85619245d93d1c07a55b55e3df08ca166dbc85bb89912270b"
+  ]
+}
+x-commit-hash: "2e420957ad07fac4ee77e978e3e193e1695077f0"

--- a/packages/wax/wax.0.1.0/opam
+++ b/packages/wax/wax.0.1.0/opam
@@ -14,8 +14,8 @@ depends: [
   "wax-lib" {= version}
   "yojson" {>= "2.0.0"}
   "cmdliner" {>= "2.0.0"}
-  "lsp" {>= "1.17.0"}
-  "jsonrpc" {>= "1.17.0"}
+  "lsp" {>= "1.26.0"}
+  "jsonrpc" {>= "1.26.0"}
   "dune-build-info" {>= "3.0.0"}
   "odoc" {with-doc}
 ]

--- a/packages/wax/wax.0.1.0/opam
+++ b/packages/wax/wax.0.1.0/opam
@@ -17,6 +17,7 @@ depends: [
   "lsp" {>= "1.26.0"}
   "jsonrpc" {>= "1.26.0"}
   "dune-build-info" {>= "3.0.0"}
+  "conf-python-3" {with-test}
   "odoc" {with-doc}
 ]
 build: [
@@ -37,10 +38,10 @@ dev-repo: "git+https://github.com/ocsigen/wax.git"
 x-maintenance-intent: ["(latest)"]
 url {
   src:
-    "https://github.com/ocsigen/wax/releases/download/v0.1.0/wax-v0.1.0.tbz"
+    "https://github.com/ocsigen/wax/releases/download/v0.1.0/wax-0.1.0.tbz"
   checksum: [
-    "sha256=695b24f38fb459a16eef209acdc9a6a33b67cc9663573354f6cdb0d18019a619"
-    "sha512=018592ec3beb0fbb040878cbb7475f0ae25bced68d96987780008798d5719190609a968403c6d3e85619245d93d1c07a55b55e3df08ca166dbc85bb89912270b"
+    "sha256=41b580846af8d41bdf6c3f005f62e38feda3e60fe2e9e4aa440db34ce515a153"
+    "sha512=4b3a181fcc7d743194a8647260870fb5190770066a197bcc48104c2b77fd40c643228b795c2bcd6b29a120820e969eb42a37a9bcec98b3f608d13f152d9f6579"
   ]
 }
-x-commit-hash: "2e420957ad07fac4ee77e978e3e193e1695077f0"
+x-commit-hash: "af9daa62d6fd141a00c6721b407ae6bc9181cea4"


### PR DESCRIPTION
A compiler toolchain for Wax, a Rust-like syntax for WebAssembly

- Project page: <a href="https://github.com/ocsigen/wax">https://github.com/ocsigen/wax</a>
- Documentation: <a href="https://ocsigen.org/wax/">https://ocsigen.org/wax/</a>

##### CHANGES:

- Initial release of the Wax toolchain: bidirectional conversion between Wax,
  WebAssembly text (WAT), and WebAssembly binary, with formatting, type
  checking, a language server, and the supporting libraries (`wax-lib`).
