### PR TITLE
[new release] codept and codept-lib 0.13.0

### DIFF
--- a/packages/codept-lib/codept-lib.0.13.0/opam
+++ b/packages/codept-lib/codept-lib.0.13.0/opam
@@ -1,0 +1,42 @@
+opam-version: "2.0"
+synopsis: "Alternative ocaml dependency  analyzer"
+description: """
+Codept intends to be a dependency solver for OCaml project and an
+  alternative to ocamldep. This package provides the core library used to build
+  the codept executable under a more permissive license in order to be easier to
+  reuse in other projects"""
+maintainer: ["Florian Angeletti <octa@polychoron.fr>"]
+authors: ["Florian Angeletti <octa@polychoron.fr>"]
+license: "LGPL-2.1-only WITH OCaml-LGPL-linking-exception"
+homepage: "https://github.com/Octachron/codept"
+bug-reports: "https://github.com/Octachron/codept/issues"
+depends: [
+  "dune" {>= "2.8"}
+  "menhir" {>= "20180523"}
+  "ocaml" {>= "4.03" & < "5.6~"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/Octachron/codept.git"
+x-maintenance-intent: ["(latest)"]
+url {
+  src:
+    "https://github.com/Octachron/codept/releases/download/0.13.0/codept-0.13.0.tbz"
+  checksum: [
+    "sha256=5e6631d6bcb84d149460d046c71afa4a6342aa8d9adaf2b1f45989dd33a3ac92"
+    "sha512=ed58520e2b94c6d6b01466f2de464e5bfd95efd8d9d8e41e1d95e3c3f250b20118b3c2d08492cbc86152c334730fa43d110331d090fcc98e8be7fdc7b47962ff"
+  ]
+}
+x-commit-hash: "b733d3e4924db511897a9201d2b8b01c8a6e9b07"

--- a/packages/codept/codept.0.13.0/opam
+++ b/packages/codept/codept.0.13.0/opam
@@ -1,0 +1,48 @@
+opam-version: "2.0"
+synopsis: "Alternative ocaml dependency analyzer"
+description: """
+Codept intends to be a dependency solver for OCaml project and an alternative to ocamldep. Compared to ocamldep, codept major features are:
+
+ * whole project analysis
+ * exhaustive warning and error messages
+ * structured format (s-expression or json) for dependencies
+ * uniform handling of delayed alias dependencies
+ * (experimental) full dependencies,
+   when dependencies up to transitive closure are not enough
+
+Both ocamldep and codept computes an over-approximation of the dependencies graph of OCaml project. However, codept uses whole project analysis to reduce the number of fictitious dependencies inferred at the project scale, whereas ocamldep is, by design, limited to local file analysis."""
+maintainer: ["Florian Angeletti <octa@polychoron.fr>"]
+authors: ["Florian Angeletti <octa@polychoron.fr>"]
+license: "GPL-3.0-or-later"
+homepage: "https://github.com/Octachron/codept"
+bug-reports: "https://github.com/Octachron/codept/issues"
+depends: [
+  "dune" {>= "2.8"}
+  "codept-lib" {= version}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/Octachron/codept.git"
+x-maintenance-intent: ["(latest)"]
+url {
+  src:
+    "https://github.com/Octachron/codept/releases/download/0.13.0/codept-0.13.0.tbz"
+  checksum: [
+    "sha256=5e6631d6bcb84d149460d046c71afa4a6342aa8d9adaf2b1f45989dd33a3ac92"
+    "sha512=ed58520e2b94c6d6b01466f2de464e5bfd95efd8d9d8e41e1d95e3c3f250b20118b3c2d08492cbc86152c334730fa43d110331d090fcc98e8be7fdc7b47962ff"
+  ]
+}
+x-commit-hash: "b733d3e4924db511897a9201d2b8b01c8a6e9b07"


### PR DESCRIPTION
This is a new release of codept which mostly adds the support for OCaml 5.5 (with one new AST node for local module type definition `let module type T = ... in ...`) and fixes two dependency corner cases in presence of module aliases: aliases of aliases were not detected correctly, and dependency induced by alias prefixes were delayed to much.


## Changelog
* Support OCaml 5.5 (Standard library update, module dependent function, local definition of module type)
* Aliases prefix `module A = Prefix.X` triggers dependencies immediately on `Prefix` even in the `-no-alias-deps` mode
* Allow aliases to alias ``` module Y = Lib.Alias ```
* Breaking library change: rename two library modules to avoid a collision with standard library modules