### PR TITLE
[new release] grace (0.4.0)

### DIFF
--- a/packages/grace/grace.0.4.0/opam
+++ b/packages/grace/grace.0.4.0/opam
@@ -1,0 +1,47 @@
+opam-version: "2.0"
+synopsis:
+  "A fancy diagnostics library that allows your compilers to exit with grace"
+maintainer: ["alistair.obrien@trili.tech"]
+authors: ["Alistair O'Brien"]
+license: "MIT"
+homepage: "https://github.com/johnyob/grace"
+bug-reports: "https://github.com/johnyob/grace/issues"
+depends: [
+  "ocaml" {>= "4.14.0"}
+  "dune" {>= "3.4"}
+  "yojson" {>= "2.1.0"}
+  "fmt" {>= "0.8.7"}
+  "iter"
+  "uutf"
+  "sexplib"
+  "ppx_sexp_conv"
+  "dedent" {with-test}
+  "core" {with-test}
+  "core_unix" {with-test}
+  "ppx_jane" {with-test}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/johnyob/grace.git"
+url {
+  src:
+    "https://github.com/johnyob/grace/releases/download/0.4.0/grace-0.4.0.tbz"
+  checksum: [
+    "sha256=0adaa1ae07f636f83f882a3315f79ac90341e57bcf42f4c7f19a3958b2448ec0"
+    "sha512=119d9f4285ba423842e0e373aeb69a169993a741724d8c6273571748a9aac7d42f93291a3522d77bb6da02d8690c04db1a7d9757991478afc971503848f56106"
+  ]
+}
+x-commit-hash: "d658dd1840f7c1ba203cc11a8be078e34cc0f947"


### PR DESCRIPTION
A fancy diagnostics library that allows your compilers to exit with grace

- Project page: <a href="https://github.com/johnyob/grace">https://github.com/johnyob/grace</a>

##### CHANGES:

- feat(renderer): add boxing to trailing labels ([johnyob/grace#92](https://github.com/johnyob/grace/pull/92))
- fix(renderer): print unicode and ansi-styled snippets as correct lengths ([johnyob/grace#88](https://github.com/johnyob/grace/pull/88))
- feat(renderer): add boxing to multi-line labels ([johnyob/grace#88](https://github.com/johnyob/grace/pull/88))
- feat(json_conv): use `Yojson.Basic.t` ([johnyob/grace#87](https://github.com/johnyob/grace/pull/87))
- feat(json_conv): add `Grace_json_conv` for conversion to Yojson ([johnyob/grace#84](https://github.com/johnyob/grace/pull/84))
- fix(core): dont catch `Sys_error` in `Source.length` if the fail doesn't exist ([johnyob/grace#81](https://github.com/johnyob/grace/pull/81))
- feat(renderer): support configurable contextual lines ([johnyob/grace#74](https://github.com/johnyob/grace/pull/74))
