### PR TITLE
[new release] termaid (1.0.0)

### DIFF
--- a/packages/termaid/termaid.1.0.0/opam
+++ b/packages/termaid/termaid.1.0.0/opam
@@ -1,0 +1,55 @@
+opam-version: "2.0"
+synopsis: "Render Mermaid diagrams as Unicode box-drawing art"
+description: """
+termaid renders a subset of Mermaid diagrams — flowcharts, state, class,
+entity-relationship, and sequence diagrams — into Unicode box-drawing art
+suitable for a terminal. Output is plain UTF-8 lines plus a TUI-agnostic
+class-tagged span model for callers that want to colorize; it depends on no
+terminal framework. Unsupported diagram types fall back to a framed raw box.
+
+This is an OCaml port of the self-contained Rust `mermaid.rs` renderer from
+xai-org/grok-build, re-implemented and repackaged for opam."""
+maintainer: ["Alex Leighton <axlelonghorn@gmail.com>"]
+authors: ["Alex Leighton <axlelonghorn@gmail.com>"]
+license: "Apache-2.0"
+tags: [
+  "mermaid" "diagram" "terminal" "tui" "box-drawing" "flowchart" "unicode"
+]
+homepage: "https://github.com/alexleighton/termaid"
+bug-reports: "https://github.com/alexleighton/termaid/issues"
+depends: [
+  "dune" {>= "3.0"}
+  "ocaml" {>= "4.14.0"}
+  "uutf" {>= "1.0.0"}
+  "uucp" {>= "14.0.0"}
+  "alcotest" {with-test}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/alexleighton/termaid.git"
+# Voluntary AI disclosure — https://github.com/avsm/ocaml-ai-disclosure
+x-ai-disclosure: "ai-generated"
+x-ai-model: "claude-opus-4-8"
+x-ai-provider: "Anthropic"
+url {
+  src:
+    "https://github.com/alexleighton/termaid/releases/download/1.0.0/termaid-1.0.0.tbz"
+  checksum: [
+    "sha256=29bf91de7d567e0dd0534a0ec814cf51c48c077d1d860f0d9a427f5d71ac7f65"
+    "sha512=bc288d8fd4918aacc79da66efac8fc76e8a94e6a9c01cbf886eb3c5f959383584ad30a526e8f5f55aa24f0477834019feb7e1d2e2ecea147cf4f18ce6a242ffa"
+  ]
+}
+x-commit-hash: "2b1ddfc8548a6099137328c59fe10e8a4e8c6647"


### PR DESCRIPTION
Render Mermaid diagrams as Unicode box-drawing art

- Project page: <a href="https://github.com/alexleighton/termaid">https://github.com/alexleighton/termaid</a>

##### CHANGES:

First release — an OCaml port of the self-contained Rust `mermaid.rs` terminal
renderer from [xai-org/grok-build](https://github.com/xai-org/grok-build)
(Apache-2.0; see `NOTICE`).

- Render five Mermaid diagram types to Unicode box-drawing art — flowchart /
  graph, state, class, entity-relationship, and sequence — including subgraphs,
  self-loops, thick/dotted edges, arrowhead variants, and diagram-specific
  features (choice pseudo-states, class members/annotations/generics, ER
  cardinalities, sequence notes/blocks/autonumber). Unrecognized or too-wide
  input renders as a framed fallback box.
- Public API: `Termaid.render : ?max_width:int -> string -> t option`, returning
  plain UTF-8 lines plus a TUI-agnostic, class-tagged span model (map the `cls`
  of each run to your own colors). No terminal-framework dependency; Unicode
  width via `uucp`/`uutf`.
- Layout engine: Sugiyama-style rank assignment, barycenter crossing reduction,
  coordinate relaxation, and greedy track packing, painted onto a box-drawing
  canvas with junction-aware glyph resolution.
- Verified byte-for-byte against the upstream renderer across 53 golden fixtures
  (every diagram type plus wide/tall/dense layout stress cases); 145 invariant
  tests faithfully port the upstream test suite. CI covers Linux and macOS on
  OCaml 4.14 and 5.
