### PR TITLE
shakuhachi: 0.3.0

### DIFF
--- a/packages/shakuhachi/shakuhachi.0.3.0/opam
+++ b/packages/shakuhachi/shakuhachi.0.3.0/opam
@@ -1,0 +1,54 @@
+opam-version: "2.0"
+synopsis: "A music collection manager"
+description: """
+shakuhachi is mainly a music collection manager but it's also a music tagger.
+ It aims to be a rather simple collection manager extensible by plugins."""
+maintainer: ["EruEri <nayinayu@mailo.com>"]
+authors: ["EruEri <nayinayu@mailo.com>"]
+license: "GPL-3.0-or-later AND MPL-2.0"
+tags: ["music collection" "music tagger"]
+homepage: "https://codeberg.org/EruEri/shakuhachi"
+bug-reports: "https://codeberg.org/EruEri/shakuhachi/issues"
+depends: [
+  "dune" {>= "3.17.2"}
+  "ocaml" {>= "4.14.0"}
+  "xdg"
+  "angstrom" {>= "0.15.0"}
+  "cmdliner" {>= "1.1.0"}
+  "sqlite3" {>= "5.1.0"}
+  "re" {>= "1.10.3"}
+  "otaglibc" {>= "0.1.0"}
+  "uunf" {>= "15.1.0"}
+  "magic-mime" {>= "1.3.0"}
+  "ppx_deriving_yojson" {>= "3.5.3"}
+  "yojson" {>= "2.0.0"}
+  "qcheck" {>= "0.90" & with-test}
+  "qcheck-alcotest" {with-test}
+  "alcotest" {with-test}
+  "fmt" {with-test}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://codeberg.org/EruEri/shakuhachi.git"
+x-maintenance-intent: ["(latest)"]
+
+url {
+  src: "https://codeberg.org/EruEri/shakuhachi/archive/0.3.0_1.tar.gz"
+  checksum: [
+    "sha256=541a7ac078a520730a71edf4d2fe0f17cc98f0b9ad82060db62120a7d2519ae5"
+    "sha512=37b98cb52dab8293adb92f71e91394cf1c5d0d481d03893c320cc8aa550459a30dabdfdc0018f512d3a7a547f2899b493a20d86f450bc084b78e30b40234a911"
+  ]
+}


### PR DESCRIPTION
A music collection manager

*CHANGES*

- feat : Add tagging options to `skhc-add(1)` (same options than `skhc-tag(1)`)
	- BREAKING CHANGE : `skhc-tag(1)` option rename : `-e` -> `-E`
- feat : add options `-D` and `--ignore-duplicate` to specify a duplicate query or to add musics regardless of duplicates.
- misc : tagging option uniformization
- feat : add configuration entry to write a query to check if a duplicate music exists
- fix  : can properly displaying value which are equal to Keys (ie. album name == %id)
- improvement : speed of displaying formatted string
- feat : skhc-query : allow matching arbitrary music properties with _%:\<key\>_
- feat : Accept dsf audio file
- fix  : Add album's coverpath inside database when adding musics
- misc : skhc-list - `-S` little info display change
- feat : skhc-tag - add `-T` option to load a plugin for adding extra tagging capacities.
- feat : skhc-replace - add `-K` option to replace a music but keep the previous location
- fix  : force linkage of skhc\* libraries into skhc for plugins to be successfully loaded.
- misc : test - raise qcheck version 0.27 -> 0.90
- misc : Metadata.pp - add breakline
- improvement : try to extract album_sort_name from metatada when creating an album.
- improvement : skhc-replace - The replacing music uses the main name instead of a duplicated one (ie. song (1).mp3).
- doc : fix typo + misc improvement