### PR TITLE
Package ifs-fractals.1.0.0

### DIFF
--- a/packages/ifs-fractals/ifs-fractals.1.0.0/opam
+++ b/packages/ifs-fractals/ifs-fractals.1.0.0/opam
@@ -1,0 +1,43 @@
+opam-version: "2.0"
+synopsis:
+  "IFS fractals (the Barnsley fern and friends) drawn with the chaos game"
+description:
+  "Draws fractals defined by iterated function systems (IFS) in an OCaml Graphics window, using the chaos game. Sixteen fractals are predefined (the Barnsley fern, the Sierpinski triangle, a dragon curve, a maple leaf, a sunflower, Queen Anne's lace, ...), available both from the ifs-fractals command-line tool and as a library for the toplevel. Defining a new fractal is a small record: a handful of affine transforms with their weights and a viewport."
+maintainer: "Cédric Bonhomme <cedric@cedricbonhomme.org>"
+authors: "Cédric Bonhomme <cedric@cedricbonhomme.org>"
+license: "GPL-3.0-or-later"
+tags: ["fractals" "graphics" "chaos-game" "ifs"]
+homepage: "https://github.com/cedricbonhomme/iterated-function-systems"
+doc: "https://github.com/cedricbonhomme/iterated-function-systems"
+bug-reports:
+  "https://github.com/cedricbonhomme/iterated-function-systems/issues"
+depends: [
+  "dune" {>= "3.8"}
+  "ocaml" {>= "4.09"}
+  "graphics" {>= "5.1"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo:
+  "git+https://github.com/cedricbonhomme/iterated-function-systems.git"
+url {
+  src:
+    "https://github.com/cedricbonhomme/iterated-function-systems/archive/refs/tags/v1.0.0.tar.gz"
+  checksum: [
+    "md5=b19169db413e22ef907ec15302e49545"
+    "sha512=ac19066c283c916e40745bfd25ea64e72b39abb5e2e15ddfc9fdd520547c5c258383c279b77f3e80cb8cf0d30c64cdbfbd4c4becd7307afd9ae7fa6869e0b068"
+  ]
+}


### PR DESCRIPTION
### `ifs-fractals.1.0.0`
IFS fractals (the Barnsley fern and friends) drawn with the chaos game
Draws fractals defined by iterated function systems (IFS) in an OCaml Graphics window, using the chaos game. Sixteen fractals are predefined (the Barnsley fern, the Sierpinski triangle, a dragon curve, a maple leaf, a sunflower, Queen Anne's lace, ...), available both from the ifs-fractals command-line tool and as a library for the toplevel. Defining a new fractal is a small record: a handful of affine transforms with their weights and a viewport.



---
* Homepage: https://github.com/cedricbonhomme/iterated-function-systems
* Source repo: git+https://github.com/cedricbonhomme/iterated-function-systems.git
* Bug tracker: https://github.com/cedricbonhomme/iterated-function-systems/issues

---
:camel: Pull-request generated by opam-publish v2.2.0