### PR TITLE
Package qiskit.2.0.1

### DIFF
--- a/packages/qiskit/qiskit.2.0.1/opam
+++ b/packages/qiskit/qiskit.2.0.1/opam
@@ -1,0 +1,34 @@
+opam-version: "2.0"
+synopsis: "Qiskit for OCaml"
+description: """
+An OCaml wrapper for the Qiskit quantum computing toolkit
+"""
+maintainer: "Davide Gessa <gessadavide@gmail.com>"
+authors: [
+  "Davide Gessa <gessadavide@gmail.com>"
+]
+
+homepage: "https://github.com/dakk/caml_qiskit"
+bug-reports: "https://github.com/dakk/caml_qiskit/issues"
+license: "MIT"
+dev-repo: "git+https://github.com/dakk/caml_qiskit.git"
+build: ["dune" "build" "-p" name "-j" jobs]
+
+depends: [
+  "ocaml" {>= "4.14.0"}
+
+  "dune" {>= "3.10.0"}
+  "pyml" {>= "20250807"}
+
+  "ounit2" {with-test & >= "2.2.7"}
+
+  "odoc" {dev & >= "2.2.1"}
+  "bisect_ppx" {dev & >= "2.8.3"}
+]
+url {
+  src: "https://github.com/dakk/caml_qiskit/archive/refs/tags/v2.0.1.tar.gz"
+  checksum: [
+    "md5=f2467e0c9a8f1c4514594cce8026aaa6"
+    "sha512=f1eb42b7f6c0eb98cc580de6ffa54dea69c89d13df5ccc493c088e9007a7ab05edd253d7173e2fe8f54ac68b066e2f3870a2c0e9f5acd34ee7047079160c5379"
+  ]
+}


### PR DESCRIPTION
### `qiskit.2.0.1`
Qiskit for OCaml
An OCaml wrapper for the Qiskit quantum computing toolkit



---
* Homepage: https://github.com/dakk/caml_qiskit
* Source repo: git+https://github.com/dakk/caml_qiskit.git
* Bug tracker: https://github.com/dakk/caml_qiskit/issues

---
:camel: Pull-request generated by opam-publish v2.7.1