### PR TITLE
[new release] qcow (4 packages) (0.15.0)

### DIFF
--- a/packages/qcow-stream/qcow-stream.0.15.0/opam
+++ b/packages/qcow-stream/qcow-stream.0.15.0/opam
@@ -1,0 +1,46 @@
+opam-version: "2.0"
+synopsis: "Library offering QCOW streaming capabilities"
+maintainer: [
+  "Dave Scott <dave@recoil.org>" "Pau Ruiz Safont" "Edwin Török "
+]
+authors: ["David Scott"]
+license: "ISC"
+tags: ["org:mirage"]
+homepage: "https://github.com/mirage/ocaml-qcow"
+bug-reports: "https://github.com/mirage/ocaml-qcow/issues"
+depends: [
+  "dune" {>= "3.18"}
+  "ocaml" {>= "4.13.0"}
+  "alcotest" {with-test & >= "1.2.0"}
+  "qcow-types" {= version}
+  "cstruct-lwt"
+  "io-page"
+  "lwt" {>= "5.5.0"}
+  "lwt_ppx" {>= "2.0.3"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/mirage/ocaml-qcow.git"
+x-maintenance-intent: ["latest"]
+url {
+  src:
+    "https://github.com/mirage/ocaml-qcow/releases/download/0.15.0/qcow-0.15.0.tbz"
+  checksum: [
+    "sha256=da9c7d259e2d7067b7eccd3fecbed79bf339af7bac223766451a5f3d5303e32b"
+    "sha512=629bafa73a69b460a521eb7aa46a3ca5b0aa29445df49eaecdac3f2cfca78684ba7d5db1b20b0af731e3830561d77d844983ee51f0eff17c4fa8941023920e8f"
+  ]
+}
+x-commit-hash: "90001d182f9acb618c7f8f3fb230e471c7ae7145"

--- a/packages/qcow-tool/qcow-tool.0.15.0/opam
+++ b/packages/qcow-tool/qcow-tool.0.15.0/opam
@@ -1,0 +1,64 @@
+opam-version: "2.0"
+synopsis: "A command-line tool for manipulating qcow2-formatted data"
+maintainer: [
+  "Dave Scott <dave@recoil.org>" "Pau Ruiz Safont" "Edwin Török "
+]
+authors: ["David Scott"]
+license: "ISC"
+tags: ["org:mirage"]
+homepage: "https://github.com/mirage/ocaml-qcow"
+bug-reports: "https://github.com/mirage/ocaml-qcow/issues"
+depends: [
+  "dune" {>= "3.18"}
+  "ocaml" {>= "4.12.0"}
+  "qcow" {= version}
+  "qcow-stream" {= version}
+  "conf-qemu-img" {with-test}
+  "cmdliner" {>= "1.1.0" & < "2.0.0"}
+  "cstruct"
+  "result"
+  "unix-type-representations"
+  "lwt"
+  "mirage-block" {>= "3.0.0"}
+  "sha" {>= "1.15.4"}
+  "sexplib"
+  "logs"
+  "fmt" {>= "0.8.2"}
+  "astring"
+  "io-page" {>= "2.4.0"}
+  "ounit" {with-test}
+  "mirage-block-ramdisk" {with-test}
+  "ezjsonm" {with-test}
+  "odoc" {with-doc}
+]
+dev-repo: "git+https://github.com/mirage/ocaml-qcow.git"
+x-maintenance-intent: ["latest"]
+build: [
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test & arch != "arm32" & arch != "x86_32"}
+    "@doc" {with-doc}
+  ]
+]
+x-ci-accept-failures: [
+  "freebsd-14.3"
+  "macos-homebrew"
+  "opensuse-15.6"
+  "opensuse-16.0"
+  "opensuse-tumbleweed"
+]
+url {
+  src:
+    "https://github.com/mirage/ocaml-qcow/releases/download/0.15.0/qcow-0.15.0.tbz"
+  checksum: [
+    "sha256=da9c7d259e2d7067b7eccd3fecbed79bf339af7bac223766451a5f3d5303e32b"
+    "sha512=629bafa73a69b460a521eb7aa46a3ca5b0aa29445df49eaecdac3f2cfca78684ba7d5db1b20b0af731e3830561d77d844983ee51f0eff17c4fa8941023920e8f"
+  ]
+}
+x-commit-hash: "90001d182f9acb618c7f8f3fb230e471c7ae7145"

