### PR TITLE
[new release] grace (0.4.0)

### DIFF
--- a/packages/grace/grace.0.4.0/opam
+++ b/packages/grace/grace.0.4.0/opam
@@ -1,0 +1,47 @@
+opam-version: "2.0"
+synopsis:
+  "A fancy diagnostics library that allows your compilers to exit with grace"
+maintainer: ["alistair.obrien@trili.tech"]
+authors: ["Alistair O'Brien"]
+license: "MIT"
+homepage: "https://github.com/johnyob/grace"
+bug-reports: "https://github.com/johnyob/grace/issues"
+depends: [
+  "ocaml" {>= "4.14.0"}
+  "dune" {>= "3.4"}
+  "yojson" {>= "2.1.0"}
+  "fmt" {>= "0.8.7"}
+  "iter"
+  "uutf"
+  "sexplib"
+  "ppx_sexp_conv"
+  "dedent" {with-test}
+  "core" {with-test}
+  "core_unix" {with-test}
+  "ppx_jane" {with-test}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/johnyob/grace.git"
+url {
+  src:
+    "https://github.com/johnyob/grace/releases/download/0.4.0/grace-0.4.0.tbz"
+  checksum: [
+    "sha256=388149857c0fbaf2489b1e396af25aadd6185998847b75570f9198a077ad1ace"
+    "sha512=9ffa701f7729f90976594c4ec77b968f15450d8d7a1f0c65fe60d092c136b18f1c8bbd5f5772a651c925dabcdc82ac7023c30a4caa1b94e3e158ef2efa34b85e"
+  ]
+}
+x-commit-hash: "3062a0d49876a7cab17a44d4dc2d84f1a5870168"


### PR DESCRIPTION
A fancy diagnostics library that allows your compilers to exit with grace

- Project page: <a href="https://github.com/johnyob/grace">https://github.com/johnyob/grace</a>

##### CHANGES:

- feat(renderer): add boxing to trailing labels ([johnyob/grace#92](https://github.com/johnyob/grace/pull/92))
- fix(renderer): print unicode and ansi-styled snippets as correct lengths ([johnyob/grace#88](https://github.com/johnyob/grace/pull/88))
- feat(renderer): add boxing to multi-line labels ([johnyob/grace#88](https://github.com/johnyob/grace/pull/88))
- feat(json_conv): use `Yojson.Basic.t` ([johnyob/grace#87](https://github.com/johnyob/grace/pull/87))
- feat(json_conv): add `Grace_json_conv` for conversion to Yojson ([johnyob/grace#84](https://github.com/johnyob/grace/pull/84))
- fix(core): dont catch `Sys_error` in `Source.length` if the fail doesn't exist ([johnyob/grace#81](https://github.com/johnyob/grace/pull/81))
- feat(renderer): support configurable contextual lines ([johnyob/grace#74](https://github.com/johnyob/grace/pull/74))
