### PR TITLE
[new release] noise (0.1.0)

### DIFF
--- a/packages/noise/noise.0.1.0/opam
+++ b/packages/noise/noise.0.1.0/opam
@@ -1,0 +1,46 @@
+opam-version: "2.0"
+synopsis: "An OCaml implementation of the Noise Protocol Framework (rev 34)"
+description:
+  "noise implements the Noise Protocol Framework (https://noiseprotocol.org/) in OCaml. It supports Curve25519 DH, AES-256-GCM and ChaCha20-Poly1305 ciphers, SHA-256, SHA-512, BLAKE2s and BLAKE2b hashes, all fundamental and deferred handshake patterns, and PSK modifiers."
+maintainer: ["Race Williams <race@raquent.in>"]
+authors: ["Race Williams"]
+license: "MIT"
+tags: ["cryptography" "networking"]
+homepage: "https://github.com/raquentin/ocaml-noise"
+bug-reports: "https://github.com/raquentin/ocaml-noise/issues"
+depends: [
+  "dune" {>= "3.17"}
+  "ocaml" {>= "5.0"}
+  "mirage-crypto" {>= "2.0"}
+  "mirage-crypto-ec" {>= "2.0"}
+  "digestif" {>= "1.3"}
+  "mirage-crypto-rng" {with-test & >= "2.0"}
+  "alcotest" {with-test & >= "1.0"}
+  "yojson" {with-test & >= "2.0"}
+  "ohex" {with-test & >= "0.2"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/raquentin/ocaml-noise.git"
+url {
+  src:
+    "https://github.com/raquentin/ocaml-noise/releases/download/v0.1.0/noise-0.1.0.tbz"
+  checksum: [
+    "sha256=fcd0da39248e25d9c96405d665d2a019b981449967611e1f41aa026c75af9ecc"
+    "sha512=450557c5ccb8cc0efb026574918466c59b2585f8c138b873b7501dae129ac21ebb197555ea27839f6f03bb90112055e84d22d051d3989cac3532b2468526b9cd"
+  ]
+}
+x-commit-hash: "4cd6c33f34b952a7b000f0aa502c7d627a259d15"


### PR DESCRIPTION
An OCaml implementation of the Noise Protocol Framework (rev 34)

- Project page: <a href="https://github.com/raquentin/ocaml-noise">https://github.com/raquentin/ocaml-noise</a>

##### CHANGES:

Initial release.

- Full Noise Protocol Framework revision 34 implementation
- Curve25519 (X25519) DH
- AES-256-GCM and ChaCha20-Poly1305 ciphers
- SHA-256, SHA-512, BLAKE2s, BLAKE2b hashes
- All fundamental patterns (N, K, X, NN, NK, NX, KN, KK, KX, XN, XK, XX, IN, IK, IX) and deferred variants
- PSK modifier support (psk0 through pskN)
- All 472 Curve25519 cacophony test vectors pass
