### PR TITLE
[new release] eio (5 packages) (1.4)

### DIFF
--- a/packages/cohttp-eio/cohttp-eio.6.2.1/opam
+++ b/packages/cohttp-eio/cohttp-eio.6.2.1/opam
@@ -23,7 +23,7 @@ depends: [
   "base-domains"
   "cohttp" {= version}
   "eio" {>= "0.12"}
-  "eio_main" {with-test}
+  "eio_main" {with-test & < "1.4"}
   "mdx" {with-test}
   "ipaddr" {>= "5.6.0"}
   "logs"

--- a/packages/eio-ssl/eio-ssl.0.3.0/opam
+++ b/packages/eio-ssl/eio-ssl.0.3.0/opam
@@ -9,7 +9,7 @@ depends: [
   "dune" {>= "2.7"}
   "ocaml" {>= "5.0"}
   "ssl" {>= "0.7.0"}
-  "eio" {>= "0.12"}
+  "eio" {>= "0.12" & < "1.4"}
   "odoc" {with-doc}
 ]
 build: [

--- a/packages/eio/eio.1.4/opam
+++ b/packages/eio/eio.1.4/opam
@@ -1,0 +1,57 @@
+opam-version: "2.0"
+synopsis: "Effect-based direct-style IO API for OCaml"
+description: "An effect-based IO API for multicore OCaml with fibers."
+maintainer: ["anil@recoil.org"]
+authors: ["Anil Madhavapeddy" "Thomas Leonard"]
+license: "ISC"
+homepage: "https://github.com/ocaml-multicore/eio"
+doc: "https://ocaml-multicore.github.io/eio/"
+bug-reports: "https://github.com/ocaml-multicore/eio/issues"
+depends: [
+  "dune" {>= "3.9"}
+  "ocaml" {>= "5.2.0"}
+  "bigstringaf" {>= "0.9.0"}
+  "cstruct" {>= "6.0.1"}
+  "lwt-dllist"
+  "optint" {>= "0.1.0"}
+  "psq" {>= "0.2.0"}
+  "fmt" {>= "0.8.9"}
+  "hmap" {>= "0.8.1"}
+  "domain-local-await" {>= "0.1.0"}
+  "crowbar" {>= "0.2" & with-test}
+  "mtime" {>= "2.0.0"}
+  "mdx" {>= "2.4.1" & with-test}
+  "lintcstubs-arity" {with-test}
+  "dscheck" {>= "0.1.0" & with-test}
+  "odoc" {with-doc}
+]
+conflicts: [
+  "seq" {< "0.3"}
+]
+build: [
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/ocaml-multicore/eio.git"
+x-extra-doc-deps: [
+  "eio_main" {= version}
+  "bigstring"
+]
+url {
+  src:
+    "https://github.com/ocaml-multicore/eio/releases/download/v1.4/eio-1.4.tbz"
+  checksum: [
+    "sha256=ba11ad486f492130dbb486f2b3bdc4905643f10016806ddf86e9a34e4346aaa5"
+    "sha512=57ef2c137ccdc26d8029e636b6a4ee92da7c6b2f35954946bd56ca595d6947a8ec42f6f83f8552f73d6719e6ce2314cae2e2fad1686a387522935e6f90e9a8d9"
+  ]
+}
+x-commit-hash: "9365c0695bdd9bb0af74958076830fb4ca2c8e38"

--- a/packages/eio_linux/eio_linux.1.4/opam
+++ b/packages/eio_linux/eio_linux.1.4/opam
@@ -1,0 +1,48 @@
+opam-version: "2.0"
+synopsis: "Eio implementation for Linux using io-uring"
+description: "An Eio implementation for Linux using io-uring."
+maintainer: ["anil@recoil.org"]
+authors: ["Anil Madhavapeddy" "Thomas Leonard"]
+license: "ISC"
+homepage: "https://github.com/ocaml-multicore/eio"
+doc: "https://ocaml-multicore.github.io/eio/"
+bug-reports: "https://github.com/ocaml-multicore/eio/issues"
+depends: [
+  "dune" {>= "3.9"}
+  "alcotest" {>= "1.7.0" & with-test}
+  "eio" {= version}
+  "mdx" {>= "2.4.1" & with-test}
+  "lintcstubs-arity" {with-test}
+  "logs" {>= "0.7.0" & with-test}
+  "fmt" {>= "0.8.9"}
+  "cmdliner" {>= "1.1.0" & with-test}
+  "uring" {>= "2.15.0"}
+  "odoc" {with-doc}
+]
+build: [
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/ocaml-multicore/eio.git"
+available: [os = "linux"]
+x-extra-doc-deps: [
+  "eio_main" {= version}
+]
+url {
+  src:
+    "https://github.com/ocaml-multicore/eio/releases/download/v1.4/eio-1.4.tbz"
+  checksum: [
+    "sha256=ba11ad486f492130dbb486f2b3bdc4905643f10016806ddf86e9a34e4346aaa5"
+    "sha512=57ef2c137ccdc26d8029e636b6a4ee92da7c6b2f35954946bd56ca595d6947a8ec42f6f83f8552f73d6719e6ce2314cae2e2fad1686a387522935e6f90e9a8d9"
+  ]
+}
+x-commit-hash: "9365c0695bdd9bb0af74958076830fb4ca2c8e38"

--- a/packages/eio_main/eio_main.1.4/opam
+++ b/packages/eio_main/eio_main.1.4/opam
@@ -1,0 +1,48 @@
+opam-version: "2.0"
+synopsis: "Effect-based direct-style IO mainloop for OCaml"
+description: "Selects an appropriate Eio backend for the current platform."
+maintainer: ["anil@recoil.org"]
+authors: ["Anil Madhavapeddy" "Thomas Leonard"]
+license: "ISC"
+homepage: "https://github.com/ocaml-multicore/eio"
+doc: "https://ocaml-multicore.github.io/eio/"
+bug-reports: "https://github.com/ocaml-multicore/eio/issues"
+depends: [
+  "dune" {>= "3.9"}
+  "mdx" {>= "2.4.1" & with-test}
+  "kcas" {>= "0.3.0" & with-test}
+  "yojson" {>= "2.0.2" & with-test}
+  "eio_linux"
+    {= version & os = "linux" &
+     (os-distribution != "centos" | os-version > "7")}
+  "eio_posix" {= version & os != "win32"}
+  "eio_windows" {= version & os = "win32"}
+  "odoc" {with-doc}
+]
+build: [
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/ocaml-multicore/eio.git"
+x-ci-accept-failures: ["macos-homebrew"]
+x-extra-doc-deps: [
+  "eio_main" {= version}
+]
+url {
+  src:
+    "https://github.com/ocaml-multicore/eio/releases/download/v1.4/eio-1.4.tbz"
+  checksum: [
+    "sha256=ba11ad486f492130dbb486f2b3bdc4905643f10016806ddf86e9a34e4346aaa5"
+    "sha512=57ef2c137ccdc26d8029e636b6a4ee92da7c6b2f35954946bd56ca595d6947a8ec42f6f83f8552f73d6719e6ce2314cae2e2fad1686a387522935e6f90e9a8d9"
+  ]
+}
+x-commit-hash: "9365c0695bdd9bb0af74958076830fb4ca2c8e38"

--- a/packages/eio_posix/eio_posix.1.4/opam
+++ b/packages/eio_posix/eio_posix.1.4/opam
@@ -1,0 +1,46 @@
+opam-version: "2.0"
+synopsis: "Eio implementation for POSIX systems"
+description: "An Eio implementation for most Unix-like platforms"
+maintainer: ["anil@recoil.org"]
+authors: ["Anil Madhavapeddy" "Thomas Leonard"]
+license: "ISC"
+homepage: "https://github.com/ocaml-multicore/eio"
+doc: "https://ocaml-multicore.github.io/eio/"
+bug-reports: "https://github.com/ocaml-multicore/eio/issues"
+depends: [
+  "dune" {>= "3.9"}
+  "eio" {= version}
+  "iomux" {>= "0.2"}
+  "mdx" {>= "2.4.1" & with-test}
+  "lintcstubs-arity" {with-test}
+  "conf-bash" {with-test}
+  "fmt" {>= "0.8.9"}
+  "odoc" {with-doc}
+]
+build: [
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/ocaml-multicore/eio.git"
+available: [os != "win32"]
+x-extra-doc-deps: [
+  "eio_main" {= version}
+]
+url {
+  src:
+    "https://github.com/ocaml-multicore/eio/releases/download/v1.4/eio-1.4.tbz"
+  checksum: [
+    "sha256=ba11ad486f492130dbb486f2b3bdc4905643f10016806ddf86e9a34e4346aaa5"
+    "sha512=57ef2c137ccdc26d8029e636b6a4ee92da7c6b2f35954946bd56ca595d6947a8ec42f6f83f8552f73d6719e6ce2314cae2e2fad1686a387522935e6f90e9a8d9"
+  ]
+}
+x-commit-hash: "9365c0695bdd9bb0af74958076830fb4ca2c8e38"

--- a/packages/eio_windows/eio_windows.1.4/opam
+++ b/packages/eio_windows/eio_windows.1.4/opam
@@ -1,0 +1,44 @@
+opam-version: "2.0"
+synopsis: "Eio implementation for Windows"
+description: "An Eio implementation using OCaml's Unix.select"
+maintainer: ["anil@recoil.org"]
+authors: ["Anil Madhavapeddy" "Thomas Leonard"]
+license: "ISC"
+homepage: "https://github.com/ocaml-multicore/eio"
+doc: "https://ocaml-multicore.github.io/eio/"
+bug-reports: "https://github.com/ocaml-multicore/eio/issues"
+depends: [
+  "dune" {>= "3.9"}
+  "eio" {= version}
+  "fmt" {>= "0.8.9"}
+  "kcas" {>= "0.3.0" & with-test}
+  "alcotest" {>= "1.7.0" & with-test}
+  "odoc" {with-doc}
+]
+build: [
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/ocaml-multicore/eio.git"
+available: [os = "win32"]
+x-extra-doc-deps: [
+  "eio_main" {= version}
+]
+url {
+  src:
+    "https://github.com/ocaml-multicore/eio/releases/download/v1.4/eio-1.4.tbz"
+  checksum: [
+    "sha256=ba11ad486f492130dbb486f2b3bdc4905643f10016806ddf86e9a34e4346aaa5"
+    "sha512=57ef2c137ccdc26d8029e636b6a4ee92da7c6b2f35954946bd56ca595d6947a8ec42f6f83f8552f73d6719e6ce2314cae2e2fad1686a387522935e6f90e9a8d9"
+  ]
+}
+x-commit-hash: "9365c0695bdd9bb0af74958076830fb4ca2c8e38"


### PR DESCRIPTION
Effect-based direct-style IO API for OCaml

- Project page: <a href="https://github.com/ocaml-multicore/eio">https://github.com/ocaml-multicore/eio</a>
- Documentation: <a href="https://ocaml-multicore.github.io/eio/">https://ocaml-multicore.github.io/eio/</a>

##### CHANGES:

Breaking changes:

- Report errors from `Net.getaddrinfo` (@talex5 @haesbaert @avsm ocaml-multicore/eio#866 ocaml-multicore/eio#900).
  Before, `Net.getaddrinfo` returned `[]` on error. It now raises an exception with the actual error.

New features:

- Add `Eio.Net.Sockopt` for setting/getting socket options (@avsm @talex5 @anmonteiro ocaml-multicore/eio#858 ocaml-multicore/eio#575 ocaml-multicore/eio#859 ocaml-multicore/eio#874 ocaml-multicore/eio#876 ocaml-multicore/eio#889 ocaml-multicore/eio#891).
  This includes all the options from OCaml's `Unix` module, plus many more (e.g. `TCP_KEEPINTVL`).

- Support `TCP_KEEPIDLE` socket option on macOS (@avsm @talex5 ocaml-multicore/eio#890).

- Add `Path.chmod` (@patricoferris @webbunivAdmin @avsm @talex5 ocaml-multicore/eio#785 ocaml-multicore/eio#872).

- Add `Path.chown` (@patricoferris @avsm @talex5 ocaml-multicore/eio#781 ocaml-multicore/eio#864 ocaml-multicore/eio#877).

- Add `Path.with_dir_entries` for incremental directory reading (@patricoferris @talex5 @avsm ocaml-multicore/eio#821 ocaml-multicore/eio#897).
  This also provides the type of each entry, saving one `stat` per entry in most cases.

- Add `Eio_unix.Pty` for pseudoterminal support (@avsm @talex5 @patricoferris @RyanGibb ocaml-multicore/eio#531).
  The `Pty` module can be used to create and configure pseudoterminals,
  `Eio_unix.Process.spawn_unix ?login_tty ...` allows connecting them up when spawning a child process.

- Add `missing_ok` to `Eio.Path.unlink` (ocaml-multicore/eio#828) (@vog @patricoferris ocaml-multicore/eio#833).

- Add `Flow.null` sink/source (@avsm @talex5 ocaml-multicore/eio#894, suggested by @jonsterling).
  This can be used as sink that consumes and discards all data written to it until end-of-file,
  and as a source that immediately returns end-of-file.

- Add `Eio_unix.Process.spawn_unix ?uid ?gid ?pgid` options (@patricoferris @talex5 ocaml-multicore/eio#802 ocaml-multicore/eio#803).
  Allows setting the user ID, group ID and process group of the child.

- Add `Eio_unix.Stdenv.override` for updating environments (@patricoferris @talex5 ocaml-multicore/eio#823).

- Add `Eio_unix.Err` module (@talex5 ocaml-multicore/eio#887).
  This is convenient whenever wrapping a function that raises `Unix_error`.

Linux backend:

- eio_linux now requires Linux 5.18 or later. On older kernels, `Eio_main.run` will use eio_posix instead.

- Add `Low_level.{socket,bind,listen}` with uring support (@avsm @talex5 ocaml-multicore/eio#884).

- Add `ftruncate`/`fdatasync` and use uring for `fsync`/`shutdown` (@avsm @talex5 ocaml-multicore/eio#850).

- Switch `fstat` to `statx` on linux and fetch `blksize` (@avsm @talex5 ocaml-multicore/eio#865).

- uring: update min to 2.15.0+ so we can use new functionality (@avsm ocaml-multicore/eio#867).

- Add `Eio_linux.Low_level.Fixed` (@talex5 ocaml-multicore/eio#848).
  This replaces the `Uring.Region` API.

- eio_linux: use `IORING_SETUP_SINGLE_ISSUER` (@talex5 ocaml-multicore/eio#841).
  This hints to uring to do some locking optimisations assuming that each ring is only written by one thread.

- eio_linux: use `IORING_SETUP_DEFER_TASKRUN` for performance (@talex5 ocaml-multicore/eio#842).

Bug fixes:

- Allow `Eio.Path.load` to handle files with zero size (@patricoferris @talex5 ocaml-multicore/eio#869 ocaml-multicore/eio#878, reported by @copy and @vog).
  This is useful for loading files in `/proc/` on Linux.

- `Eio.Process`: match Unix search behaviour (@talex5 ocaml-multicore/eio#820).
  Don't search `$PATH` if the name contains a `/`.

- eio_posix: on macOS, fall back to `select()` for FDs where `poll()` fails (@avsm @talex5 ocaml-multicore/eio#893, reported by @aaronjeline).
  macOS `poll()` returns `POLLNVAL` for some device FDs such as `/dev/tty` or `/dev/null`.

- eio_posix: wait for a writer when first reading from a FIFO (@talex5 ocaml-multicore/eio#857).
  Before, it would return end-of-file if there was no waiter.

- eio_posix: open confined paths in non-blocking mode too (@talex5 ocaml-multicore/eio#855).
  Previously, paths opened using `fs` were opened in non-blocking mode, but paths opened with `cwd` were not.
  This probably only affects FIFOs.

- eio_posix: use `MSG_CMSG_CLOEXEC` when receiving file descriptors (@talex5 @avsm ocaml-multicore/eio#843).

- eio_linux: `read_upto` and `write_single` didn't hold the FD open (@avsm ocaml-multicore/eio#871).
  This could be a problem if another fiber closed the FD before the operation was submitted.

- eio_linux: handle ENOMEM from `io_uring_queue_init` (@talex5 ocaml-multicore/eio#852).
  We would already fall back to eio_posix if there wasn't enough lockable memory to add a fixed buffer,
  but didn't cope with not having enough memory for the ring itself.

- fork_action: retry on `EINTR` when writing to pipe (@avsm ocaml-multicore/eio#870).

- eio_windows: fix removing of FDs from read/write sets (@z-rui @talex5 ocaml-multicore/eio#861).
  Could cause high CPU use in some cases.

- eio_windows: remove unused `unix_cstruct.ml` file (@talex5 ocaml-multicore/eio#817, reported by @dijkstracula).
  Caused an error if linking with `-linkall`.

Minor changes:

- Propagate `errno` back from `fork_actions` into `Eio.Process` (@Innf107 @avsm @talex5 ocaml-multicore/eio#854).
  Report Unix `fork_action` failures as Eio exceptions instead of `Failure`.
  This allows matching on specific errors (e.g. `Argument_list_too_long`).

- Alias `Path.open_dir` to `open_subtree` (@talex5 @avsm ocaml-multicore/eio#853).
  This more accurately describes what it's for.

- Prioritize returning `Fiber.any` value over cancelling quickly (@adamchol @talex5 ocaml-multicore/eio#806).
  This works better with the new `combine` option.

- Relax return types of `Eio.Process.Pipe` (@Arogbonlo @patricoferris @talex5 ocaml-multicore/eio#775, requested by @rizo).

- `Eio.Pool.use`: move `never_block` argument (@talex5 ocaml-multicore/eio#747).

- eta expand some function applications to support OxCaml (@avsm ocaml-multicore/eio#898).

- fork_action: reject ids that don't fit uid_t/gid_t/pid_t (@avsm ocaml-multicore/eio#895).


Documentation:

- eio_unix: minor typo in `Unix_error` docstring (@avsm ocaml-multicore/eio#888).

- Simplify custom "env" type in example (@vog ocaml-multicore/eio#832).

- Fix docs for `without_binding` (@patricoferris ocaml-multicore/eio#822).

- Clarify Eio as a possible concurrency library (@patricoferris ocaml-multicore/eio#879).

Code cleanups:

- Add braces around switch case block (@olafhering ocaml-multicore/eio#882).

- eio_linux: use `Uring.Res` module for safer error handling (@talex5 @avsm ocaml-multicore/eio#868).

- eio_linux: move read/write retries out of scheduler (@talex5 @avsm ocaml-multicore/eio#849).

- eio_linux: split out `net.ml`, `process.ml`, `fs.ml` and `time.ml` (@talex5 ocaml-multicore/eio#886).
  This more closely matches the layout in eio_posix.

- eio_linux: remove unused code (@talex5 ocaml-multicore/eio#851).
  uring should never ask us to retry a job.

- Remove all use of `[@@@alert "-unstable"]` (@talex5 ocaml-multicore/eio#885).
  This was needed a long time ago to work around a bug in Merlin.

- Remove some test files after running the tests (@avsm ocaml-multicore/eio#883).

- win32: declare unixsupport functions as `CAMLextern` (@avsm @dra27 ocaml-multicore/eio#881).
  This is necessary under Windows to prevent flexdll errors.

- Remove unused `show_backend_exceptions` flag (@talex5 ocaml-multicore/eio#880).

- Improve formatting of IP addresses in tests (@talex5 ocaml-multicore/eio#847).

- Add lintcstubs-arity as a test dependency (@talex5 ocaml-multicore/eio#846).

- Update Dockerfiles to recent versions (@talex5 ocaml-multicore/eio#844).

- Skip `test_alloc_fixed_or_wait` if no fixed buffers are available (@talex5 ocaml-multicore/eio#815).
  Prevents spurious CI failures.

- Make `eio_unix_fork_error` call `_exit` automatically (@talex5 ocaml-multicore/eio#896).
