### PR TITLE
Package opam-publish.3.0.1

### DIFF
--- a/packages/opam-publish/opam-publish.3.0.1/opam
+++ b/packages/opam-publish/opam-publish.3.0.1/opam
@@ -1,0 +1,42 @@
+opam-version: "2.0"
+synopsis: "A tool to ease contributions to opam repositories"
+description: """\
+opam-publish automates publishing packages to package repositories: it checks that the
+opam file is complete using `opam lint`, verifies and adds the archive URL and its
+checksum and files a GitHub pull request for merging it."""
+maintainer: "Kate <kit-ty-kate@exn.st>"
+authors: [
+  "Louis Gesbert <louis.gesbert@ocamlpro.com>"
+  "David Sheets <sheets@alum.mit.edu>"
+  "Jeremie Dimino <jdimino@janestreet.com>"
+  "Raja Boujbel <raja.boujbel@ocamlpro.com>"
+  "Kate <kit-ty-kate@exn.st>"
+]
+license: "LGPL-2.1-only WITH OCaml-LGPL-linking-exception"
+homepage: "https://github.com/ocaml/opam-publish"
+bug-reports: "https://github.com/ocaml/opam-publish/issues"
+depends: [
+  "cmdliner" {>= "2.0.0"}
+  "dune" {>= "1.0"}
+  "lwt" {>= "3.0.0"}
+  "tls-lwt" {>= "0.16.0"}
+  "ocaml" {>= "4.11.0"}
+  "opam-core" {>= "2.2.0"}
+  "opam-format" {>= "2.2.0"}
+  "opam-state" {>= "2.2.0"}
+  "github" {>= "4.3.2"}
+  "cohttp" {>= "0.99"}
+  "cohttp-lwt-unix" {>= "0.99"}
+]
+flags: plugin
+build: ["dune" "build" "-p" name "-j" jobs]
+dev-repo: "git+https://github.com/ocaml/opam-publish.git"
+url {
+  src:
+    "https://github.com/ocaml/opam-publish/releases/download/3.0.1/opam-publish-3.0.1.tar.gz"
+  checksum: [
+    "md5=c819887d6f92fe77edfd6bcd62e2ae39"
+    "sha512=b32fa7798f610be4e1cbad260280fada81566aaf6bddefa5fa2e41bf577c7f1afba029c9358645e00249132392d8a9e9bce05b466622aa20f1e637ddb15bc408"
+  ]
+}
+x-maintenance-intent: ["(latest)"]


### PR DESCRIPTION
### `opam-publish.3.0.1`
A tool to ease contributions to opam repositories
opam-publish automates publishing packages to package repositories: it checks that the
opam file is complete using `opam lint`, verifies and adds the archive URL and its
checksum and files a GitHub pull request for merging it.



---
* Homepage: https://github.com/ocaml/opam-publish
* Source repo: git+https://github.com/ocaml/opam-publish.git
* Bug tracker: https://github.com/ocaml/opam-publish/issues

---
:camel: Pull-request generated by opam-publish v3.0.0