### PR TITLE
Package opam-grep.0.4.1

### DIFF
--- a/packages/opam-grep/opam-grep.0.4.1/opam
+++ b/packages/opam-grep/opam-grep.0.4.1/opam
@@ -1,0 +1,28 @@
+opam-version: "2.0"
+synopsis:
+  "An opam plugin that greps anything in the sources of every opam packages"
+maintainer: "Kate <kit-ty-kate@exn.st>"
+authors: "Kate <kit-ty-kate@exn.st>"
+license: "MIT"
+homepage: "https://github.com/kit-ty-kate/opam-grep"
+bug-reports: "https://github.com/kit-ty-kate/opam-grep/issues"
+depends: [
+  "ocaml" {>= "4.08"}
+  "dune" {>= "2.0"}
+  "progress" {>= "0.2.1"}
+  "cmdliner" {>= "1.1.0"}
+  "fpath" {>= "0.7.3"}
+  "bos" {>= "0.2.0"}
+]
+available: os != "win32"
+flags: plugin
+build: ["dune" "build" "-p" name "-j" jobs]
+dev-repo: "git+https://github.com/kit-ty-kate/opam-grep.git"
+url {
+  src:
+    "https://github.com/kit-ty-kate/opam-grep/releases/download/v0.4.1/opam-grep-0.4.1.tar.gz"
+  checksum: [
+    "md5=8b75e9c3a496e03d749cc967cae74f68"
+    "sha512=c2b16db4b0f07f6b8f03d1c8014605614c56c8dfb13c037f837f83e7ee0c97153342ee641a84fdebfc31926a9bedc6337aa357d5ce3ad2f0ba63bc5ac4127a2d"
+  ]
+}


### PR DESCRIPTION
### `opam-grep.0.4.1`
An opam plugin that greps anything in the sources of every opam packages



---
* Homepage: https://github.com/kit-ty-kate/opam-grep
* Source repo: git+https://github.com/kit-ty-kate/opam-grep.git
* Bug tracker: https://github.com/kit-ty-kate/opam-grep/issues

---
:camel: Pull-request generated by opam-publish v3.0.0