### PR TITLE
[new release] quickjs (0.5.1)

### DIFF
--- a/packages/quickjs/quickjs.0.5.1/opam
+++ b/packages/quickjs/quickjs.0.5.1/opam
@@ -1,0 +1,44 @@
+opam-version: "2.0"
+synopsis:
+  "Bindings for QuickJS (a Javascript Engine to be embedded https://bellard.org/quickjs)"
+maintainer: ["David Sancho <dsnxmoreno@gmail.com>"]
+authors: ["David Sancho <dsnxmoreno@gmail.com>"]
+license: "MIT"
+homepage: "https://github.com/ml-in-barcelona/quickjs.ml"
+bug-reports: "https://github.com/ml-in-barcelona/quickjs.ml/issues"
+depends: [
+  "dune" {>= "3.8"}
+  "ocaml" {>= "4.14.0"}
+  "integers" {>= "0.7.0"}
+  "ctypes" {>= "0.24.0"}
+  "alcotest" {with-test}
+  "odoc" {with-doc}
+  "ocaml-lsp-server" {with-dev-setup}
+  "ocamlformat" {= "0.28.1" & with-dev-setup}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/ml-in-barcelona/quickjs.ml.git"
+conflicts: [ "ocaml-option-bytecode-only" ]
+x-maintenance-intent: ["(latest)"]
+url {
+  src:
+    "https://github.com/ml-in-barcelona/quickjs.ml/releases/download/0.5.1/quickjs-0.5.1.tbz"
+  checksum: [
+    "sha256=42397865f43779613b04bb2f3532b060c6dcca2d41aa1337b31124fca21629a4"
+    "sha512=52bf83c9e3a9e37764b514e34e1acbcdabef9ccac9cefa510e4683b693328ddde42ff59e8475e19c9f1a90caee8b790f2438f5808a11eca7700412b55f41a30e"
+  ]
+}
+x-commit-hash: "7549b5e1085050fe72a64cbbe2d24da074afc996"


### PR DESCRIPTION
Bindings for QuickJS (a Javascript Engine to be embedded https://bellard.org/quickjs)

- Project page: <a href="https://github.com/ml-in-barcelona/quickjs.ml">https://github.com/ml-in-barcelona/quickjs.ml</a>

##### CHANGES:

- Add `RegExp.prepare_input` and `exec_prepared` for reusing one matching buffer and UTF-16 map across repeated matches
- Add prepared-input source range, substring and `AdvanceStringIndex` helpers
- Fix regexp captures whose UTF-16 range splits a surrogate pair: the unpaired half is represented as U+FFFD instead of slicing the wrong UTF-8 bytes
- Fix Unicode global and sticky regexps starting from the trailing half of a surrogate pair instead of the pair's start
