### PR TITLE
[new release] decompress (2 packages) (1.6.0)

### DIFF
--- a/packages/decompress/decompress.1.6.0/opam
+++ b/packages/decompress/decompress.1.6.0/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+maintainer:   "Romain Calascibetta <romain.calascibetta@gmail.com>"
+authors:      "Romain Calascibetta <romain.calascibetta@gmail.com>"
+homepage:     "https://github.com/mirage/decompress"
+bug-reports:  "https://github.com/mirage/decompress/issues"
+dev-repo:     "git+https://github.com/mirage/decompress.git"
+doc:          "https://mirage.github.io/decompress/"
+license:      "MIT"
+synopsis:     "Implementation of Zlib and GZip in OCaml"
+description: """Decompress is an implementation of Zlib and GZip in OCaml
+
+It provides a pure non-blocking interface to inflate and deflate data flow.
+"""
+
+build: [ "dune" "build" "-p" name "-j" jobs ]
+run-test: [ "dune" "runtest" "-p" name "-j" jobs ]
+
+depends: [
+  "ocaml"       {>= "4.07.0"}
+  "dune"        {>= "2.8.0"}
+  "cmdliner"    {>= "1.1.0"}
+  "optint"      {>= "0.1.0"}
+  "checkseum"   {>= "0.2.0"}
+  "bstr"        {with-test & >= "0.0.4"}
+  "alcotest"    {with-test & >= "1.7.0"}
+  "fmt"         {with-test & >= "0.8.7"}
+  "bytesrw"     {with-test}
+  "camlzip"     {>= "1.10" & with-test}
+  "base64"      {>= "3.0.0" & with-test}
+  "crowbar"     {with-test & >= "0.2"}
+]
+x-maintenance-intent: [ "(latest)" ]
+url {
+  src:
+    "https://github.com/mirage/decompress/releases/download/v1.6.0/decompress-1.6.0.tbz"
+  checksum: [
+    "sha256=aa2e842dc009bcddcbb5c0791f5dbeee2bda5a104ecc7681aa37ac42537e3121"
+    "sha512=58e2529fa93f4f671ffd0a69c3542e835868f8c72db9c62b48d207c31f3585101d4d314f7e5922b273c86609b00c87343987b03b568d3e69749d2c7f7fa4089b"
+  ]
+}
+x-commit-hash: "61f87f1dcc13186ea4ebe1640781a8aa6f829fd2"

--- a/packages/rfc1951/rfc1951.1.6.0/opam
+++ b/packages/rfc1951/rfc1951.1.6.0/opam
@@ -1,0 +1,34 @@
+opam-version: "2.0"
+maintainer:   "Romain Calascibetta <romain.calascibetta@gmail.com>"
+authors:      "Romain Calascibetta <romain.calascibetta@gmail.com>"
+homepage:     "https://github.com/mirage/decompress"
+bug-reports:  "https://github.com/mirage/decompress/issues"
+dev-repo:     "git+https://github.com/mirage/decompress.git"
+doc:          "https://mirage.github.io/decompress/"
+license:      "MIT"
+synopsis:     "Implementation of RFC1951 in OCaml"
+description: """This package provide an implementation of RFC1951 in OCaml.
+
+We provide a pure non-blocking interface to inflate and deflate data flow.
+"""
+
+build: [ "dune" "build" "-p" name "-j" jobs ]
+run-test: [ "dune" "runtest" "-p" name "-j" jobs ]
+
+depends: [
+  "ocaml"      {>= "4.07.0"}
+  "dune"       {>= "2.8"}
+  "decompress" {= version}
+  "checkseum"
+  "optint"
+]
+x-maintenance-intent: [ "(latest)" ]
+url {
+  src:
+    "https://github.com/mirage/decompress/releases/download/v1.6.0/decompress-1.6.0.tbz"
+  checksum: [
+    "sha256=aa2e842dc009bcddcbb5c0791f5dbeee2bda5a104ecc7681aa37ac42537e3121"
+    "sha512=58e2529fa93f4f671ffd0a69c3542e835868f8c72db9c62b48d207c31f3585101d4d314f7e5922b273c86609b00c87343987b03b568d3e69749d2c7f7fa4089b"
+  ]
+}
+x-commit-hash: "61f87f1dcc13186ea4ebe1640781a8aa6f829fd2"


### PR DESCRIPTION
Implementation of Zlib and GZip in OCaml

- Project page: <a href="https://github.com/mirage/decompress">https://github.com/mirage/decompress</a>
- Documentation: <a href="https://mirage.github.io/decompress/">https://mirage.github.io/decompress/</a>

##### CHANGES:

- Add x-maintenance-intent (@hannesm, mirage/decompress#163)
- Fix documentation (@reynir, mirage/decompress#161)
- Apply ocamlformat.0.29.0 (@dinosaure, mirage/decompress#165)
- Improve our benchmark tool and compare decompress with camlzip and
  bytesrw.zlib (@dinosaure, mirage/decompress#167)
- Use warning names instead of numbers (@hannesm, mirage/decompress#170)
- Choose a better kind of block when we compress and approximate the cost
  between a Fixed and a Dynamic block (@dinosaure, mirage/decompress#166)
- Use a xxHash implementation for our hashtable when we deflate
  (@dinosaure, mirage/decompress#171)
- Use a two-level lookup table (as it's done by zlib, see inftrees.c) to
  speed-up the inflation (@dinosaure, mirage/decompress#173)

  **breaking change**: De.Lookup.t is updated with a new root field.
  Nobody should use this module.
