### PR TITLE
more flexible libcurl depext on debian/ubuntu

### DIFF
--- a/packages/conf-libcurl-gnutls/conf-libcurl-gnutls.1/opam
+++ b/packages/conf-libcurl-gnutls/conf-libcurl-gnutls.1/opam
@@ -1,0 +1,13 @@
+opam-version: "2.0"
+maintainer: ["Christopher Zimmermann <christopher@gmerlin.de>"]
+authors: ["Christopher Zimmermann <christopher@gmerlin.de>"]
+homepage: "http://curl.haxx.se/"
+license: "curl"
+available: os-family = "debian" | os-family = "ubuntu"
+depexts: "libcurl4-gnutls-dev"
+synopsis: "Virtual package relying on a libcurl system installation with GnuTLS backend"
+description:
+  "This package can only install if libcurl with GnuTLS is installed on the system."
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
+flags: conf
+conflict-class: [ "conf-libcurl" ]

--- a/packages/conf-libcurl-gnutls/conf-libcurl-gnutls.1/opam
+++ b/packages/conf-libcurl-gnutls/conf-libcurl-gnutls.1/opam
@@ -1,0 +1,12 @@
+opam-version: "2.0"
+maintainer: ["Christopher Zimmermann <christopher@gmerlin.de>"]
+authors: ["Christopher Zimmermann <christopher@gmerlin.de>"]
+homepage: "http://curl.haxx.se/"
+license: "curl"
+available: os-family = "debian" | os-family = "ubuntu"
+depexts: "libcurl4-gnutls-dev"
+synopsis: "Virtual package relying on a libcurl system installation with GnuTLS backend"
+description:
+  "This package can only install if libcurl with GnuTLS is installed on the system."
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
+flags: conf

--- a/packages/conf-libcurl-openssl/conf-libcurl-openssl.1/opam
+++ b/packages/conf-libcurl-openssl/conf-libcurl-openssl.1/opam
@@ -1,0 +1,12 @@
+opam-version: "2.0"
+maintainer: ["Christopher Zimmermann <christopher@gmerlin.de>"]
+authors: ["Christopher Zimmermann <christopher@gmerlin.de>"]
+homepage: "http://curl.haxx.se/"
+license: "curl"
+available: os-family = "debian" | os-family = "ubuntu"
+depexts: "libcurl4-openssl-dev"
+synopsis: "Virtual package relying on a libcurl system installation with OpenSSL backend"
+description:
+  "This package can only install if libcurl with OpenSSL is installed on the system."
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
+flags: conf

--- a/packages/conf-libcurl-openssl/conf-libcurl-openssl.1/opam
+++ b/packages/conf-libcurl-openssl/conf-libcurl-openssl.1/opam
@@ -1,0 +1,13 @@
+opam-version: "2.0"
+maintainer: ["Christopher Zimmermann <christopher@gmerlin.de>"]
+authors: ["Christopher Zimmermann <christopher@gmerlin.de>"]
+homepage: "http://curl.haxx.se/"
+license: "curl"
+available: os-family = "debian" | os-family = "ubuntu"
+depexts: "libcurl4-openssl-dev"
+synopsis: "Virtual package relying on a libcurl system installation with OpenSSL backend"
+description:
+  "This package can only install if libcurl with OpenSSL is installed on the system."
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
+flags: conf
+conflict-class: [ "conf-libcurl" ]

--- a/packages/conf-libcurl/conf-libcurl.3/opam
+++ b/packages/conf-libcurl/conf-libcurl.3/opam
@@ -2,13 +2,11 @@ opam-version: "2.0"
 maintainer: "blue-prawn"
 authors: ["Daniel Stenberg"]
 homepage: "http://curl.haxx.se/"
