### PR TITLE
Package cvc5.1.3.0-2

### DIFF
--- a/packages/cvc5/cvc5.1.3.0-2/opam
+++ b/packages/cvc5/cvc5.1.3.0-2/opam
@@ -1,0 +1,45 @@
+opam-version: "2.0"
+synopsis: "OCaml bindings for the cvc5 SMT solver"
+description: "OCaml bindings for the cvc5 SMT solver"
+maintainer: "João Pereira <joaomhmpereira@tecnico.ulisboa.pt>"
+authors: "João Pereira <joaomhmpereira@tecnico.ulisboa.pt>"
+license: "MIT"
+homepage: "https://github.com/formalsec/ocaml-cvc5"
+bug-reports: "https://github.com/formalsec/ocaml-cvc5/issues"
+depends: [
+  "dune" {>= "3.19"}
+  "ocaml" {>= "4.12"}
+  "conf-gcc" {build}
+  "conf-g++" {build}
+  "conf-gmp" {build}
+  "conf-cmake" {build}
+  "conf-python-3" {build}
+  "conf-python-3-dev" {build}
+  "conf-python3-pyparsing" {build}
+  "conf-python3-tomli" {build}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/formalsec/ocaml-cvc5.git"
+url {
+  src:
+    "https://github.com/formalsec/ocaml-cvc5/releases/download/v1.3.0-2/ocaml-cvc5-v1.3.0-2.tar.gz"
+  checksum: [
+    "md5=d21b0a2c7edc45f90bae326d04b1fd9c"
+    "sha512=3b437b8c8ced4206b44073be598b6abd0b54badd4a70d6c30a3e03308cc23cfffcf7ef4e672ae6fc0228e7f99e62697ae61717b82d143560ce2babbe09133047"
+  ]
+}
+x-maintenance-intent: ["(latest)" "(latest).(latest-1).(any)"]


### PR DESCRIPTION
### `cvc5.1.3.0-2`
OCaml bindings for the cvc5 SMT solver
OCaml bindings for the cvc5 SMT solver



---
* Homepage: https://github.com/formalsec/ocaml-cvc5
* Source repo: git+https://github.com/formalsec/ocaml-cvc5.git
* Bug tracker: https://github.com/formalsec/ocaml-cvc5/issues

---
#### Git shortlog

```
Andrew Brown (4):
      working sygus interface!
      formatting
      add binding for sygus assumptions
      fix rebase

Filipe Marques (4):
      Add flake.nix for opam build
      Support shared library in addition to static
      Use our own ocaml docker images in CI
      Add missing `CAMLreturn` to sort_to_string
```


---
:camel: Pull-request generated by opam-publish v3.0.0