### PR TITLE
[new release] server-reason-react (0.5.1)

### DIFF
--- a/packages/server-reason-react/server-reason-react.0.5.1/opam
+++ b/packages/server-reason-react/server-reason-react.0.5.1/opam
@@ -1,0 +1,62 @@
+opam-version: "2.0"
+synopsis: "Rendering React components on the server natively"
+maintainer: ["David Sancho <dsnxmoreno@gmail.com>"]
+authors: ["David Sancho <dsnxmoreno@gmail.com>"]
+license: "MIT"
+homepage: "https://github.com/ml-in-barcelona/server-reason-react"
+bug-reports: "https://github.com/ml-in-barcelona/server-reason-react/issues"
+depends: [
+  "dune" {>= "3.9"}
+  "ocaml" {>= "4.14.1"}
+  "reason" {>= "3.17.2"}
+  "melange" {>= "3.0.0" & (< "7.0.0" | >= "7.0.1")}
+  "uucp" {>= "16.0.0"}
+  "ppxlib" {>= "0.36.0"}
+  "quickjs" {>= "0.5.1" & < "0.6.0"}
+  "lwt" {>= "5.9.2"}
+  "lwt_ppx" {>= "2.1.0"}
+  "uri" {>= "4.2.0"}
+  "yojson" {>= "2.2.0"}
+  "integers" {>= "0.7.0"}
+  "zarith" {>= "1.14"}
+  "uutf" {>= "1.0.3"}
+  "melange-fetch" {>= "0.2.0"}
+  "melange-json" {>= "2.0.0"}
+  "melange-json-native" {>= "2.0.0"}
+  "melange-webapi" {>= "0.21.0"}
+  "reason-react" {>= "0.16.0"}
+  "odoc" {with-doc}
+  "ocamlformat" {= "0.28.1" & with-test}
+  "ocaml-lsp-server" {with-dev-setup}
+  "dream" {= "1.0.0~alpha8" & with-dev-setup}
+  "reason-react-ppx" {with-dev-setup}
+  "alcotest" {with-test}
+  "alcotest-lwt" {with-test}
+  "fmt" {with-test}
+  "merlin" {with-test}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/ml-in-barcelona/server-reason-react.git"
+x-maintenance-intent: ["(latest)"]
+url {
+  src:
+    "https://github.com/ml-in-barcelona/server-reason-react/releases/download/0.5.1/server-reason-react-0.5.1.tbz"
+  checksum: [
+    "sha256=3972f64a3ec22b120b40137f74e7862629b2164e5bbf8b85489d4c7b8bc13288"
+    "sha512=24a52537c091c4b278ea5e468aa6786378f8b559ed2128e824b6f84f26c283856a30e7ef01aab6101087bd53b9bdc2ecd8152c00db10bccff67221b9c67318a0"
+  ]
+}
+x-commit-hash: "9b7fe578fcfd19ae37a8db16bc4b75ed2b8f9165"


### PR DESCRIPTION
Rendering React components on the server natively

- Project page: <a href="https://github.com/ml-in-barcelona/server-reason-react">https://github.com/ml-in-barcelona/server-reason-react</a>

##### CHANGES:

* Require `quickjs >= 0.5.1 & < 0.6.0`: global `Js.String.replaceByRe`/`unsafeReplaceBy*`/`splitByRe` operations now prepare the regexp input once instead of copying and converting it for every match, making ordinary dense global replacements and splits linear in input plus output size. Replacement rendering writes source ranges directly without repeated UTF-16 rescans or eager prefix/suffix copies, callback replacements collect matches before invoking callbacks like JavaScript, and matches that split a surrogate pair produce U+FFFD rather than slicing the wrong UTF-8 bytes by @davesnx
