### PR TITLE
Package spdx_licenses.1.5.0

### DIFF
--- a/packages/spdx_licenses/spdx_licenses.1.5.0/opam
+++ b/packages/spdx_licenses/spdx_licenses.1.5.0/opam
@@ -1,0 +1,27 @@
+opam-version: "2.0"
+synopsis: "A library providing a strict SPDX License Expression parser"
+description: """\
+An OCaml library aiming to provide an up-to-date and strict SPDX License Expression parser.
+It implements the format described in: https://spdx.github.io/spdx-spec/v3.0.1/annexes/spdx-license-expressions/
+See https://spdx.org/licenses/ for more details."""
+maintainer: "Kate <kit-ty-kate@exn.st>"
+authors: "Kate <kit-ty-kate@exn.st>"
+license: "MIT"
+homepage: "https://github.com/kit-ty-kate/spdx_licenses"
+bug-reports: "https://github.com/kit-ty-kate/spdx_licenses/issues"
+depends: [
+  "ocaml" {>= "4.08"}
+  "dune" {>= "2.3"}
+  "alcotest" {with-test & >= "1.4.0"}
+]
+build: ["dune" "build" "-p" name "-j" jobs]
+run-test: ["dune" "runtest" "-p" name "-j" jobs]
+dev-repo: "git+https://github.com/kit-ty-kate/spdx_licenses.git"
+url {
+  src:
+    "https://github.com/kit-ty-kate/spdx_licenses/releases/download/v1.5.0/spdx_licenses-1.5.0.tar.gz"
+  checksum: [
+    "md5=1071f6377ebc872404e3ee0d03838299"
+    "sha512=6d86133c2d668521b8f2ed2984dd2574e00cfe91bff63628dfad3ffacc47c7000a9e7a63d5e250be30568ff75680215ff37fca61b6dbd3890fa382a72615482c"
+  ]
+}


### PR DESCRIPTION
### `spdx_licenses.1.5.0`
A library providing a strict SPDX License Expression parser
An OCaml library aiming to provide an up-to-date and strict SPDX License Expression parser.
It implements the format described in: https://spdx.github.io/spdx-spec/v3.0.1/annexes/spdx-license-expressions/
See https://spdx.org/licenses/ for more details.



---
* Homepage: https://github.com/kit-ty-kate/spdx_licenses
* Source repo: git+https://github.com/kit-ty-kate/spdx_licenses.git
* Bug tracker: https://github.com/kit-ty-kate/spdx_licenses/issues

---
:camel: Pull-request generated by opam-publish v3.0.0