### PR TITLE
[new release] mariadb (2.0.0)

### DIFF
--- a/packages/caqti-driver-mariadb/caqti-driver-mariadb.1.0.0/opam
+++ b/packages/caqti-driver-mariadb/caqti-driver-mariadb.1.0.0/opam
@@ -9,7 +9,7 @@ depends: [
   "ocaml"
   "caqti" {>= "1.0.0" & < "1.1.0~"}
   "dune"
-  "mariadb" {>= "1.1.1"}
+  "mariadb" {>= "1.1.1" & < "2.0.0~"}
 ]
 build: [
   ["dune" "build" "-p" name "-j" jobs]

--- a/packages/caqti-driver-mariadb/caqti-driver-mariadb.1.1.0/opam
+++ b/packages/caqti-driver-mariadb/caqti-driver-mariadb.1.1.0/opam
@@ -9,7 +9,7 @@ depends: [
   "ocaml"
   "caqti" {>= "1.0.0" & < "1.2.0~"}
   "dune"
-  "mariadb" {>= "1.1.1"}
+  "mariadb" {>= "1.1.1" & < "2.0.0~"}
 ]
 build: [
   ["dune" "build" "-p" name "-j" jobs]

--- a/packages/caqti-driver-mariadb/caqti-driver-mariadb.1.2.0/opam
+++ b/packages/caqti-driver-mariadb/caqti-driver-mariadb.1.2.0/opam
@@ -9,7 +9,7 @@ depends: [
   "ocaml"
   "caqti" {= "1.2.0"}
   "dune" {>= "1.11"}
-  "mariadb" {>= "1.1.1"}
+  "mariadb" {>= "1.1.1" & < "2.0.0~"}
 ]
 build: [
   ["dune" "build" "-p" name "-j" jobs]

--- a/packages/caqti-driver-mariadb/caqti-driver-mariadb.1.2.1/opam
+++ b/packages/caqti-driver-mariadb/caqti-driver-mariadb.1.2.1/opam
@@ -9,7 +9,7 @@ depends: [
   "ocaml"
   "caqti" {>= "1.2.1" & < "1.2.3~"}
   "dune" {>= "1.11"}
-  "mariadb" {>= "1.1.1"}
+  "mariadb" {>= "1.1.1" & < "2.0.0~"}
 ]
 build: [
   ["dune" "build" "-p" name "-j" jobs]

--- a/packages/caqti-driver-mariadb/caqti-driver-mariadb.1.2.3/opam
+++ b/packages/caqti-driver-mariadb/caqti-driver-mariadb.1.2.3/opam
@@ -9,7 +9,7 @@ depends: [
   "ocaml"
   "caqti" {>= "1.2.3" & < "1.3.0~"}
   "dune" {>= "1.11"}
-  "mariadb" {>= "1.1.1"}
+  "mariadb" {>= "1.1.1" & < "2.0.0~"}
 ]
 build: [
   ["dune" "build" "-p" name "-j" jobs]

--- a/packages/caqti-driver-mariadb/caqti-driver-mariadb.1.3.0/opam
+++ b/packages/caqti-driver-mariadb/caqti-driver-mariadb.1.3.0/opam
@@ -9,7 +9,7 @@ depends: [
   "ocaml"
   "caqti" {>= "1.3.0" & < "1.4.0~"}
   "dune" {>= "1.11"}
-  "mariadb" {>= "1.1.1"}
+  "mariadb" {>= "1.1.1" & < "2.0.0~"}
 ]
 build: [
   ["dune" "build" "-p" name "-j" jobs]

--- a/packages/caqti-driver-mariadb/caqti-driver-mariadb.1.4.0/opam
+++ b/packages/caqti-driver-mariadb/caqti-driver-mariadb.1.4.0/opam
@@ -9,7 +9,7 @@ depends: [
   "ocaml"
   "caqti" {>= "1.4.0" & < "1.5.0~"}
   "dune" {>= "1.11"}
-  "mariadb" {>= "1.1.1"}
+  "mariadb" {>= "1.1.1" & < "2.0.0~"}
 ]
 build: [
   ["dune" "build" "-p" name "-j" jobs]

--- a/packages/caqti-driver-mariadb/caqti-driver-mariadb.1.5.0/opam
+++ b/packages/caqti-driver-mariadb/caqti-driver-mariadb.1.5.0/opam
@@ -9,7 +9,7 @@ depends: [
   "ocaml"
   "caqti" {>= "1.5.0" & < "1.6.0~"}
   "dune" {>= "1.11"}
-  "mariadb" {>= "1.1.1"}
+  "mariadb" {>= "1.1.1" & < "2.0.0~"}
 ]
 build: [
   ["dune" "build" "-p" name "-j" jobs]

--- a/packages/caqti-driver-mariadb/caqti-driver-mariadb.1.5.1/opam
+++ b/packages/caqti-driver-mariadb/caqti-driver-mariadb.1.5.1/opam
@@ -9,7 +9,7 @@ depends: [
   "ocaml"
   "caqti" {>= "1.5.0" & < "1.6.0~"}
   "dune" {>= "1.11"}
-  "mariadb" {>= "1.1.1"}
+  "mariadb" {>= "1.1.1" & < "2.0.0~"}
 ]
 build: [
   ["dune" "build" "-p" name "-j" jobs]

--- a/packages/caqti-driver-mariadb/caqti-driver-mariadb.1.6.0/opam
+++ b/packages/caqti-driver-mariadb/caqti-driver-mariadb.1.6.0/opam
@@ -9,7 +9,7 @@ depends: [
   "ocaml"
   "caqti" {>= "1.6.0" & < "1.7.0~"}
   "dune" {>= "1.11"}
-  "mariadb" {>= "1.1.1"}
+  "mariadb" {>= "1.1.1" & < "2.0.0~"}
 ]
 build: [
   ["dune" "build" "-p" name "-j" jobs]

--- a/packages/caqti-driver-mariadb/caqti-driver-mariadb.1.7.0/opam
+++ b/packages/caqti-driver-mariadb/caqti-driver-mariadb.1.7.0/opam
@@ -10,7 +10,7 @@ depends: [
   "ocaml"
   "caqti" {>= "1.7.0" & < "1.8.0~"}
   "dune" {>= "2.0"}
-  "mariadb" {>= "1.1.1"}
+  "mariadb" {>= "1.1.1" & < "2.0.0~"}
   "odoc" {with-doc}
 ]
 build: [

--- a/packages/caqti-driver-mariadb/caqti-driver-mariadb.1.8.0/opam
+++ b/packages/caqti-driver-mariadb/caqti-driver-mariadb.1.8.0/opam
@@ -11,7 +11,7 @@ depends: [
   "caqti" {>= "1.8.0" & < "1.9.0~"}
   "cmdliner" {with-test & >= "1.1.0"}
   "dune" {>= "2.0"}
-  "mariadb" {>= "1.1.1"}
+  "mariadb" {>= "1.1.1" & < "2.0.0~"}
   "odoc" {with-doc}
 ]
 build: [

--- a/packages/caqti-driver-mariadb/caqti-driver-mariadb.1.9.0/opam
+++ b/packages/caqti-driver-mariadb/caqti-driver-mariadb.1.9.0/opam
@@ -11,7 +11,7 @@ depends: [
   "caqti" {>= "1.9.0" & < "1.10.0~"}
   "cmdliner" {with-test & >= "1.1.0"}
   "dune" {>= "2.0"}
-  "mariadb" {>= "1.1.5"}
+  "mariadb" {>= "1.1.5" & < "2.0.0~"}
   "odoc" {with-doc}
 ]
 build: [

--- a/packages/caqti-driver-mariadb/caqti-driver-mariadb.2.0.1/opam
+++ b/packages/caqti-driver-mariadb/caqti-driver-mariadb.2.0.1/opam
@@ -11,7 +11,7 @@ depends: [
   "caqti" {>= "2.0.0" & < "2.1.0~"}
   "cmdliner" {with-test & >= "1.1.0"}
   "dune" {>= "3.0"}
-  "mariadb" {>= "1.1.5"}
+  "mariadb" {>= "1.1.5" & < "2.0.0~"}
   "odoc" {with-doc}
 ]
 build: [

--- a/packages/caqti-driver-mariadb/caqti-driver-mariadb.2.1.1/opam
+++ b/packages/caqti-driver-mariadb/caqti-driver-mariadb.2.1.1/opam
@@ -11,7 +11,7 @@ depends: [
   "caqti" {>= "2.1.0" & < "2.2.0~"}
   "cmdliner" {with-test & >= "1.1.0"}
   "dune" {>= "3.9"}
-  "mariadb" {>= "1.1.5"}
+  "mariadb" {>= "1.1.5" & < "2.0.0~"}
   "odoc" {with-doc}
 ]
 build: [

--- a/packages/caqti-driver-mariadb/caqti-driver-mariadb.2.2.4/opam
+++ b/packages/caqti-driver-mariadb/caqti-driver-mariadb.2.2.4/opam
@@ -11,7 +11,7 @@ depends: [
   "caqti" {>= "2.2.0" & < "2.3.0~"}
   "cmdliner" {with-test & >= "1.1.0"}
   "dune" {>= "3.9"}
-  "mariadb" {>= "1.1.5"}
+  "mariadb" {>= "1.1.5" & < "2.0.0~"}
   "odoc" {with-doc}
 ]
 build: [

--- a/packages/caqti-driver-mariadb/caqti-driver-mariadb.2.3.0/opam
+++ b/packages/caqti-driver-mariadb/caqti-driver-mariadb.2.3.0/opam
@@ -12,7 +12,7 @@ depends: [
   "caqti" {>= "2.3.0" & < "2.4.0~"}
   "cmdliner" {with-test & >= "1.1.0"}
   "dune" {>= "3.9"}
-  "mariadb" {>= "1.3.0"}
+  "mariadb" {>= "1.3.0" & < "2.0.0~"}
   "odoc" {with-doc}
 ]
 build: [

--- a/packages/caqti-driver-mariadb/caqti-driver-mariadb.3.0.0/opam
+++ b/packages/caqti-driver-mariadb/caqti-driver-mariadb.3.0.0/opam
@@ -12,7 +12,7 @@ depends: [
   "caqti" {>= "3.0.0" & < "3.1.0~"}
   "cmdliner" {with-test & >= "1.1.0"}
   "dune" {>= "3.23.1"}
-  "mariadb" {>= "1.3.0"}
+  "mariadb" {>= "1.3.0" & < "2.0.0~"}
   "odoc" {with-doc}
 ]
 build: [

--- a/packages/mariadb/mariadb.2.0.0/opam
+++ b/packages/mariadb/mariadb.2.0.0/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+maintainer: "Petter A. Urkedal <paurkedal@gmail.com>"
+authors: "Andre Nathan <andrenth@gmail.com>"
+homepage: "https://github.com/ocaml-community/ocaml-mariadb"
+bug-reports: "https://github.com/ocaml-community/ocaml-mariadb/issues"
+license: "MIT"
+dev-repo: "git+https://github.com/ocaml-community/ocaml-mariadb.git"
+synopsis: "OCaml bindings for MariaDB"
+description: "OCaml-MariaDB provides Ctypes-based bindings for MariaDB, including its nonblocking API."
+
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+depends: [
+  "ocaml" {>= "4.07.0"}
+  "ctypes" {>= "0.13.0"}
+  "conf-mariadb"
+  "conf-gcc"
+  "conf-pkg-config"
+  "dune" {>= "3.15.0"}
+  "dune-configurator"
+  "async" {with-test}
+  "lwt" {with-test}
+]
+conflicts: [ "ocaml-option-bytecode-only" ]
+url {
+  src:
+    "https://github.com/ocaml-community/ocaml-mariadb/releases/download/2.0.0/mariadb-2.0.0.tbz"
+  checksum: [
+    "sha256=327b063c7e2002ce34d58f3fbafaef471db5b2d41256b53d458a42d93f1311cc"
+    "sha512=a261be759e730520d98c4736eda4ea68480c7623b2bce4b37b8eeacd9ad618f162f4e930e73d5b61c43fdbe8240a477c06b8b45bbe410476abf1c70acb9b6f40"
+  ]
+}
+x-commit-hash: "9d021d979bd032bbef95af5586656ac774c52894"

--- a/packages/sqlgg/sqlgg.20200521/opam
+++ b/packages/sqlgg/sqlgg.20200521/opam
@@ -22,7 +22,7 @@ depends: [
   "ounit"
 ]
 depopts: [
-  "mariadb"
+  "mariadb" {< "2.0.0~"}
   "mysql"
   "sqlite3"
 ]

--- a/packages/sqlgg/sqlgg.20231201/opam
+++ b/packages/sqlgg/sqlgg.20231201/opam
@@ -22,7 +22,7 @@ depends: [
   "ounit"
 ]
 depopts: [
-  "mariadb"
+  "mariadb" {< "2.0.0~"}
   "mysql"
   "sqlite3"
 ]


### PR DESCRIPTION
OCaml bindings for MariaDB

- Project page: <a href="https://github.com/ocaml-community/ocaml-mariadb">https://github.com/ocaml-community/ocaml-mariadb</a>

##### CHANGES:

  - Added support for signed and unsigned 64 bit integers (ocaml-community/ocaml-mariadb#66 by Mauricio
    Fernández).
  - Added some reasonable conversions for integer extractors, esp. to avoid
    predicting the type in case of expressions.
  - Added JSON type support (ocaml-community/ocaml-mariadb#69 by Javier Chavarri, jongleb, Gleb Patsiia,
    and Petter A.  Urkedal).
  - Fixed error reporting for blocking connect (ocaml-community/ocaml-mariadb#70 by Petter A. Urkedal).
