### PR TITLE
[new release] theo (0.1.0)

### DIFF
--- a/packages/theo/theo.0.1.0/opam
+++ b/packages/theo/theo.0.1.0/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+synopsis: "A BDD library with theory support"
+description:
+  "A Boolean Decision Diagram library implemented in OCaml, with built-in support for atomic constraints over specific theories (like strings and semantic versions)."
+maintainer: ["Jérôme Vouillon"]
+authors: ["Jérôme Vouillon"]
+license: "MIT"
+homepage: "https://github.com/vouillon/theo"
+doc: "https://vouillon.github.io/theo/"
+bug-reports: "https://github.com/vouillon/theo/issues"
+depends: [
+  "dune" {>= "3.17"}
+  "ocaml" {>= "4.08"}
+  "qcheck" {with-test & >= "0.90"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/vouillon/theo.git"
+url {
+  src:
+    "https://github.com/vouillon/theo/releases/download/0.1.0/theo-0.1.0.tbz"
+  checksum: [
+    "sha256=bdaa3e26ec5ab84a6a378693cdc4d5ca3470b52c9a36715e7ccb6543100281ed"
+    "sha512=9d3ac06b7dc9f154ac987cc376af5725bdbce326f245d5036ff54412eeae9edbca7cbeec60dbec3451122396a74699c9befcd238b47d4492334b86730e178e76"
+  ]
+}
+x-commit-hash: "b535bf4c6bd40d2e78189df9af24bb8b1db32aaa"

--- a/packages/theo/theo.0.1.0/opam
+++ b/packages/theo/theo.0.1.0/opam
@@ -10,7 +10,7 @@ doc: "https://vouillon.github.io/theo/"
 bug-reports: "https://github.com/vouillon/theo/issues"
 depends: [
   "dune" {>= "3.17"}
-  "ocaml" {>= "4.08"}
+  "ocaml" {>= "4.14"}
   "qcheck" {with-test & >= "0.90"}
   "odoc" {with-doc}
 ]


### PR DESCRIPTION
A BDD library with theory support

- Project page: <a href="https://github.com/vouillon/theo">https://github.com/vouillon/theo</a>
- Documentation: <a href="https://vouillon.github.io/theo/">https://vouillon.github.io/theo/</a>

##### CHANGES:

Initial release.

- Core BDD engine with hash-consing and canonical negative-edge form
- Boolean operations: AND, OR, NOT, IMPLIES, EQUIV, XOR, and `exists`/`forall` quantifiers
- Pluggable theory support over linear orders and equality (booleans, strings,
  integers, semantic versions), with a `Combine` functor to mix theories
- `restrict` operation for partial evaluation, and constraint introspection via
  pattern matching
- Irredundant sum-of-products (Minato-Morreale) computation
- Property-based test suite
