### PR TITLE
2 packages from mirage/ocaml-solo5 at 1.3.3

### DIFF
--- a/packages/ocaml-solo5-cross-aarch64/ocaml-solo5-cross-aarch64.1.3.3/opam
+++ b/packages/ocaml-solo5-cross-aarch64/ocaml-solo5-cross-aarch64.1.3.3/opam
@@ -1,0 +1,56 @@
+opam-version: "2.0"
+synopsis: "OCaml cross-compiler to the freestanding 64-bit ARM Solo5 backend"
+description:
+  "This package provides a OCaml cross-compiler for ARM64, suitable for linking with a Solo5 unikernel."
+maintainer: "Martin Lucina <martin@lucina.net>"
+authors: "Martin Lucina <martin@lucina.net>"
+license: "MIT"
+tags: "org:mirage"
+homepage: "https://github.com/mirage/ocaml-solo5"
+bug-reports: "https://github.com/mirage/ocaml-solo5/issues/"
+depends: [
+  "opatch" {build}
+  "ocamlfind" {build}
+  "ocaml-src" {build}
+  "ocaml" {= "5.4.1" | = "5.5.0"}
+  "solo5" {>= "0.9.1"}
+  "solo5-cross-aarch64" {>= "0.9.1"}
+]
+depopts: ["ocaml-option-no-flat-float-array" "ocaml-option-flambda"]
+conflicts: [
+  "ocaml-solo5"
+  "sexplib" {= "v0.9.0"}
+  "solo5-kernel-ukvm"
+  "solo5-kernel-virtio"
+  "solo5-kernel-muen"
+]
+available:
+  os = "linux" & (arch = "x86_64" | arch = "arm64") |
+  os = "freebsd" & arch = "x86_64" |
+  os = "openbsd" & arch = "x86_64"
+build: [
+  [
+    "./configure.sh"
+    "--prefix=%{prefix}%"
+    "--sysroot=%{_:lib}%"
+    "--target=aarch64-solo5-none-static"
+    "--ocaml-configure-option=--disable-flat-float-array"
+      {ocaml-option-no-flat-float-array:installed}
+    "--ocaml-configure-option=--enable-flambda"
+      {ocaml-option-flambda:installed}
+  ]
+  [make "-j%{jobs}%"]
+  [make "%{name}%.install"]
+]
+run-test: [make "test"]
+install: [make "install-ocaml"]
+dev-repo: "git+https://github.com/mirage/ocaml-solo5.git"
+url {
+  src:
+    "https://github.com/mirage/ocaml-solo5/archive/refs/tags/v1.3.3.tar.gz"
+  checksum: [
+    "md5=47876167068345542f49279e8fd28896"
+    "sha512=272081ec51a6ed69c08e4e8fa64fee3df53fd84c66c0c07a653891c88b342cf74553e1c95711e4fbc18922c899a3448a649f3bd9858f8d89cae834ad2b67fffb"
+  ]
+}
+x-maintenance-intent: ["(latest)"]

--- a/packages/ocaml-solo5/ocaml-solo5.1.3.3/opam
+++ b/packages/ocaml-solo5/ocaml-solo5.1.3.3/opam
@@ -1,0 +1,55 @@
+opam-version: "2.0"
+synopsis: "OCaml cross-compiler to the freestanding Solo5 backend"
+description:
+  "This package provides a OCaml cross-compiler, suitable for linking with a Solo5 unikernel."
+maintainer: "Martin Lucina <martin@lucina.net>"
+authors: "Martin Lucina <martin@lucina.net>"
+license: "MIT"
+tags: "org:mirage"
+homepage: "https://github.com/mirage/ocaml-solo5"
+bug-reports: "https://github.com/mirage/ocaml-solo5/issues/"
+depends: [
+  "opatch" {build}
+  "ocamlfind" {build}
+  "ocaml-src" {build}
+  "ocaml" {= "5.4.1" | = "5.5.0"}
+  "solo5" {>= "0.9.1"}
+]
+depopts: ["ocaml-option-no-flat-float-array" "ocaml-option-flambda"]
+conflicts: [
+  "sexplib" {= "v0.9.0"}
+  "solo5-kernel-ukvm"
+  "solo5-kernel-virtio"
+  "solo5-kernel-muen"
+]
+available:
+  os = "linux" & (arch = "x86_64" | arch = "arm64") |
+  os = "freebsd" & arch = "x86_64" |
+  os = "openbsd" & arch = "x86_64" |
+  os = "dragonfly" & arch = "x86_64"
+build: [
+  [
+    "./configure.sh"
+    "--prefix=%{prefix}%"
+    "--target=x86_64-solo5-none-static" {arch = "x86_64"}
+    "--target=aarch64-solo5-none-static" {arch = "arm64"}
+    "--ocaml-configure-option=--disable-flat-float-array"
+      {ocaml-option-no-flat-float-array:installed}
+    "--ocaml-configure-option=--enable-flambda"
+      {ocaml-option-flambda:installed}
+  ]
+  [make "-j%{jobs}%"]
+  [make "%{name}%.install"]
+]
+run-test: [make "test"]
+install: [make "install-ocaml"]
+dev-repo: "git+https://github.com/mirage/ocaml-solo5.git"
+url {
+  src:
+    "https://github.com/mirage/ocaml-solo5/archive/refs/tags/v1.3.3.tar.gz"
+  checksum: [
+    "md5=47876167068345542f49279e8fd28896"
+    "sha512=272081ec51a6ed69c08e4e8fa64fee3df53fd84c66c0c07a653891c88b342cf74553e1c95711e4fbc18922c899a3448a649f3bd9858f8d89cae834ad2b67fffb"
+  ]
+}
+x-maintenance-intent: ["(latest)"]


### PR DESCRIPTION
This pull-request concerns:
- `ocaml-solo5.1.3.3`: OCaml cross-compiler to the freestanding Solo5 backend
- `ocaml-solo5-cross-aarch64.1.3.3`: OCaml cross-compiler to the freestanding 64-bit ARM Solo5 backend



---
* Homepage: https://github.com/mirage/ocaml-solo5
* Source repo: git+https://github.com/mirage/ocaml-solo5.git
* Bug tracker: https://github.com/mirage/ocaml-solo5/issues/

---
:camel: Pull-request generated by opam-publish v3.0.0