### PR TITLE
[new release] cascade (1.0.0)

### DIFF
--- a/packages/cascade/cascade.1.0.0/opam
+++ b/packages/cascade/cascade.1.0.0/opam
@@ -1,0 +1,57 @@
+opam-version: "2.0"
+synopsis: "CSS generation and manipulation library for OCaml"
+description: """
+Cascade provides a typed CSS AST, parser, pretty-printer, and optimizer.
+   Supports selectors, properties, values, media queries, container queries,
+   @supports, @property, @layer, @keyframes, @font-face, and CSS variables."""
+maintainer: ["Thomas Gazagnaire"]
+authors: ["Thomas Gazagnaire"]
+license: "ISC"
+homepage: "https://github.com/samoht/cascade"
+bug-reports: "https://github.com/samoht/cascade/issues"
+depends: [
+  "ocaml" {>= "5.2"}
+  "dune" {>= "3.21"}
+  "dune-build-info"
+  "alcotest" {>= "1.7.0" & with-test}
+  "alcobar" {with-test}
+  "astring" {with-test}
+  "eio" {>= "0.14" & with-test}
+  "eio_main" {>= "0.14" & with-test}
+  "lambdasoup"
+  "mdx" {with-test}
+  "re" {with-test}
+  "fmt" {>= "0.10.0"}
+  "base-unix"
+  "uutf"
+  "psq"
+  "logs"
+  "cmdliner" {>= "1.1.0"}
+  "memtrace"
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/samoht/cascade.git"
+x-maintenance-intent: ["(latest)"]
+url {
+  src:
+    "https://github.com/samoht/cascade/releases/download/1.0.0/cascade-1.0.0.tbz"
+  checksum: [
+    "sha256=c11bbdc7ab0eee8c03cd162e3e7fd1cb20de62beb13342b3b150a89264ee0056"
+    "sha512=43fd97a55c3b1dc4db5c87aa1a5a047d902e902ab2064af3a7c5bf945ebc333f8cd90ecca8013c17be5b950498eace8e0094ee4319eba408285e2bec8d7cdf7b"
+  ]
+}
+x-commit-hash: "db2a2c2e9d6b420bbeca32016a6e2628a8da69bc"


### PR DESCRIPTION
CSS generation and manipulation library for OCaml

- Project page: <a href="https://github.com/samoht/cascade">https://github.com/samoht/cascade</a>

##### CHANGES:

First public release. Cascade was extracted from the [tw](https://github.com/samoht/tw) (Tailwind CSS v4 in OCaml) project as a standalone CSS command-line tool and library, then stabilised over several internal milestones.
