### PR TITLE
[new release] sqlgg (20260721)

### DIFF
--- a/packages/sqlgg/sqlgg.20260721/opam
+++ b/packages/sqlgg/sqlgg.20260721/opam
@@ -1,0 +1,51 @@
+opam-version: "2.0"
+maintainer: "ygrek@autistici.org"
+authors: ["ygrek"]
+homepage: "https://ygrek.org/p/sqlgg/"
+dev-repo: "git+https://github.com/ygrek/sqlgg.git"
+bug-reports: "https://github.com/ygrek/sqlgg/issues"
+license: "GPL-2.0-only"
+tags: [ "org:ygrek" ]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs "@install" "@doc" {with-doc}]
+]
+depends: [
+  "ocaml" {>= "4.13.0"}
+  "yojson" {>= "1.6.0"}
+  "dune" {>= "2.7"}
+  "integers" {>= "0.4.0"}
+  "menhir" {>= "20180523"}
+  "mybuild" {> "3"}
+  "ppx_deriving" {>= "4.3"}
+  "ppxlib" {>= "0.36.2"}
+  ("extlib" {>= "1.7.8"} | "extlib-compat" {>= "1.7.8"})
+  "base-unix"
+  "odoc" {with-doc}
+  "ounit"
+]
+depopts: [
+  "mariadb"
+  "mysql"
+  "sqlite3"
+]
+synopsis: "SQL Guided (code) Generator"
+description: """
+sqlgg is an SQL query parser and binding code generator for C#, C++, Java, OCaml.
+It starts off with SQL schema and queries, and generates code (or XML, allowing
+further code generation for various purposes). Generated code only defines a mapping
+of output columns and query parameters to the host language, trying to be as unobtrusive
+as possible and leaving the choice of SQL database (and API to access it) to the developer."""
+
+conflicts: [
+  "mariadb" {<= "1.3.0"}
+]
+url {
+  src:
+    "https://github.com/ygrek/sqlgg/releases/download/20260721/sqlgg-20260721.tbz"
+  checksum: [
+    "sha256=40d7699187951dd2f17d885c4f4f04124930bf7dc1119d4cca322c5f0cb42d8e"
+    "sha512=e7c90683cddcff3ca0ba9de9e40c2c4c69923ea62e2647f1a70083e42ed00b7cab53f8a14d1a965ee4465966bc02fa75fa7cb42e485beae1a9c26bdc252c3665"
+  ]
+}
+x-commit-hash: "067060f8d0634aad1b346d01725b006823ad378d"


### PR DESCRIPTION
SQL Guided (code) Generator

- Project page: <a href="https://ygrek.org/p/sqlgg/">https://ygrek.org/p/sqlgg/</a>

##### CHANGES:

+ sql: dynamic select, pick which columns to SELECT at runtime (caml only)
	+ sql: eliminate unused JOINs and subqueries in dynamic select
	+ ocaml: sqlgg.ppx to map query results to records
	+ sql: dialect feature checks with -dialect mysql|sqlite|postgresql|tidb
	+ cli: generate migrations from schema diff (-migrate, -diff)
	+ sql: custom types for columns via [sqlgg] metadata
	+ sql: ENUM as polymorphic variants
	+ sql: BIGINT UNSIGNED as uint64 (requires mariadb > 1.3.0)
	+ sql: JSON type and functions
	+ sql: allow to type-annotate parameters with `:: SQLTYPE NULL?` to help type-checker
	+ sql: bool choices `{ expr }?` and `@var?`
	+ sql: reusable queries in CTEs, recursive CTEs
	+ sql: ON CONFLICT DO NOTHING/DO UPDATE, GROUP_CONCAT, ORDER BY in function arguments,
		more date and window functions, multi-table UPDATE with ORDER BY and LIMIT,
		(a,b) IN @param, CASE as expression, REPLACE, STRAIGHT_JOIN, SET STATEMENT ... FOR,
		parametrized ORDER BY and LIMIT, CREATE TYPE, ALTER COLUMN, DROP CHECK, TTL, LOCK
	* typing: track nullability
	* improve single-row detection using constraints
	+ ocaml: cache prepared statements per connection
	+ ocaml: Single module with labeled arguments