-license: "BSD-like"
+license: "curl"
 build: [
   ["sh" {os = "win32" & os-distribution != "cygwinports"} "curl-config" "--libs"]
 ]
 depexts: [
-  ["libcurl4-gnutls-dev"] {os-family = "debian"}
-  ["libcurl4-gnutls-dev"] {os-family = "ubuntu"}
   ["libcurl-devel"] {os-distribution = "mageia"}
   ["libcurl-devel" "openssl-devel"] {os-distribution = "centos"}
   ["curl"] {os-distribution = "nixos"}
@@ -23,6 +21,7 @@ depexts: [
   ["curl"] {os = "freebsd"}
 ]
 depends: [
+  "conf-libcurl-openssl" | "conf-libcurl-gnutls" {os-family = "debian" | os-family = "ubuntu"}
   # curl-config is in the sys-root bin directory, which needs to be in PATH for
   # the build command above to work; this package therefore depends on the C
   # compiler as well.

--- a/packages/conf-libcurl/conf-libcurl.3/opam
+++ b/packages/conf-libcurl/conf-libcurl.3/opam
@@ -1,0 +1,36 @@
+opam-version: "2.0"
+maintainer: "blue-prawn"
+authors: ["Daniel Stenberg"]
+homepage: "http://curl.haxx.se/"
+license: "curl"
+build: [
+  ["sh" {os = "win32" & os-distribution != "cygwinports"} "curl-config" "--libs"]
+]
+depexts: [
+  ["libcurl-devel"] {os-distribution = "mageia"}
+  ["libcurl-devel" "openssl-devel"] {os-distribution = "centos"}
+  ["curl"] {os-distribution = "nixos"}
+  ["curl"] {os-distribution = "arch"}
+  ["curl"] {os = "win32" & os-distribution = "cygwinports"}
+  ["curl-dev"] {os-distribution = "alpine"}
+  ["libcurl-devel"] {os-family = "suse" | os-family = "opensuse"}
+  ["libcurl-devel"] {os-family = "fedora"}
+  ["libcurl-devel"] {os-distribution = "ol"}
+  ["curl"] {os-distribution = "homebrew" & os = "macos"}
+  ["curl"] {os-distribution = "macports" & os = "macos"}
+  ["curl"] {os = "freebsd"}
+]
+depends: [
+  "conf-libcurl-openssl" | "conf-libcurl-gnutls" {os-family = "debian" | os-family = "ubuntu"}
+  # curl-config is in the sys-root bin directory, which needs to be in PATH for
+  # the build command above to work; this package therefore depends on the C
+  # compiler as well.
+  ("host-arch-x86_64" {os = "win32" & os-distribution != "cygwinports"} & "conf-mingw-w64-gcc-x86_64" {os = "win32" & os-distribution != "cygwinports"} & "conf-mingw-w64-curl-x86_64" {os = "win32" & os-distribution != "cygwinports"} |
+   "host-arch-x86_32" {os = "win32" & os-distribution != "cygwinports"} & "conf-mingw-w64-gcc-i686" {os = "win32" & os-distribution != "cygwinports"} & "conf-mingw-w64-curl-i686" {os = "win32" & os-distribution != "cygwinports"})
+]
+depopts: "mingw-w64-shims" {< "1.0.0"}
+synopsis: "Virtual package relying on a libcurl system installation"
+description:
+  "This package can only install if the libcurl is installed on the system."
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
+flags: conf

--- a/packages/conf-libcurl/conf-libcurl.3/opam
+++ b/packages/conf-libcurl/conf-libcurl.3/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+maintainer: "blue-prawn"
+authors: ["Daniel Stenberg"]
+homepage: "http://curl.haxx.se/"
+license: "BSD-like"
+build: [
+  ["sh" {os = "win32" & os-distribution != "cygwinports"} "curl-config" "--libs"]
+]
+depexts: [
+  ["libcurl4-gnutls-dev"] {os-family = "debian"}
+  ["libcurl4-gnutls-dev"] {os-family = "ubuntu"}
+  ["libcurl-devel"] {os-distribution = "mageia"}
+  ["libcurl-devel" "openssl-devel"] {os-distribution = "centos"}
+  ["curl"] {os-distribution = "nixos"}
+  ["curl"] {os-distribution = "arch"}
+  ["curl"] {os = "win32" & os-distribution = "cygwinports"}
+  ["curl-dev"] {os-distribution = "alpine"}
+  ["libcurl-devel"] {os-family = "suse" | os-family = "opensuse"}
+  ["libcurl-devel"] {os-family = "fedora"}
+  ["libcurl-devel"] {os-distribution = "ol"}
+  ["curl"] {os-distribution = "homebrew" & os = "macos"}
+  ["curl"] {os-distribution = "macports" & os = "macos"}
+  ["curl"] {os = "freebsd"}
+]
+depends: [
+  # curl-config is in the sys-root bin directory, which needs to be in PATH for
+  # the build command above to work; this package therefore depends on the C
+  # compiler as well.
+  ("host-arch-x86_64" {os = "win32" & os-distribution != "cygwinports"} & "conf-mingw-w64-gcc-x86_64" {os = "win32" & os-distribution != "cygwinports"} & "conf-mingw-w64-curl-x86_64" {os = "win32" & os-distribution != "cygwinports"} |
+   "host-arch-x86_32" {os = "win32" & os-distribution != "cygwinports"} & "conf-mingw-w64-gcc-i686" {os = "win32" & os-distribution != "cygwinports"} & "conf-mingw-w64-curl-i686" {os = "win32" & os-distribution != "cygwinports"})
+]
+depopts: "mingw-w64-shims" {< "1.0.0"}
+synopsis: "Virtual package relying on a libcurl system installation"
+description:
+  "This package can only install if the libcurl is installed on the system."
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
+flags: conf


### PR DESCRIPTION
libcurl4-openssl-dev works as well as the gnutls variant. Therefore depend only on the libcurl-dev virtual package, which makes sure that any variant of libcurl4-*-dev is installed.