### PR TITLE
[new release] quickjs (0.6.0)

### DIFF
--- a/packages/quickjs/quickjs.0.6.0/opam
+++ b/packages/quickjs/quickjs.0.6.0/opam
@@ -1,0 +1,44 @@
+opam-version: "2.0"
+synopsis:
+  "Bindings for QuickJS (a Javascript Engine to be embedded https://bellard.org/quickjs)"
+maintainer: ["David Sancho <dsnxmoreno@gmail.com>"]
+authors: ["David Sancho <dsnxmoreno@gmail.com>"]
+license: "MIT"
+homepage: "https://github.com/ml-in-barcelona/quickjs.ml"
+bug-reports: "https://github.com/ml-in-barcelona/quickjs.ml/issues"
+depends: [
+  "dune" {>= "3.8"}
+  "ocaml" {>= "4.14.0"}
+  "integers" {>= "0.7.0"}
+  "ctypes" {>= "0.24.0"}
+  "alcotest" {with-test}
+  "odoc" {with-doc}
+  "ocaml-lsp-server" {with-dev-setup}
+  "ocamlformat" {= "0.28.1" & with-dev-setup}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/ml-in-barcelona/quickjs.ml.git"
+conflicts: [ "ocaml-option-bytecode-only" ]
+x-maintenance-intent: ["(latest)"]
+url {
+  src:
+    "https://github.com/ml-in-barcelona/quickjs.ml/releases/download/0.6.0/quickjs-0.6.0.tbz"
+  checksum: [
+    "sha256=24e60ef65737c2b8e762b98fbdbc836380425c35c5b3ffae657a14671e51d959"
+    "sha512=3868ca89255ebc03ea8a9ba6fe1604c8c5aad5060274d518be99a3300883ebeae864b8b68bf3782875c527a41828f40b3cb75d50179d6802ec0eafd59591af4f"
+  ]
+}
+x-commit-hash: "08c6f5056d80e0864d2b1fcd7008e2bd173d6d0f"


### PR DESCRIPTION
Bindings for QuickJS (a Javascript Engine to be embedded https://bellard.org/quickjs)

- Project page: <a href="https://github.com/ml-in-barcelona/quickjs.ml">https://github.com/ml-in-barcelona/quickjs.ml</a>

##### CHANGES:

- Update QuickJS-NG to `c2f37ec`, adopting its register-based regexp engine and latest memory-safety fixes
- Add regexp modifiers, duplicate named capture groups, full Unicode sets, and Unicode properties of strings