--- a/packages/qcow-types/qcow-types.0.15.0/opam
+++ b/packages/qcow-types/qcow-types.0.15.0/opam
@@ -1,0 +1,50 @@
+opam-version: "2.0"
+synopsis: "Minimal set of dependencies for qcow-stream, shared with qcow"
+maintainer: [
+  "Dave Scott <dave@recoil.org>" "Pau Ruiz Safont" "Edwin Török "
+]
+authors: ["David Scott"]
+license: "ISC"
+tags: ["org:mirage"]
+homepage: "https://github.com/mirage/ocaml-qcow"
+bug-reports: "https://github.com/mirage/ocaml-qcow/issues"
+depends: [
+  "dune" {>= "3.18"}
+  "ocaml" {>= "4.12.0"}
+  "astring"
+  "cstruct" {>= "6.1.0"}
+  "diet" {>= "0.3.0"}
+  "logs"
+  "lwt"
+  "lwt_ppx" {>= "1.0.1"}
+  "mirage-block" {>= "3.0.0"}
+  "ppx_sexp_conv"
+  "prometheus"
+  "sexplib"
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/mirage/ocaml-qcow.git"
+x-maintenance-intent: ["latest"]
+url {
+  src:
+    "https://github.com/mirage/ocaml-qcow/releases/download/0.15.0/qcow-0.15.0.tbz"
+  checksum: [
+    "sha256=da9c7d259e2d7067b7eccd3fecbed79bf339af7bac223766451a5f3d5303e32b"
+    "sha512=629bafa73a69b460a521eb7aa46a3ca5b0aa29445df49eaecdac3f2cfca78684ba7d5db1b20b0af731e3830561d77d844983ee51f0eff17c4fa8941023920e8f"
+  ]
+}
+x-commit-hash: "90001d182f9acb618c7f8f3fb230e471c7ae7145"

--- a/packages/qcow/qcow.0.15.0/opam
+++ b/packages/qcow/qcow.0.15.0/opam
@@ -1,0 +1,63 @@
+opam-version: "2.0"
+synopsis: "Support for Qcow2 images"
+maintainer: [
+  "Dave Scott <dave@recoil.org>" "Pau Ruiz Safont" "Edwin Török "
+]
+authors: ["David Scott"]
+license: "ISC"
+tags: ["org:mirage"]
+homepage: "https://github.com/mirage/ocaml-qcow"
+bug-reports: "https://github.com/mirage/ocaml-qcow/issues"
+depends: [
+  "dune" {>= "3.18"}
+  "ocaml" {>= "4.12.0"}
+  "qcow-types" {= version}
+  "base-bytes"
+  "cstruct" {>= "3.4.0"}
+  "result"
+  "io-page" {>= "2.4.0"}
+  "lwt" {>= "5.5.0"}
+  "mirage-block" {>= "3.0.0"}
+  "mirage-block-unix" {>= "2.5.0"}
+  "mirage-block-combinators"
+  "mirage-sleep"
+  "sexplib"
+  "logs"
+  "fmt" {>= "0.8.2"}
+  "astring"
+  "prometheus"
+  "unix-type-representations"
+  "stdlib-shims"
+  "sha" {>= "1.15.4"}
+  "ppx_deriving"
+  "ppx_sexp_conv"
+  "ounit" {with-test}
+  "mirage-block-ramdisk" {with-test & >= "0.5"}
+  "ezjsonm" {with-test}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/mirage/ocaml-qcow.git"
+x-maintenance-intent: ["latest"]
+url {
+  src:
+    "https://github.com/mirage/ocaml-qcow/releases/download/0.15.0/qcow-0.15.0.tbz"
+  checksum: [
+    "sha256=da9c7d259e2d7067b7eccd3fecbed79bf339af7bac223766451a5f3d5303e32b"
+    "sha512=629bafa73a69b460a521eb7aa46a3ca5b0aa29445df49eaecdac3f2cfca78684ba7d5db1b20b0af731e3830561d77d844983ee51f0eff17c4fa8941023920e8f"
+  ]
+}
+x-commit-hash: "90001d182f9acb618c7f8f3fb230e471c7ae7145"


### PR DESCRIPTION
Support for Qcow2 images

- Project page: <a href="https://github.com/mirage/ocaml-qcow">https://github.com/mirage/ocaml-qcow</a>

##### CHANGES:

- qcow_stream: Fix reporting of progress (last-genius mirage/ocaml-qcow#139)
