### PR TITLE
conf-python3-{tomli,pyparsing}: add centos depexts, fix opensuse tomli name

### DIFF
--- a/packages/conf-python3-pyparsing/conf-python3-pyparsing.1/opam
+++ b/packages/conf-python3-pyparsing/conf-python3-pyparsing.1/opam
@@ -15,6 +15,7 @@ depexts: [
   ["python3-pyparsing"] {os-family = "debian"}
   ["python3-pyparsing"] {os-family = "ubuntu"}
   ["python3-pyparsing"] {os-family = "fedora"}
+  ["python3-pyparsing"] {os-distribution = "centos" & os-version >= "8"}
   ["python3-pyparsing"] {os-family = "suse" | os-family = "opensuse"}
   ["python-pyparsing"] {os-family = "arch"}
   ["py3-parsing"] {os-family = "alpine"}

--- a/packages/conf-python3-tomli/conf-python3-tomli.1/opam
+++ b/packages/conf-python3-tomli/conf-python3-tomli.1/opam
@@ -15,7 +15,8 @@ depexts: [
   ["python3-tomli"] {os-family = "debian"}
   ["python3-tomli"] {os-family = "ubuntu"}
   ["python3-tomli"] {os-family = "fedora"}
-  ["python-tomli"] {os-family = "suse" | os-family = "opensuse"}
+  ["epel-release" "python3-tomli"] {os-distribution = "centos" & os-version >= "8"}
+  ["python3-tomli"] {os-family = "suse" | os-family = "opensuse"}
   ["python-tomli"] {os-family = "arch"}
   ["py3-tomli"] {os-family = "alpine"}
   ["py39-tomli"] {os = "freebsd"}


### PR DESCRIPTION
Fixes issues installing dependencies of cvc5, failures raised in #30289 