### PR TITLE
[new release] capnp-rpc (3 packages) (2.1.2)

### DIFF
--- a/packages/capnp-rpc-net/capnp-rpc-net.2.1.2/opam
+++ b/packages/capnp-rpc-net/capnp-rpc-net.2.1.2/opam
@@ -1,0 +1,47 @@
+opam-version: "2.0"
+synopsis:
+  "Cap'n Proto is a capability-based RPC system with bindings for many languages"
+description: """
+This package provides support for using Cap'n Proto services over a network,
+optionally using TLS."""
+maintainer: "Thomas Leonard <talex5@gmail.com>"
+authors: "Thomas Leonard <talex5@gmail.com>"
+license: "Apache-2.0"
+homepage: "https://github.com/mirage/capnp-rpc"
+bug-reports: "https://github.com/mirage/capnp-rpc/issues"
+doc: "https://mirage.github.io/capnp-rpc/"
+depends: [
+  "ocaml" {>= "5.2"}
+  "conf-capnproto" {build}
+  "capnp" {>= "3.6.0"}
+  "capnp-rpc" {= version}
+  "astring"
+  "fmt" {>= "0.8.7"}
+  "logs"
+  "cstruct" {>= "6.0.0"}
+  "tls-eio" {>= "1.0.2"}
+  "base64" {>= "3.0.0"}
+  "uri" {>= "1.6.0"}
+  "ptime"
+  "prometheus" {>= "0.5"}
+  "asn1-combinators" {>= "0.2.0"}
+  "x509" {>= "1.0.3"}
+  "dune" {>= "3.16"}
+  "mirage-crypto" {>= "1.2.0"}
+  "mirage-crypto-rng" {>= "1.2.0"}
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/mirage/capnp-rpc.git"
+x-maintenance-intent: ["(latest)"]
+url {
+  src:
+    "https://github.com/mirage/capnp-rpc/releases/download/v2.1.2/capnp-rpc-2.1.2.tbz"
+  checksum: [
+    "sha256=ef3f64b22d90bfe87f96e751bc61d29646c970032803c4135bec8626aecf704d"
+    "sha512=41731da19a0ec67ae8d519f70ba95bae143493df64133965e9dfd9eb7ca33c745efa6047f8784689be6230a2fefd77649b61635e9b713366e42fd8e89ee07512"
+  ]
+}
+x-commit-hash: "d9edc3b1f4e8e68e2e9c0a80555883c1390d76ee"

--- a/packages/capnp-rpc-unix/capnp-rpc-unix.2.1.2/opam
+++ b/packages/capnp-rpc-unix/capnp-rpc-unix.2.1.2/opam
@@ -1,0 +1,46 @@
+opam-version: "2.0"
+synopsis:
+  "Cap'n Proto is a capability-based RPC system with bindings for many languages"
+description:
+  "This package contains some helpers for use with traditional (non-Unikernel) operating systems."
+maintainer: "Thomas Leonard <talex5@gmail.com>"
+authors: "Thomas Leonard <talex5@gmail.com>"
+license: "Apache-2.0"
+homepage: "https://github.com/mirage/capnp-rpc"
+doc: "https://mirage.github.io/capnp-rpc/"
+bug-reports: "https://github.com/mirage/capnp-rpc/issues"
+depends: [
+  "ocaml" {>= "5.2"}
+  "capnp-rpc-net" {= version}
+  "cmdliner" {>= "1.1.0"}
+  "cstruct" {>= "6.2.0"}
+  "astring"
+  "fmt" {>= "0.8.7"}
+  "logs"
+  "base64" {>= "3.0.0"}
+  "dune" {>= "3.16"}
+  "ipaddr" {>= "5.3.0" }
+  "alcotest" {>= "1.6.0" & with-test}
+  "mirage-crypto-rng" {>= "1.2.0"}
+  "mdx" {>= "2.4.1" & with-test}
+  "eio_main" {with-test}
+  "eio" {>= "1.4"}
+]
+conflicts: [
+  "jbuilder"
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test & os != "macos"}
+]
+dev-repo: "git+https://github.com/mirage/capnp-rpc.git"
+x-maintenance-intent: ["(latest)"]
+url {
+  src:
+    "https://github.com/mirage/capnp-rpc/releases/download/v2.1.2/capnp-rpc-2.1.2.tbz"
+  checksum: [
+    "sha256=ef3f64b22d90bfe87f96e751bc61d29646c970032803c4135bec8626aecf704d"
+    "sha512=41731da19a0ec67ae8d519f70ba95bae143493df64133965e9dfd9eb7ca33c745efa6047f8784689be6230a2fefd77649b61635e9b713366e42fd8e89ee07512"
+  ]
+}
+x-commit-hash: "d9edc3b1f4e8e68e2e9c0a80555883c1390d76ee"

--- a/packages/capnp-rpc/capnp-rpc.2.1.2/opam
+++ b/packages/capnp-rpc/capnp-rpc.2.1.2/opam
@@ -1,0 +1,44 @@
+opam-version: "2.0"
+synopsis:
+  "Cap'n Proto is a capability-based RPC system with bindings for many languages"
+description: """
+This package provides a version of the Cap'n Proto RPC system using the Cap'n
+Proto serialisation format and Eio for concurrency."""
+maintainer: "Thomas Leonard <talex5@gmail.com>"
+authors: "Thomas Leonard <talex5@gmail.com>"
+license: "Apache-2.0"
+homepage: "https://github.com/mirage/capnp-rpc"
+bug-reports: "https://github.com/mirage/capnp-rpc/issues"
+doc: "https://mirage.github.io/capnp-rpc/"
+depends: [
+  "ocaml" {>= "5.2"}
+  "conf-capnproto" {build}
+  "capnp" {>= "3.6.0"}
+  "stdint" {>= "0.6.0"}
+  "eio" {>= "1.4"}
+  "astring"
+  "fmt" {>= "0.8.7"}
+  "logs"
+  "uri" {>= "1.6.0"}
+  "dune" {>= "3.16"}
+  "alcotest" {>= "1.6.0" & with-test}
+  "afl-persistent" {with-test}
+]
+conflicts: [
+  "result" {< "1.5"}
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/mirage/capnp-rpc.git"
+x-maintenance-intent: ["(latest)"]
+url {
+  src:
+    "https://github.com/mirage/capnp-rpc/releases/download/v2.1.2/capnp-rpc-2.1.2.tbz"
+  checksum: [
+    "sha256=ef3f64b22d90bfe87f96e751bc61d29646c970032803c4135bec8626aecf704d"
+    "sha512=41731da19a0ec67ae8d519f70ba95bae143493df64133965e9dfd9eb7ca33c745efa6047f8784689be6230a2fefd77649b61635e9b713366e42fd8e89ee07512"
+  ]
+}
+x-commit-hash: "d9edc3b1f4e8e68e2e9c0a80555883c1390d76ee"


### PR DESCRIPTION
Cap'n Proto is a capability-based RPC system with bindings for many languages

- Project page: <a href="https://github.com/mirage/capnp-rpc">https://github.com/mirage/capnp-rpc</a>
- Documentation: <a href="https://mirage.github.io/capnp-rpc/">https://mirage.github.io/capnp-rpc/</a>

##### CHANGES:

- Use Eio 1.4 sockopt support instead of handrolled stubs (@talex5 mirage/capnp-rpc#321 mirage/capnp-rpc#322)
- Fix build on oxcaml and remove extlib dep (@avsm mirage/capnp-rpc#318 mirage/capnp-rpc#319)
- Fix hanging tests with dune 3.20 (@talex5 mirage/capnp-rpc#320)
