### PR TITLE
[new release] ppx_deriving_hash (0.1.4)

### DIFF
--- a/packages/ppx_deriving_hash/ppx_deriving_hash.0.1.4/opam
+++ b/packages/ppx_deriving_hash/ppx_deriving_hash.0.1.4/opam
@@ -1,0 +1,42 @@
+opam-version: "2.0"
+synopsis: "[@@deriving hash]"
+description:
+  "Deriver for standard hash functions without extra dependencies."
+maintainer: ["Simmo Saan <simmo.saan@gmail.com>"]
+authors: ["Simmo Saan <simmo.saan@gmail.com>"]
+license: "MIT"
+homepage: "https://github.com/sim642/ppx_deriving_hash"
+bug-reports: "https://github.com/sim642/ppx_deriving_hash/issues"
+depends: [
+  "dune" {>= "3.21"}
+  "ppxlib" {>= "0.36.0"}
+  "ppx_deriving" {>= "5.0"}
+  "ounit2" {with-test}
+  "cppo" {with-test}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/sim642/ppx_deriving_hash.git"
+x-maintenance-intent: ["(latest)"]
+url {
+  src:
+    "https://github.com/sim642/ppx_deriving_hash/releases/download/0.1.4/ppx_deriving_hash-0.1.4.tbz"
+  checksum: [
+    "sha256=e44633f43c007455be2a613ef41fa24e9b01bc727db0cb770e16a6833ea82d45"
+    "sha512=9abecceb408608c15f601cc99a83412f507dabc7d719f8f3735ee5e7c20c21fa788e0e4d6230a963ae716c61533af0f1aef32b3242ef3b453f130c3ece23465f"
+  ]
+}
+x-commit-hash: "fd849b8da6f3208866691f8260717745d55befb2"


### PR DESCRIPTION
[@@deriving hash]

- Project page: <a href="https://github.com/sim642/ppx_deriving_hash">https://github.com/sim642/ppx_deriving_hash</a>

##### CHANGES:

* Fix expressions not allowed in `let rec` using eta-expansion (sim642/ppx_deriving_hash#7).
* Optimize syntactic function arity on OCaml >= 5.2 (sim642/ppx_deriving_hash#7).
* Use `Ppxlib.really_recursive` for implementation (sim642/ppx_deriving_hash#8).
* Fix missing locations due to `default_loc`.
* Mark locations as `loc_ghost`.
* Add tests (sim642/ppx_deriving_hash#7).
