### PR TITLE
[new release] noise (0.2.0)

### DIFF
--- a/packages/noise/noise.0.2.0/opam
+++ b/packages/noise/noise.0.2.0/opam
@@ -1,0 +1,46 @@
+opam-version: "2.0"
+synopsis: "An OCaml implementation of the Noise Protocol Framework (rev 34)"
+description:
+  "noise implements the Noise Protocol Framework (https://noiseprotocol.org/) in OCaml. It supports Curve25519 DH, AES-256-GCM and ChaCha20-Poly1305 ciphers, SHA-256, SHA-512, BLAKE2s and BLAKE2b hashes, all fundamental and deferred handshake patterns, and PSK modifiers."
+maintainer: ["Race Williams <race@raquent.in>"]
+authors: ["Race Williams"]
+license: "MIT"
+tags: ["cryptography" "networking"]
+homepage: "https://github.com/raquentin/ocaml-noise"
+bug-reports: "https://github.com/raquentin/ocaml-noise/issues"
+depends: [
+  "dune" {>= "3.17"}
+  "ocaml" {>= "5.0"}
+  "mirage-crypto" {>= "2.0"}
+  "mirage-crypto-ec" {>= "2.0"}
+  "digestif" {>= "1.3"}
+  "mirage-crypto-rng" {with-test & >= "2.0"}
+  "alcotest" {with-test & >= "1.0"}
+  "yojson" {with-test & >= "2.0"}
+  "ohex" {with-test & >= "0.2"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/raquentin/ocaml-noise.git"
+url {
+  src:
+    "https://github.com/raquentin/ocaml-noise/releases/download/v0.2.0/noise-v0.2.0.tbz"
+  checksum: [
+    "sha256=3970103d44c960cd97a44f571079d0b04c170874a89f8fb1c9cd94ff912952db"
+    "sha512=fb5ffc7e3156532444556caf702d14180c94b08f12bd1b7db9febee4a16100868b73b31ff668f09bcfae5de04e973ecc1c4e83cf7630eaa4fd19afecebe5333b"
+  ]
+}
+x-commit-hash: "f1ef7fdf54cc91a5e63c5a02be8fb6e7105c2ce2"


### PR DESCRIPTION
An OCaml implementation of the Noise Protocol Framework (rev 34)

- Project page: <a href="https://github.com/raquentin/ocaml-noise">https://github.com/raquentin/ocaml-noise</a>

##### CHANGES:

- `Handshake.split_raw`: extract the two raw 32-byte transport keys from a
  finished handshake, for driving a custom transport like WireGuard's
  explicit-nonce data channel instead of `Transport`. Shares the
  extracted-once semantics of `Transport.of_handshake`.
- `Handshake.remote_static`: read the peer's static public key once the
  handshake reveals it, so a responder can map a connection to a known peer or
  account.
- Documented the CSPRNG requirement, the absence of key zeroization, and the
  need for constant-time comparison of `handshake_hash` / `remote_static`.
- New `ik_custom_transport` example: an IK handshake with peer identification
  and a hand-rolled explicit-nonce, reordering-tolerant transport over the raw
  keys.
- Reject a PSK modifier whose index exceeds the pattern's message count like `XXpsk4` instead of silently dropping the PSK.
- Validate the length of `?rs` / `?re` public keys at handshake creation
  rather than mixing a malformed key into the transcript.
