### PR TITLE
[new release] mnet (7 packages) (0.0.4)

### DIFF
--- a/packages/mnet-cli/mnet-cli.0.0.4/opam
+++ b/packages/mnet-cli/mnet-cli.0.0.4/opam
@@ -1,0 +1,38 @@
+opam-version: "2.0"
+maintainer: "Robur <team@robur.coop>"
+authors: ["Robur <team@robur.coop>"]
+homepage: "https://github.com/robur-coop/mnet"
+dev-repo: "git+https://github.com/robur-coop/mnet.git"
+bug-reports: "https://github.com/robur-coop/mnet/issues"
+license: "MIT"
+
+depends: [
+  "ocaml" {>= "5.0.0"}
+  "utcp"
+  "dune" {>= "2.7.0"}
+  "mnet" {= version}
+  "mirage-ptime"
+  "re"
+  "duration"
+  "dns"
+  "tls"
+  "cmdliner" {>= "2.0.0"}
+  "ca-certs-nss" {>= "3.118"}
+  "mirage-ptime" {>= "5.2.0"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+synopsis: "A library for defining the options required by a unikernel to configure its TCP/IP stack"
+url {
+  src:
+    "https://github.com/robur-coop/mnet/releases/download/v0.0.4/mnet-0.0.4.tbz"
+  checksum: [
+    "sha256=154c3b18bbb019535a4f37d1fefa3c6131b636e53316a63b395d030b186f2a59"
+    "sha512=894d12ff3140b294de1129f76893b295e73093101edec137ba2b2106059081f94385e3e3420c48cde14df6aefbef333bec12f5772c1b85c7ecc73dcde9e5bb8c"
+  ]
+}
+x-commit-hash: "d707bf63767d17279ebaa6698a8527be2455cf6f"

--- a/packages/mnet-dhcp/mnet-dhcp.0.0.4/opam
+++ b/packages/mnet-dhcp/mnet-dhcp.0.0.4/opam
@@ -1,0 +1,48 @@
+opam-version: "2.0"
+maintainer: "Robur <team@robur.coop>"
+authors: ["Robur <team@robur.coop>"]
+homepage: "https://github.com/robur-coop/mnet"
+dev-repo: "git+https://github.com/robur-coop/mnet.git"
+bug-reports: "https://github.com/robur-coop/mnet/issues"
+license: "MIT"
+
+depends: [
+  "ocaml" {>= "5.0.0"}
+  "dune" {>= "2.7.0"}
+  "mnet" {= version}
+  "mkernel"
+  "miou"
+  "utcp"
+  "charrua" {>= "3.2.0"}
+  "charrua-client" {>= "3.2.0"}
+  "cstruct" {>= "6.0.0"}
+  "mirage-crypto-rng"
+  "slice"
+  "bstr" {>= "0.0.4"}
+  "ipaddr"
+  "macaddr"
+  "fmt"
+  "logs"
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+synopsis: "A DHCP client integration for the mnet TCP/IP stack"
+description: """
+mnet-dhcp provides a DHCP-enabled TCP/IP stack on top of mnet, using the charrua
+DHCP implementation. The core mnet library stays free of any DHCP dependency:
+the stack can be configured (and reconfigured) at runtime from DHCP leases, and
+the user is notified of and may confirm or reject configuration changes.
+"""
+url {
+  src:
+    "https://github.com/robur-coop/mnet/releases/download/v0.0.4/mnet-0.0.4.tbz"
+  checksum: [
+    "sha256=154c3b18bbb019535a4f37d1fefa3c6131b636e53316a63b395d030b186f2a59"
+    "sha512=894d12ff3140b294de1129f76893b295e73093101edec137ba2b2106059081f94385e3e3420c48cde14df6aefbef333bec12f5772c1b85c7ecc73dcde9e5bb8c"
+  ]
+}
+x-commit-hash: "d707bf63767d17279ebaa6698a8527be2455cf6f"

--- a/packages/mnet-dns/mnet-dns.0.0.4/opam
+++ b/packages/mnet-dns/mnet-dns.0.0.4/opam
@@ -1,0 +1,34 @@
+opam-version: "2.0"
+maintainer: "Robur <team@robur.coop>"
+authors: ["Robur <team@robur.coop>"]
+homepage: "https://github.com/robur-coop/mnet"
+dev-repo: "git+https://github.com/robur-coop/mnet.git"
+bug-reports: "https://github.com/robur-coop/mnet/issues"
+license: "MIT"
+
+depends: [
+  "ocaml" {>= "5.0.0"}
+  "utcp"
+  "dune" {>= "2.7.0"}
+  "mnet" {= version}
+  "mnet-tls" {= version}
+  "mnet-happy-eyeballs" {= version}
+  "dns"
+  "dns-client"
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+synopsis: "An implementation of DNS in OCaml for Miou & Solo5"
+url {
+  src:
+    "https://github.com/robur-coop/mnet/releases/download/v0.0.4/mnet-0.0.4.tbz"
+  checksum: [
+    "sha256=154c3b18bbb019535a4f37d1fefa3c6131b636e53316a63b395d030b186f2a59"
+    "sha512=894d12ff3140b294de1129f76893b295e73093101edec137ba2b2106059081f94385e3e3420c48cde14df6aefbef333bec12f5772c1b85c7ecc73dcde9e5bb8c"
+  ]
+}
+x-commit-hash: "d707bf63767d17279ebaa6698a8527be2455cf6f"

--- a/packages/mnet-happy-eyeballs/mnet-happy-eyeballs.0.0.4/opam
+++ b/packages/mnet-happy-eyeballs/mnet-happy-eyeballs.0.0.4/opam
@@ -1,0 +1,31 @@
+opam-version: "2.0"
+maintainer: "Robur <team@robur.coop>"
+authors: ["Robur <team@robur.coop>"]
+homepage: "https://github.com/robur-coop/mnet"
+dev-repo: "git+https://github.com/robur-coop/mnet.git"
+bug-reports: "https://github.com/robur-coop/mnet/issues"
+license: "MIT"
+
+depends: [
+  "ocaml" {>= "5.0.0"}
+  "utcp"
+  "dune" {>= "2.7.0"}
+  "mnet" {= version}
+  "happy-eyeballs" {>= "2.0.0"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+synopsis: "Connecting to a remote host via IP version 4 or 6 using mnet"
+url {
+  src:
+    "https://github.com/robur-coop/mnet/releases/download/v0.0.4/mnet-0.0.4.tbz"
+  checksum: [
+    "sha256=154c3b18bbb019535a4f37d1fefa3c6131b636e53316a63b395d030b186f2a59"
+    "sha512=894d12ff3140b294de1129f76893b295e73093101edec137ba2b2106059081f94385e3e3420c48cde14df6aefbef333bec12f5772c1b85c7ecc73dcde9e5bb8c"
+  ]
+}
+x-commit-hash: "d707bf63767d17279ebaa6698a8527be2455cf6f"

--- a/packages/mnet-ssh/mnet-ssh.0.0.4/opam
+++ b/packages/mnet-ssh/mnet-ssh.0.0.4/opam
@@ -1,0 +1,33 @@
+opam-version: "2.0"
+maintainer: "Robur <team@robur.coop>"
+authors: ["Robur <team@robur.coop>"]
+homepage: "https://github.com/robur-coop/mnet"
+dev-repo: "git+https://github.com/robur-coop/mnet.git"
+bug-reports: "https://github.com/robur-coop/mnet/issues"
+license: "MIT"
+
+depends: [
+  "ocaml" {>= "5.0.0"}
+  "utcp"
+  "miou" {>= "0.7.0"}
+  "dune" {>= "2.7.0"}
+  "mnet" {= version}
+  "awa" {>= "0.6.1"}
+  "flux"
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+synopsis: "An implementation of SSH in OCaml for Miou & Solo5"
+url {
+  src:
+    "https://github.com/robur-coop/mnet/releases/download/v0.0.4/mnet-0.0.4.tbz"
+  checksum: [
+    "sha256=154c3b18bbb019535a4f37d1fefa3c6131b636e53316a63b395d030b186f2a59"
+    "sha512=894d12ff3140b294de1129f76893b295e73093101edec137ba2b2106059081f94385e3e3420c48cde14df6aefbef333bec12f5772c1b85c7ecc73dcde9e5bb8c"
+  ]
+}
+x-commit-hash: "d707bf63767d17279ebaa6698a8527be2455cf6f"

--- a/packages/mnet-tls/mnet-tls.0.0.4/opam
+++ b/packages/mnet-tls/mnet-tls.0.0.4/opam
@@ -11,7 +11,7 @@ depends: [
   "utcp"
   "dune" {>= "2.7.0"}
   "mnet" {= version}
-  "tls" {>= "2.1.0"}
+  "tls" {>= "2.1.1"}
 ]
 build: [
   ["dune" "subst"] {dev}

--- a/packages/mnet-tls/mnet-tls.0.0.4/opam
+++ b/packages/mnet-tls/mnet-tls.0.0.4/opam
@@ -1,0 +1,31 @@
+opam-version: "2.0"
+maintainer: "Robur <team@robur.coop>"
+authors: ["Robur <team@robur.coop>"]
+homepage: "https://github.com/robur-coop/mnet"
+dev-repo: "git+https://github.com/robur-coop/mnet.git"
+bug-reports: "https://github.com/robur-coop/mnet/issues"
+license: "MIT"
+
+depends: [
+  "ocaml" {>= "5.0.0"}
+  "utcp"
+  "dune" {>= "2.7.0"}
+  "mnet" {= version}
+  "tls" {>= "2.1.0"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+synopsis: "An implementation of TLS in OCaml for Miou & Solo5"
+url {
+  src:
+    "https://github.com/robur-coop/mnet/releases/download/v0.0.4/mnet-0.0.4.tbz"
+  checksum: [
+    "sha256=154c3b18bbb019535a4f37d1fefa3c6131b636e53316a63b395d030b186f2a59"
+    "sha512=894d12ff3140b294de1129f76893b295e73093101edec137ba2b2106059081f94385e3e3420c48cde14df6aefbef333bec12f5772c1b85c7ecc73dcde9e5bb8c"
+  ]
+}
+x-commit-hash: "d707bf63767d17279ebaa6698a8527be2455cf6f"

--- a/packages/mnet/mnet.0.0.4/opam
+++ b/packages/mnet/mnet.0.0.4/opam
@@ -13,7 +13,7 @@ depends: [
   "bstr" {>= "0.0.4"}
   "bin"
   "slice"
-  "mkernel"
+  "mkernel" {>= "0.0.3"}
   "mirage-crypto-rng"
   "duration"
   "fmt"

--- a/packages/mnet/mnet.0.0.4/opam
+++ b/packages/mnet/mnet.0.0.4/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+maintainer: "Robur <team@robur.coop>"
+authors: ["Robur <team@robur.coop>"]
+homepage: "https://github.com/robur-coop/mnet"
+dev-repo: "git+https://github.com/robur-coop/mnet.git"
+bug-reports: "https://github.com/robur-coop/mnet/issues"
+license: "MIT"
+
+depends: [
+  "ocaml" {>= "5.0.0"}
+  "utcp" {>= "0.0.7"}
+  "dune" {>= "2.7.0"}
+  "bstr" {>= "0.0.4"}
+  "bin"
+  "slice"
+  "mkernel"
+  "mirage-crypto-rng"
+  "duration"
+  "fmt"
+  "ipaddr"
+  "macaddr"
+  "hxd"
+  "tls"
+  "happy-eyeballs"
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+synopsis: "An implementation of TCP (Transmission Control Protocol) in OCaml for Miou & Solo5"
+url {
+  src:
+    "https://github.com/robur-coop/mnet/releases/download/v0.0.4/mnet-0.0.4.tbz"
+  checksum: [
+    "sha256=154c3b18bbb019535a4f37d1fefa3c6131b636e53316a63b395d030b186f2a59"
+    "sha512=894d12ff3140b294de1129f76893b295e73093101edec137ba2b2106059081f94385e3e3420c48cde14df6aefbef333bec12f5772c1b85c7ecc73dcde9e5bb8c"
+  ]
+}
+x-commit-hash: "d707bf63767d17279ebaa6698a8527be2455cf6f"


### PR DESCRIPTION
An implementation of TCP (Transmission Control Protocol) in OCaml for Miou & Solo5

- Project page: <a href="https://github.com/robur-coop/mnet">https://github.com/robur-coop/mnet</a>

##### CHANGES:

- Add the support of DHCP and the new package `mnet-dhcp` (@dinosaure, @reynir,
  [!34][34])
- Add a basic implementation of the SSH client (@dinosaure, [!33][33])
- Fix the compilation for OCaml 5.5 (@dinosaure, @kit-ty-kate, [!36][36],
  [robur-coop/mnet#3][g3])
- Use `Miou.Mutex.protect` when we want to signal a `Notify.t` value
  (@dinosaure, [!35][35])
- Replace our internal `Bstr.t` by bytes when it's about buffering on the TCP
  stack (@dinosaure, [!38][38])
- Use the new interface of `utcp.0.0.6` (@dinosaure, [!38][38])
- Add `?ip` on `Mnet_tls.client_of_fd` (@hannesm, [!40][40])
- Add a hard limit for incoming passive TCP connections (@dinosaure, @hannesm,
  [!42][42])
- Improve throughput for `mnet-tls` (@dinosaure, @hannesm, [!39][39])
- Fix how we handle active connection and use `utcp.0.0.7` (@dinosaure,
  @hannesm, [!43][43])

[34]: https://git.robur.coop/robur/mnet/pulls/34
[33]: https://git.robur.coop/robur/mnet/pulls/33
[36]: https://git.robur.coop/robur/mnet/pulls/36
[g3]: https://github.com/robur-coop/mnet/issues/3
[38]: https://git.robur.coop/robur/mnet/pulls/38
[40]: https://git.robur.coop/robur/mnet/pulls/40
[42]: https://git.robur.coop/robur/mnet/pulls/42
[39]: https://git.robur.coop/robur/mnet/pulls/39
[43]: https://git.robur.coop/robur/mnet/pulls/43
