### PR TITLE
[new release] ppx_deriving_melange (0.2.0)

### DIFF
--- a/packages/ppx_deriving_melange/ppx_deriving_melange.0.2.0/opam
+++ b/packages/ppx_deriving_melange/ppx_deriving_melange.0.2.0/opam
@@ -1,0 +1,51 @@
+opam-version: "2.0"
+synopsis: "Melange-compatible deriving plugins for OCaml"
+description:
+  "A Melange-compatible subset of ppx_deriving: eq, fold, iter, make, map, ord, and show."
+maintainer: [
+  "Vitalii Shapoval <vytalych@gmail.com>" "Ahrefs <github@ahrefs.com>"
+]
+authors: [
+  "Vitalii Shapoval <vytalych@gmail.com>" "Ahrefs <github@ahrefs.com>"
+]
+license: "MIT"
+tags: ["org:ahrefs" "syntax" "melange" "ppx"]
+homepage: "https://github.com/ahrefs/ppx_deriving_melange"
+bug-reports: "https://github.com/ahrefs/ppx_deriving_melange/issues"
+depends: [
+  "dune" {>= "3.16"}
+  "ocaml" {>= "5.0.0"}
+  "ppxlib" {> "0.36.0"}
+  "melange" {>= "5.0.0"}
+  "ounit2" {with-test}
+  "melange-fest" {with-test}
+  "conf-npm" {with-test}
+  "ocamlformat" {= "0.29.0" & with-test}
+  "ocaml-lsp-server" {with-dev-setup}
+  "odoc-driver" {with-doc}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/ahrefs/ppx_deriving_melange.git"
+url {
+  src:
+    "https://github.com/ahrefs/ppx_deriving_melange/releases/download/0.2.0/ppx_deriving_melange-0.2.0.tbz"
+  checksum: [
+    "sha256=1ff2e1d503be5aedba21b7078e56e95e526d968f6ccb315365eb05317e5b33e8"
+    "sha512=b8ce66ec5a72794985586e24a6455b13f29e8dfa90e1b785c6e1840689a0989cedaf0e52d0596daccd5da7e7f074e507a2a9b328e78e430bff9627c4d0abffb8"
+  ]
+}
+x-commit-hash: "b785ee99671112e05f95da3139c8a020c5fafbbc"


### PR DESCRIPTION
Melange-compatible deriving plugins for OCaml

- Project page: <a href="https://github.com/ahrefs/ppx_deriving_melange">https://github.com/ahrefs/ppx_deriving_melange</a>

##### CHANGES:

- add `fold` deriver
- add `make` deriver
- fix a bare-attribute registration conflict in the `make` deriver
