### PR TITLE
[new release] miou (0.8.0)

### DIFF
--- a/packages/miou/miou.0.8.0/opam
+++ b/packages/miou/miou.0.8.0/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+maintainer:   "Romain Calascibetta <romain.calascibetta@gmail.com>"
+authors:      "Romain Calascibetta <romain.calascibetta@gmail.com>"
+homepage:     "https://github.com/robur-coop/miou"
+bug-reports:  "https://github.com/robur-coop/miou/issues"
+dev-repo:     "git+https://github.com/robur-coop/miou.git"
+doc:          "https://docs.osau.re/local/miou/"
+license:      "MIT"
+synopsis:     "Composable concurrency primitives for OCaml"
+
+build: [ "dune" "build" "-p" name "-j" jobs ]
+run-test: [ "dune" "runtest" "-p" name "-j" jobs ]
+
+depends: [
+  "ocaml"             {>= "5.1.0"}
+  "dune"              {>= "3.13.0"}
+  "dune-configurator"
+  "dscheck"           {with-test & >= "0.4.0"}
+  "digestif"          {with-test}
+  "happy-eyeballs"    {with-test & >= "0.6.0"}
+  "dns-client"        {with-test}
+  "hxd"               {with-test}
+  "mirage-crypto-rng" {with-test}
+  "ipaddr"            {with-test}
+  "logs"              {with-test & >= "0.7.0"}
+  "dns"               {with-test}
+  "dns-client"        {with-test}
+  "mtime"             {with-test & >= "2.0.0"}
+  "ocamlformat"       {with-dev-setup & = "0.27.0"}
+]
+x-maintenance-intent: [ "(latest)" ]
+url {
+  src:
+    "https://github.com/robur-coop/miou/releases/download/v0.8.0/miou-0.8.0.tbz"
+  checksum: [
+    "sha256=8cc05f77a23680a52a3008d461afed3b210c29c6cccdacd113232c41bab789fa"
+    "sha512=61bc945b1c8c15e65b927cae6837d18988d296f5797012acae5d245cc86be41c6fc3cf88ebe82670181acaaa1ed3f3b0648af63f8c768952bf4d834e5fa92bc2"
+  ]
+}
+x-commit-hash: "3569499f30a0fe565a149f7b97bc4a2676c0c505"


### PR DESCRIPTION
Composable concurrency primitives for OCaml

- Project page: <a href="https://github.com/robur-coop/miou">https://github.com/robur-coop/miou</a>
- Documentation: <a href="https://docs.osau.re/local/miou/">https://docs.osau.re/local/miou/</a>

##### CHANGES:

- Be able to run the `dune-configurator` on the host side (@samoht, robur-coop/miou#117)
- Add `Miou_unix.{recvfrom,sendto}` (@dinosaure, asked by @pukkamustard, robur-coop/miou#118)
- Fix `Miou_unix.connect` when it raises an error (@dinosaure, robur-coop/miou#119)
- Add `Miou_trace.Clean` to signal when Miou really clean children (@dinosaure, robur-coop/miou#121)
- Fix the behavior of our `dom0` and let it to enter into the sleep mode (bug spotted by @voodoos, fixed by @dinosaure, robur-coop/miou#120)