### PR TITLE
2 packages from kit-ty-kate/opam-build at 0.3.1

### DIFF
--- a/packages/opam-build/opam-build.0.3.1/opam
+++ b/packages/opam-build/opam-build.0.3.1/opam
@@ -1,0 +1,26 @@
+opam-version: "2.0"
+synopsis: "An opam plugin to build projects"
+maintainer: "Kate <kit-ty-kate@exn.st>"
+authors: "Kate <kit-ty-kate@exn.st>"
+license: "MIT"
+homepage: "https://github.com/kit-ty-kate/opam-build"
+bug-reports: "https://github.com/kit-ty-kate/opam-build/issues"
+depends: [
+  "ocaml" {>= "4.08"}
+  "dune" {>= "2.0"}
+  "opam-client" {>= "2.6" & < "2.7"}
+  "cmdliner" {>= "1.1"}
+  "xdg" {>= "3.0.0"}
+]
+available: opam-version >= "2.6" & opam-version < "2.7"
+flags: plugin
+build: ["dune" "build" "-p" name "-j" jobs]
+dev-repo: "git+https://github.com/kit-ty-kate/opam-build.git"
+url {
+  src:
+    "https://github.com/kit-ty-kate/opam-build/releases/download/v0.3.1/opam-build-0.3.1.tar.gz"
+  checksum: [
+    "md5=d2304776731938719b4b0b790764495e"
+    "sha512=deecb60b8c547848eb30879a4c46644c929a19344e8b0056a88fe839bfb95df40c34f11ba9f024bce5ba01c0f33243b5346e6bfcbcd065605088fe8d01fe65ea"
+  ]
+}

--- a/packages/opam-test/opam-test.0.3.1/opam
+++ b/packages/opam-test/opam-test.0.3.1/opam
@@ -1,0 +1,26 @@
+opam-version: "2.0"
+synopsis: "An opam plugin to test projects"
+maintainer: "Kate <kit-ty-kate@exn.st>"
+authors: "Kate <kit-ty-kate@exn.st>"
+license: "MIT"
+homepage: "https://github.com/kit-ty-kate/opam-build"
+bug-reports: "https://github.com/kit-ty-kate/opam-build/issues"
+depends: [
+  "ocaml" {>= "4.08"}
+  "dune" {>= "2.0"}
+  "opam-client" {>= "2.6" & < "2.7"}
+  "cmdliner" {>= "1.1"}
+  "xdg" {>= "3.0.0"}
+]
+available: opam-version >= "2.6" & opam-version < "2.7"
+flags: plugin
+build: ["dune" "build" "-p" name "-j" jobs]
+dev-repo: "git+https://github.com/kit-ty-kate/opam-build.git"
+url {
+  src:
+    "https://github.com/kit-ty-kate/opam-build/releases/download/v0.3.1/opam-build-0.3.1.tar.gz"
+  checksum: [
+    "md5=d2304776731938719b4b0b790764495e"
+    "sha512=deecb60b8c547848eb30879a4c46644c929a19344e8b0056a88fe839bfb95df40c34f11ba9f024bce5ba01c0f33243b5346e6bfcbcd065605088fe8d01fe65ea"
+  ]
+}


### PR DESCRIPTION
This pull-request concerns:
- `opam-build.0.3.1`: An opam plugin to build projects
- `opam-test.0.3.1`: An opam plugin to test projects



---
* Homepage: https://github.com/kit-ty-kate/opam-build
* Source repo: git+https://github.com/kit-ty-kate/opam-build.git
* Bug tracker: https://github.com/kit-ty-kate/opam-build/issues

---
:camel: Pull-request generated by opam-publish v3.0.0