### PR TITLE
Package dspml.1.0.2

### DIFF
--- a/packages/dspml/dspml.1.0.2/opam
+++ b/packages/dspml/dspml.1.0.2/opam
@@ -1,0 +1,27 @@
+opam-version: "2.0"
+maintainer: "Philippe Strauss <catseyechandra@proton.me>"
+authors: [ "Philippe Strauss <catseyechandra@proton.me>" ]
+license: "LGPL-3.0-or-later"
+homepage: "https://codeberg.org/catseyechandra/dspml"
+dev-repo: "git+https://codeberg.org/catseyechandra/dspml.git"
+bug-reports: "https://codeberg.org/catseyechandra/dspml/issues"
+doc: "https://codeberg.org/catseyechandra/dspml"
+build: [
+  [
+      "dune" "build" "-p" name "-j" jobs
+  ]
+]
+depends: [
+  "ocaml"
+  "dune" {>= "2.0.0"}
+  "dune-configurator"
+]
+synopsis: "One-dimension DSP in OCaml"
+description: "DSPML is a small library for unidimensional (one dimension, 1D, vector) based discrete-time signal processing"
+url {
+  src: "https://codeberg.org/catseyechandra/dspml/archive/v1.0.2.tar.gz"
+  checksum: [
+    "md5=089da2196aa00ce449374fe19ae791bd"
+    "sha512=698b441d8bfdf5ac9cb449dcb62f5e443cce7679e194feeb427262089e6f74314db027342bfbb006593214adf50d4f0c8db45cfbdc6f7860a3de1672a634736f"
+  ]
+}


### PR DESCRIPTION
### `dspml.1.0.2`
One-dimension DSP in OCaml
DSPML is a small library for unidimensional (one dimension, 1D, vector) based discrete-time signal processing



---
* Homepage: https://codeberg.org/catseyechandra/dspml
* Source repo: git+https://codeberg.org/catseyechandra/dspml.git
* Bug tracker: https://codeberg.org/catseyechandra/dspml/issues

---
:camel: Pull-request generated by opam-publish v3.0.0