### PR TITLE
[new release] ppx_matches (0.2.0)

### DIFF
--- a/packages/ppx_matches/ppx_matches.0.2.0/opam
+++ b/packages/ppx_matches/ppx_matches.0.2.0/opam
@@ -1,0 +1,38 @@
+opam-version: "2.0"
+synopsis: "A syntax extension for Rust's `matches!` in OCaml 🐪"
+maintainer: ["ajob410@gmail.com"]
+authors: ["Alistair O'Brien"]
+license: "MIT"
+homepage: "https://github.com/johnyob/ppx-matches"
+bug-reports: "https://github.com/johnyob/ppx-matches/issues"
+depends: [
+  "ocaml" {>= "4.14.0"}
+  "dune" {>= "3.18" & >= "3.18"}
+  "ppxlib" {>= "0.31.0"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/johnyob/ppx-matches.git"
+x-maintenance-intent: ["(latest)"]
+url {
+  src:
+    "https://github.com/johnyob/ppx-matches/releases/download/0.2.0/ppx_matches-0.2.0.tbz"
+  checksum: [
+    "sha256=9d9630cd912e2483af1bae545f9bec53aa926be894667e43406b105bed1d60ae"
+    "sha512=542e838ca4a6c9045bc6574cdecb4a21cc444f248172ca9b7429b775c28019a358218a93fce2341a389a3d230c5b3e5f369dd2be7870c9900839a6001fc1fc03"
+  ]
+}
+x-commit-hash: "c51b7c83a50ffddb8c1da46e18f260ebdabc7cb4"


### PR DESCRIPTION
A syntax extension for Rust's `matches!` in OCaml 🐪

- Project page: <a href="https://github.com/johnyob/ppx-matches">https://github.com/johnyob/ppx-matches</a>

##### CHANGES:

- chore: remove dependency on core ([johnyob/ppx-matches#2](https://github.com/johnyob/ppx-matches/pull/2))
