### PR TITLE
Package plcairo.5.15.0.1

### DIFF
--- a/packages/plcairo/plcairo.5.15.0.1/opam
+++ b/packages/plcairo/plcairo.5.15.0.1/opam
@@ -1,0 +1,34 @@
+opam-version: "2.0"
+maintainer: "Philippe Strauss <catseyechandra@proton.me>"
+authors: [ "Hezekiah M. Carty <hez@0ok.org>" ]
+license: "LGPL-3.0-or-later"
+homepage: "https://codeberg.org/catseyechandra/ocaml-plcairo"
+dev-repo: "git+https://codeberg.org/catseyechandra/ocaml-plcairo.git"
+bug-reports: "https://codeberg.org/catseyechandra/ocaml-plcairo/issues"
+doc: "https://hcarty.github.io/ocaml-plcairo/plcairo"
+build: [ "dune" "build" "-p" name "-j" jobs ]
+depends: [
+  "ocaml" {>= "4.13.0"}
+  "dune" {>= "2.0.0"}
+  "dune-configurator"
+]
+depexts: [
+  ["libplplot-dev" "libshp-dev"] {os-family = "debian"}
+  ["plplot"] {os = "macos" & os-distribution = "homebrew"}
+  ["plpot"] {os-family = "arch"}
+  ["plplot-devel"] {os-family = "rhel"}
+  ["plplot-devel"] {os-family = "fedora"}
+  ["plplot-devel"] {os-family = "suse"}
+  ["plplot-devel" "epel-release"] {os-distribution = "centos"}
+  ["plplot"] {os-distribution = "nixos"}
+]
+synopsis: "Bindings for the PLplot Cairo support"
+description: "Binding for the Cairo rendering layer of PLplot, a high quality scientific plotting library with long history"
+url {
+  src:
+    "https://codeberg.org/catseyechandra/ocaml-plcairo/archive/v5.15.0.1.tar.gz"
+  checksum: [
+    "md5=db9cfcf2ca2200bce2950bc040dce3be"
+    "sha512=2b5cb76adf7ce1a27b73ee52a2668e2ae5d49c26f01ba64c9d1015111bc7a0bb47f0bd68e9cfa425466ab49c2cb51c21dda02d5ebaa329e2cf3298950b3a25d8"
+  ]
+}


### PR DESCRIPTION
### `plcairo.5.15.0.1`
Bindings for the PLplot Cairo support
Binding for the Cairo rendering layer of PLplot, a high quality scientific plotting library with long history



---
* Homepage: https://codeberg.org/catseyechandra/ocaml-plcairo
* Source repo: git+https://codeberg.org/catseyechandra/ocaml-plcairo.git
* Bug tracker: https://codeberg.org/catseyechandra/ocaml-plcairo/issues

---
:camel: Pull-request generated by opam-publish v3.0.0