### PR TITLE
[new release] tw (1.0.0)

### DIFF
--- a/packages/tw/tw.1.0.0/opam
+++ b/packages/tw/tw.1.0.0/opam
@@ -1,0 +1,51 @@
+opam-version: "2.0"
+synopsis: "Type-safe Tailwind CSS v4 in OCaml"
+description:
+  "tw is a type-safe OCaml implementation of Tailwind CSS v4. It compiles to CSS through a strongly-typed variable system that mirrors Tailwind's pipeline, producing byte-for-byte identical output. Supports all core utilities and the official forms and typography plugins."
+maintainer: ["Thomas Gazagnaire <thomas@gazagnaire.org>"]
+authors: ["Thomas Gazagnaire"]
+license: "ISC"
+homepage: "https://github.com/samoht/tw"
+bug-reports: "https://github.com/samoht/tw/issues"
+depends: [
+  "ocaml" {>= "5.2"}
+  "dune" {>= "3.21"}
+  "cascade" {>= "1.0.0"}
+  "cmdliner"
+  "fmt"
+  "re" {with-test}
+  "uutf"
+  "brr" {>= "0.0.6"}
+  "js_of_ocaml"
+  "alcotest" {with-test}
+  "alcotest-js" {with-test}
+  "astring" {with-test}
+  "crunch" {with-test}
+  "alcobar" {with-test}
+  "mdx" {with-test}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/samoht/tw.git"
+x-maintenance-intent: ["(latest)"]
+url {
+  src: "https://github.com/samoht/tw/releases/download/1.0.0/tw-1.0.0.tbz"
+  checksum: [
+    "sha256=198a142b69828a53a0c8812b70f279be6c216b411b370c3433d5fe94be5d495e"
+    "sha512=fe0a94ef1ff22e19c669d4370c6b555bf323053e05a8cfc315196beb312703f68ec62966b2b7780b6a79c2e8db88e8aa816d7fe3cb3a2044e6f52ed4d839a3b4"
+  ]
+}
+x-commit-hash: "509287b8af562b9d32ef76de1674c17ee0248540"


### PR DESCRIPTION
Type-safe Tailwind CSS v4 in OCaml

- Project page: <a href="https://github.com/samoht/tw">https://github.com/samoht/tw</a>

##### CHANGES:

- Initial public release candidate. Type-safe Tailwind CSS v4 in OCaml,
  with parity against the upstream v4 compiler (core utilities plus the
  official `forms` and `typography` plugins).
