### PR TITLE
[new release] mkernel (0.0.3)

### DIFF
--- a/packages/mkernel/mkernel.0.0.3/opam
+++ b/packages/mkernel/mkernel.0.0.3/opam
@@ -12,7 +12,7 @@ build:        [
   [ "dune" "runtest" "-p" name ] {with-test}
 ]
 run-test: [ "dune" "runtest" "-p" name "-j" jobs ]
-synopsis: "An unikernel with Miou in OCaml to provide I/O for Solo5/Unikraft"
+synopsis: "An unikernel with Miou in OCaml to provide I/O for Solo5"
 depends: [
   "ocaml" {>= "5.2.1"}
   "dune"  {>= "3.23"}

--- a/packages/mkernel/mkernel.0.0.3/opam
+++ b/packages/mkernel/mkernel.0.0.3/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+maintainer:   "romain.calascibetta@gmail.com"
+homepage:     "https://git.robur.coop/robur/mkernel"
+bug-reports:  "https://git.robur.coop/robur/mkernel/issues"
+dev-repo:     "git+https://github.com/robur-coop/mkernel.git"
+doc:          "https://git.robur.coop/robur/mkernel"
+license:      "MIT"
+authors:      [ "Romain Calascibetta <romain.calascibetta@gmail.com>" ]
+build:        [
+  [ "dune" "subst" ] {dev}
+  [ "dune" "build" "-p" name "-j" jobs ]
+  [ "dune" "runtest" "-p" name ] {with-test}
+]
+run-test: [ "dune" "runtest" "-p" name "-j" jobs ]
+synopsis: "An unikernel with Miou in OCaml to provide I/O for Solo5/Unikraft"
+depends: [
+  "ocaml" {>= "5.2.1"}
+  "dune"  {>= "3.0"}
+  "bstr"
+  "miou"  {>= "0.5.2"}
+  "ptime"
+  "solo5"
+  "logs"
+  "jsont"
+  "bytesrw"
+  "ocaml-solo5"
+  "hxd" {with-test}
+  "fmt" {with-test}
+  "cachet" {with-test}
+]
+url {
+  src:
+    "https://github.com/robur-coop/mkernel/releases/download/v0.0.3/mkernel-0.0.3.tbz"
+  checksum: [
+    "sha256=170289316d1a4dcb73dac28dcee153743aa0bb07000f4b18842b8433a1e406e3"
+    "sha512=b23c23ae020a1afb128e53a7d641c88b995776a11e6fb41422d4e62348ec19a16090e9790d99650e7d9b32200244a3cbee2d4d22c010394e1bca2832879ec541"
+  ]
+}
+x-commit-hash: "8a6c6ca14fa29db36d484770ede3526d50fd245a"

--- a/packages/mkernel/mkernel.0.0.3/opam
+++ b/packages/mkernel/mkernel.0.0.3/opam
@@ -15,7 +15,7 @@ run-test: [ "dune" "runtest" "-p" name "-j" jobs ]
 synopsis: "An unikernel with Miou in OCaml to provide I/O for Solo5/Unikraft"
 depends: [
   "ocaml" {>= "5.2.1"}
-  "dune"  {>= "3.0"}
+  "dune"  {>= "3.23"}
   "bstr"
   "miou"  {>= "0.5.2"}
   "ptime"


### PR DESCRIPTION
An unikernel with Miou in OCaml to provide I/O for Solo5/Unikraft

- Project page: <a href="https://git.robur.coop/robur/mkernel">https://git.robur.coop/robur/mkernel</a>
- Documentation: <a href="https://git.robur.coop/robur/mkernel">https://git.robur.coop/robur/mkernel</a>

##### CHANGES:

- Clean-up the distribution and remove the unikraft support (@dinosaure, robur-coop/mkernel#18)
- Add `Mkernel.wakeup` (@dinosaure, robur-coop/mkernel#18)

  `Mkernel.wakeup` is better if you would like to wake up a task at a specific date
  instead of `Mkernel.sleep` (which is better for small amount of times)

- Fix `Mkernel.wakeup` (@dinosaure, robur-coop/mkernel#19)
- Better way to handle and clean-up sleepers (@dinosaure, robur-coop/mkernel#20)
- Delete useless `Gc.compact` when we trigger a major cycle (@dinosaure, be761d5)
- Add `Mkernel.heap_size` (@dinosaure, robur-coop/mkernel#21)
