### PR TITLE
Package sndfile.0.9.1

### DIFF
--- a/packages/sndfile/sndfile.0.9.1/opam
+++ b/packages/sndfile/sndfile.0.9.1/opam
@@ -1,0 +1,32 @@
+opam-version: "2.0"
+maintainer: "Philippe Strauss <catseyechandra@proton.me>"
+authors: [ "Erik de Castro Lopo <erikd@mega-nerd.com>" ]
+license: "LGPL-3.0-or-later"
+homepage: "https://codeberg.org/catseyechandra/ocaml-libsndfile"
+dev-repo: "git+https://codeberg.org/catseyechandra/ocaml-libsndfile.git"
+bug-reports: "https://codeberg.org/catseyechandra/ocaml-libsndfile/issues"
+doc: "https://codeberg.org/catseyechandra/ocaml-libsndfile"
+build: [
+  [
+      "dune" "build" "-p" name "-j" jobs
+  ]
+]
+depends: [
+  "ocaml"
+  "dune" {>= "2.0.0"}
+  "dune-configurator"
+]
+depexts: [
+  ["libsndfile-dev"] {os-family = "debian"}
+  ["libsndfile"] {os = "macos" & os-distribution = "homebrew"}
+]
+synopsis: "Bindings for the libsndfile soundfile manipulation library"
+description: "Libsndfile is a soundfile reading/writing/manipulation library written in C"
+url {
+  src:
+    "https://codeberg.org/catseyechandra/ocaml-libsndfile/archive/v0.9.1.tar.gz"
+  checksum: [
+    "md5=fd11ef323a5ea4ae000928f6d3131f44"
+    "sha512=1d071c470e80e0ae7822df2743ec546686f7aec0db861b22f8a1d15e9b060e45f03df57bb313632ccfe6c6f818b78a0cb6d8909ab0c01311a6816ffd986986fd"
+  ]
+}


### PR DESCRIPTION
### `sndfile.0.9.1`
Bindings for the libsndfile soundfile manipulation library
Libsndfile is a soundfile reading/writing/manipulation library written in C



---
* Homepage: https://codeberg.org/catseyechandra/ocaml-libsndfile
* Source repo: git+https://codeberg.org/catseyechandra/ocaml-libsndfile.git
* Bug tracker: https://codeberg.org/catseyechandra/ocaml-libsndfile/issues

---
:camel: Pull-request generated by opam-publish v3.0.0