### PR TITLE
[new release] flux (2 packages) (0.0.1~beta6)

### DIFF
--- a/packages/flux/flux.0.0.1~beta6/opam
+++ b/packages/flux/flux.0.0.1~beta6/opam
@@ -1,0 +1,35 @@
+opam-version: "2.0"
+maintainer:   "Romain Calascibetta <romain.calascibetta@gmail.com>"
+authors:
+  [ "Romain Calascibetta <romain.calascibetta@gmail.com>"
+    "Rizo I <rizo@odis.io>" ]
+homepage:     "https://github.com/robur-coop/flux"
+bug-reports:  "https://github.com/robur-coop/flux/issues"
+dev-repo:     "git+https://github.com/robur-coop/flux.git"
+doc:          "https://robur-coop.github.io/flux/"
+license:      "MIT"
+synopsis:     "Composable streaming abstractions with Miou"
+
+build: [ "dune" "build" "-p" name "-j" jobs ]
+run-test: [ "dune" "runtest" "-p" name "-j" jobs ]
+
+depends: [
+  "ocaml"             {>= "5.0.0"}
+  "dune"              {>= "3.20.0"}
+  "miou"              {>= "0.5.0"}
+  "ocamlformat"       {with-dev-setup & = "0.27.0"}
+  "httpcats"          {with-dev-setup}
+  "mirage-crypto-rng" {with-dev-setup}
+  "alcotest"          {with-test}
+]
+x-maintenance-intent: [ "(latest)" ]
+available: os-family != "windows"
+url {
+  src:
+    "https://github.com/robur-coop/flux/releases/download/v0.0.1_beta6/flux-0.0.1.beta6.tbz"
+  checksum: [
+    "sha256=a73ac59332c252a7ec2bf1b6cf59f1f03e0a2bbd8fa93a059c31a1263527b759"
+    "sha512=c020ad017f3606b430bb717d45615baa4b875c1b3aee5945ac84a65d85b5c01ffad198bf7d3c3c65c864bfc53d702d474b82d5655eb4e926dd03bb10e55f1d3b"
+  ]
+}
+x-commit-hash: "ce7e077ef8f1f54bde05906dc653166c5e6be8b8"

--- a/packages/fluxt/fluxt.0.0.1~beta6/opam
+++ b/packages/fluxt/fluxt.0.0.1~beta6/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+maintainer:   "Romain Calascibetta <romain.calascibetta@gmail.com>"
+authors:      "Romain Calascibetta <romain.calascibetta@gmail.com>"
+homepage:     "https://github.com/robur-coop/flux"
+bug-reports:  "https://github.com/robur-coop/flux/issues"
+dev-repo:     "git+https://github.com/robur-coop/flux.git"
+doc:          "https://robur-coop.github.io/flux/"
+license:      "MIT"
+synopsis:     "Extensions of flux to provide basic streams (compression, hash, format)"
+
+build: [ "dune" "build" "-p" name "-j" jobs ]
+run-test: [ "dune" "runtest" "-p" name "-j" jobs ]
+
+depends: [
+  "ocaml"             {>= "5.2.0"}
+  "dune"              {>= "2.8.0"}
+  "miou"              {>= "0.5.0"}
+  "decompress"
+  "tar"               {>= "3.5.0"}
+  "bstr"
+  "digestif"          {>= "1.3.0"}
+  "angstrom"
+  "ptime"
+  "flux"              {= version}
+  "ocamlformat"       {with-dev-setup & = "0.27.0"}
+  "alcotest"          {with-test}
+]
+x-maintenance-intent: [ "(latest)" ]
+url {
+  src:
+    "https://github.com/robur-coop/flux/releases/download/v0.0.1_beta6/flux-0.0.1.beta6.tbz"
+  checksum: [
+    "sha256=a73ac59332c252a7ec2bf1b6cf59f1f03e0a2bbd8fa93a059c31a1263527b759"
+    "sha512=c020ad017f3606b430bb717d45615baa4b875c1b3aee5945ac84a65d85b5c01ffad198bf7d3c3c65c864bfc53d702d474b82d5655eb4e926dd03bb10e55f1d3b"
+  ]
+}
+x-commit-hash: "ce7e077ef8f1f54bde05906dc653166c5e6be8b8"

--- a/packages/fluxt/fluxt.0.0.1~beta6/opam
+++ b/packages/fluxt/fluxt.0.0.1~beta6/opam
@@ -17,6 +17,7 @@ depends: [
   "miou"              {>= "0.5.0"}
   "decompress"
   "tar"               {>= "3.5.0"}
+  "fmt"
   "bstr"
   "digestif"          {>= "1.3.0"}
   "angstrom"


### PR DESCRIPTION
Composable streaming abstractions with Miou

- Project page: <a href="https://github.com/robur-coop/flux">https://github.com/robur-coop/flux</a>
- Documentation: <a href="https://robur-coop.github.io/flux/">https://robur-coop.github.io/flux/</a>

##### CHANGES:

- Update `fluxt.tar` with `tar.3.5.0` (robur-coop/flux#19, @dinosaure)
- Be able to decide the size of the buffer for `Flux_angstrom` (robur-coop/flux#20, @dinosaure)
- Add `Flux_unzip` (`fluxt.unzip`) (robur-coop/flux#22, @dinosaure)
- Fix a `assert false` on `Flux_de` (robur-coop/flux#22, spotted by @voodoos, fixed by @dinosaure)
- Use `Mirage_crypto_rng_unix.use_default` (robur-coop/flux#23, @dinosaure, @hannesm)
- Add `Flux.Flow.tee` (robur-coop/flux#24, @theAlexes, @dinosaure)
