### PR TITLE
[new release] ppx_deriving (6.1.3)

### DIFF
--- a/packages/ppx_deriving/ppx_deriving.6.1.3/opam
+++ b/packages/ppx_deriving/ppx_deriving.6.1.3/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+maintainer: "whitequark <whitequark@whitequark.org>"
+authors: [ "whitequark <whitequark@whitequark.org>" ]
+license: "MIT"
+homepage: "https://github.com/ocaml-ppx/ppx_deriving"
+doc: "https://ocaml-ppx.github.io/ppx_deriving/"
+bug-reports: "https://github.com/ocaml-ppx/ppx_deriving/issues"
+dev-repo: "git+https://github.com/ocaml-ppx/ppx_deriving.git"
+tags: [ "syntax" ]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+  ["dune" "build" "@doc" "-p" name "-j" jobs] {with-doc}
+]
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "1.6.3"}
+  "cppo" {>= "1.1.0" & build}
+  "ocamlfind"
+  "ppx_derivers"
+  "ppxlib" {>= "0.36.0"}
+  "ounit2" {with-test}
+]
+synopsis: "Type-driven code generation for OCaml"
+description: """
+ppx_deriving provides common infrastructure for generating
+code based on type definitions, and a set of useful plugins
+for common tasks.
+"""
+url {
+  src:
+    "https://github.com/ocaml-ppx/ppx_deriving/releases/download/6.1.3/ppx_deriving-6.1.3.tbz"
+  checksum: [
+    "sha256=a654239a2bfeb3ffd4d2002d81d62191663eca8b3447d83fafc55d5dc2ae9d0a"
+    "sha512=a1b5056f305d92bd32f47b30fe5df8fe8ea2749ed0bd09c356ac3e98ca14780c749fe936eb189b8c2cd92cf7d87056585b9beb786979ada6df1411d766fdc3e0"
+  ]
+}
+x-commit-hash: "e0f3a79ed21488129ab9a776158db7cb0180fb47"


### PR DESCRIPTION
Type-driven code generation for OCaml

- Project page: <a href="https://github.com/ocaml-ppx/ppx_deriving">https://github.com/ocaml-ppx/ppx_deriving</a>
- Documentation: <a href="https://ocaml-ppx.github.io/ppx_deriving/">https://ocaml-ppx.github.io/ppx_deriving/</a>

##### CHANGES:

* Fix fold plugin for polymorphic variants
  ocaml-ppx/ppx_deriving#256
  (@danielmercier)

* Coalesce syntactic arity in `poly_{fun,apply}_of_type_*`
  ocaml-ppx/ppx_deriving#306
  (@sim642)

* Add default locations to `eq`, `ord` and `show` extensions
  ocaml-ppx/ppx_deriving#312
  (@sim642)

* Fix double printing of submessage locations (used by `enum`)
  ocaml-ppx/ppx_deriving#310, ocaml-ppx/ppx_deriving#315
  (@gasche)

* Mark locations as `loc_ghost`
  ocaml-ppx/ppx_deriving#313, ocaml-ppx/ppx_deriving#312, ocaml-ppx/ppx_deriving#316
  (@fantazio, @sim642)

* Remove now-unnecessary unused-rec-flag suppression from `sanitize`
  ocaml-ppx/ppx_deriving#311
  (@sim642)

* Fix misplaced suppression attribute in `sanitize`
  ocaml-ppx/ppx_deriving#283
  (@samwgoldman)

* Remove unnecessary cppo usage
  ocaml-ppx/ppx_deriving#308, ocaml-ppx/ppx_deriving#309
  (@sim642)
