### PR TITLE
[new release] lstar-rocq (2 packages) (3.0)

### DIFF
--- a/packages/lstar-rocq/lstar-rocq.3.0/opam
+++ b/packages/lstar-rocq/lstar-rocq.3.0/opam
@@ -1,0 +1,43 @@
+opam-version: "2.0"
+synopsis: "Formally-verified automata learning in Rocq"
+description:
+  "Formally-verified implementations of L* and similar algorithms in Rocq"
+maintainer: ["Charles Averill <charlesaverill20@gmail.com>"]
+authors: ["Charles Averill <charlesaverill20@gmail.com>"]
+license: "MIT"
+homepage: "https://github.com/CharlesAverill/lstar-rocq"
+doc: "https://github.com/CharlesAverill/lstar-rocq"
+bug-reports: "https://github.com/CharlesAverill/lstar-rocq/issues"
+depends: [
+  "dune" {>= "3.21"}
+  "rocq-core" {>= "9.1.0"}
+  "rocq-prover"
+  "rocq-stdlib"
+  "rocq-runtime"
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/CharlesAverill/lstar-rocq.git"
+x-maintenance-intent: ["(latest)"]
+url {
+  src:
+    "https://github.com/CharlesAverill/lstar-rocq/releases/download/v3.0/lstar-rocq-3.0.tbz"
+  checksum: [
+    "sha256=ae76ede9f91f2b2898340aee12dea0f948de2b668733ff61d15f97536c637eb3"
+    "sha512=a35b569227d661aec37e13a029229a294a68c5ee5c2ad107afc0e592cf0097b40d395a565d4209ee6b7055b8501017dc24f8f4ca95d98996e9e0172f45477fc7"
+  ]
+}
+x-commit-hash: "af9e8d57bb38d162f923b34186123659d80ad303"

--- a/packages/lstar/lstar.3.0/opam
+++ b/packages/lstar/lstar.3.0/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+synopsis: "Automata learning with lstar-rocq"
+description: "Formally-verified implementations of L* and similar algorithms"
+maintainer: ["Charles Averill <charlesaverill20@gmail.com>"]
+authors: ["Charles Averill <charlesaverill20@gmail.com>"]
+license: "MIT"
+homepage: "https://github.com/CharlesAverill/lstar-rocq"
+doc: "https://github.com/CharlesAverill/lstar-rocq"
+bug-reports: "https://github.com/CharlesAverill/lstar-rocq/issues"
+depends: [
+  "dune" {>= "3.21"}
+  "rocq-core" {>= "9.1.0"}
+  "rocq-prover"
+  "rocq-stdlib"
+  "rocq-runtime"
+  "lstar-rocq" {= version}
+  "odoc" {with-doc}
+]
+dev-repo: "git+https://github.com/CharlesAverill/lstar-rocq.git"
+x-maintenance-intent: ["(latest)"]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src:
+    "https://github.com/CharlesAverill/lstar-rocq/releases/download/v3.0/lstar-rocq-3.0.tbz"
+  checksum: [
+    "sha256=ae76ede9f91f2b2898340aee12dea0f948de2b668733ff61d15f97536c637eb3"
+    "sha512=a35b569227d661aec37e13a029229a294a68c5ee5c2ad107afc0e592cf0097b40d395a565d4209ee6b7055b8501017dc24f8f4ca95d98996e9e0172f45477fc7"
+  ]
+}
+x-commit-hash: "af9e8d57bb38d162f923b34186123659d80ad303"


### PR DESCRIPTION
Formally-verified automata learning in Rocq

- Project page: <a href="https://github.com/CharlesAverill/lstar-rocq">https://github.com/CharlesAverill/lstar-rocq</a>
- Documentation: <a href="https://github.com/CharlesAverill/lstar-rocq">https://github.com/CharlesAverill/lstar-rocq</a>

##### CHANGES:

Breaking changes.
Teacher modules have changed substantially.
TTT for DFAs, L* for Moore and Mealy machines are now supported.
