### PR TITLE
Introcaml 5.5.0: alpha preview of OCaml with polymorphic printing

### DIFF
--- a/packages/ocaml-compiler/ocaml-compiler.5.5.0+introcaml/opam
+++ b/packages/ocaml-compiler/ocaml-compiler.5.5.0+introcaml/opam
@@ -1,0 +1,123 @@
+opam-version: "2.0"
+license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
+synopsis: "OCaml 5.5.0 with introspection"
+maintainer: [
+  "David Allsopp <dra27@dra27.uk>"
+  "Florian Angeletti <florian.angeletti@inria.fr>"
+]
+authors: [
+  "Xavier Leroy"
+  "Damien Doligez"
+  "Alain Frisch"
+  "Jacques Garrigue"
+  "Didier Rémy"
+  "KC Sivaramakrishnan"
+  "Jérôme Vouillon"
+]
+homepage: "https://ocaml.org"
+bug-reports: "https://github.com/let-def/ocaml/issues"
+dev-repo: "git+https://github.com/let-def/ocaml.git#introcaml-550"
+# 64-bit only
+available: [ arch = "x86_64" | arch = "ppc64" | arch = "arm64" | arch = "sparc64" ]
+depends: [
+  # This is OCaml 5.5.0
+  "ocaml" {= "5.5.0" & post}
+  "compiler-cloning" {build & (os != "macos" | = "disabled")}
+
+  # General base- packages
+  "base-unix" {post}
+  "base-bigarray" {post}
+  "base-threads" {post}
+  "base-domains" {post}
+  "base-nnp" {post}
+  "base-effects" {post}
+
+  # Port selection (Windows)
+  # amd64 mingw-w64 / MSVC
+  (("arch-x86_64" {os = "win32" & arch = "x86_64"} &
+     ("system-mingw" |
+      ("system-msvc" & "ocaml-option-no-compression" {os = "win32"}))) |
+  # i686 mingw-w64 / MSVC
+   ("arch-x86_32" {os = "win32"} & "ocaml-option-bytecode-only" {os = "win32"} &
+     ("system-mingw" |
+      ("system-msvc" & "ocaml-option-no-compression" {os = "win32"}))) |
+  # Non-Windows systems need to install something to satisfy this formula, so
+  # repeat the base-unix dependency
+   "base-unix" {os != "win32" & post})
+
+  # Support Packages
+  "flexdll" {>= "0.44" & os = "win32"}
+]
+build-env: [
+  [MSYS2_ARG_CONV_EXCL = "*"]
+  [LSAN_OPTIONS = "detect_leaks=0,exitcode=0"]
+  [ASAN_OPTIONS = "detect_leaks=0,exitcode=0"]
+
+  # Build ocaml with stdlib/stdlib.cma not boot/stdlib.cma
+  [OCAML_OVERRIDE_FLAGS = "-I ./stdlib"]
+]
+build: [
+  [
+    "sh" "tools/opam/process.sh" make "-j%{jobs}%" _:build-id _:name compiler-cloning:version
+    "--host=x86_64-pc-windows"  {system-msvc:installed & arch-x86_64:installed}
+    "--host=x86_64-w64-mingw32" {os-distribution = "cygwin" & system-mingw:installed & arch-x86_64:installed}
+    "--host=i686-pc-windows"    {system-msvc:installed & arch-x86_32:installed}
+    "--host=i686-w64-mingw32"   {os-distribution = "cygwin" & system-mingw:installed & arch-x86_32:installed}
+    "--prefix=%{prefix}%"
+    "--docdir=%{doc}%/ocaml"
+    "--with-additional-stublibsdir"
+    "--with-relative-libdir"
+    "--enable-runtime-search"
+    "--enable-runtime-search-target=fallback"
+    "--with-flexdll=%{flexdll:share}%" {os = "win32" & flexdll:installed}
+    "--with-afl" {ocaml-option-afl:installed}
+    "--disable-native-compiler" {ocaml-option-bytecode-only:installed}
+    "--disable-flat-float-array" {ocaml-option-no-flat-float-array:installed}
+    "--enable-flambda" {ocaml-option-flambda:installed}
+    "--enable-frame-pointers" {ocaml-option-fp:installed}
+    "--without-zstd" {ocaml-option-no-compression:installed}
+    "--enable-tsan" {ocaml-option-tsan:installed}
+    "CC=cc" {!ocaml-option-32bit:installed & !ocaml-option-musl:installed & (os = "openbsd" | os = "macos")}
+    "CC=clang" {ocaml-option-tsan:installed & (os="macos")}
+    "CC=musl-gcc" {ocaml-option-musl:installed & os-distribution!="alpine"}
+    "CFLAGS=-Os" {ocaml-option-musl:installed & arch != "arm64"}
+    "CFLAGS=-Os -mno-outline-atomics" {ocaml-option-musl:installed & arch = "arm64"}
+    "LDFLAGS=-Wl,--no-as-needed,-ldl" {ocaml-option-leak-sanitizer:installed | (ocaml-option-address-sanitizer:installed & os!="macos")}
+    "CC=gcc -ldl -fsanitize=leak -fno-omit-frame-pointer -O1 -g" {ocaml-option-leak-sanitizer:installed}
+    "CC=gcc -ldl -fsanitize=address -fno-omit-frame-pointer -O1 -g" {ocaml-option-address-sanitizer:installed & os!="macos"}
+    "CC=clang -fsanitize=address -fno-omit-frame-pointer -O1 -g" {ocaml-option-address-sanitizer:installed & os="macos"}
+    "CC=gcc -m32" {ocaml-option-32bit:installed & os="linux"}
+    "CC=gcc -Wl,-read_only_relocs,suppress -arch i386 -m32" {ocaml-option-32bit:installed & os="macos"}
+    "ASPP=musl-gcc -c" {ocaml-option-musl:installed & os-distribution!="alpine"}
+    "--host=i386-linux" {ocaml-option-32bit:installed & os="linux"}
+    "--host=i386-apple-darwin13.2.0" {ocaml-option-32bit:installed & os="macos"}
+    "LIBS=-static" {ocaml-option-static:installed}
+    "--disable-warn-error"
+    "--enable-reserved-header-bits=22"
+    "--enable-introspect"
+  ]
+]
+install: ["sh" "tools/opam/process.sh" make "install" _:build-id _:name prefix]
+url {
+  src: "https://github.com/let-def/ocaml/archive/refs/tags/introcaml0.tar.gz"
+  checksum: "sha256=9476b33dfc13f12668c10ddf6350e4dc218b9374fd3db735e2836cbc280c011d"
+}
+depopts: [
+  "ocaml-option-afl"
+  "ocaml-option-bytecode-only"
+  "ocaml-option-no-flat-float-array"
+  "ocaml-option-flambda"
+  "ocaml-option-fp"
+  "ocaml-option-no-compression"
+  "ocaml-option-musl"
+  "ocaml-option-leak-sanitizer"
+  "ocaml-option-address-sanitizer"
+  "ocaml-option-static"
+  "ocaml-option-tsan"
+]
+post-messages: [
+"This switch had to be compiled from sources, but future switches with the 🐌
+same compiler version and configuration should assemble instantly." {!failure & !_:cloned & compiler-cloning:version != "disabled"}
+"As requested, this switch was compiled from sources 😴" {!failure & compiler-cloning:version = "disabled"}
+"Switch cloned by %{_:clone-mechanism}% from %{_:clone-source}% 💨" {!failure & _:cloned}
+]

--- a/packages/ocaml-variants/ocaml-variants.5.5.0+introcaml/opam
+++ b/packages/ocaml-variants/ocaml-variants.5.5.0+introcaml/opam
@@ -1,0 +1,23 @@
+opam-version: "2.0"
+license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
+synopsis: "OCaml 5.5.0 with introspection"
+maintainer: [
+  "Frédéric Bour <frederic.bour@lakaban.net>"
+]
+authors: [
+  "Xavier Leroy"
+  "Damien Doligez"
+  "Alain Frisch"
+  "Jacques Garrigue"
+  "Didier Rémy"
+  "KC Sivaramakrishnan"
+  "Jérôme Vouillon"
+]
+homepage: "https://ocaml.org"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
+dev-repo: "git+https://github.com/ocaml/ocaml.git#5.5"
+depends: [
+  "ocaml-compiler" {= "5.5.0+introcaml"}
+]
+conflict-class: "ocaml-core-compiler"
+flags: [ compiler avoid-version ]


### PR DESCRIPTION
OCaml's toplevel has long been able to print arbitrary values without requiring explicit printer functions, but this ability was internal to the toplevel.
Introcaml brings introspection machinery into the standard library to enable polymorphic printing in user programs.

The `Introspect.Print` module provides polymorphic printing functions that work on values of any type, recovering structure from metadata embedded in compiled code.

```ocaml
open Introspect.Print

type config = { host : string; port : int; debug : bool }
print_any_endline { host = "localhost"; port = 8080; debug = true };;
(* Output: {host = "localhost"; port = 8080; debug = true} *)

(* Break through abstraction *)
module M = Map.Make(Int)
print_any_endline (M.of_list [1, "one"; 2, "two"]);;
(* Output: Node {l = Empty;
                 v = 1; d = "one";
                 r = Node {l = Empty; v = 2; d = "two"; r = Empty; h = 1};
                 h = 2} *)

(* Handle cyclic structures *)
let rec cycle = 1 :: cycle
print_any_endline cycle;;
(* Output: [1; <cycle>] *)

(* Extension constructors and polymorphic variants *)
type t = ..
type t += Foo of int
print_any_endline (Foo 42);;
(* Output: Foo/<uid> 42 *)
```

The feature also supports dynamic libraries: descriptors from dynlinked code are automatically incorporated into the printing index.
Availability can be checked at runtime via `Sys.introspection_enabled` or `Introspect.enabled`. A fallback implementation is provided such that code using introspection can still work when instrumentation is disabled.

For the lower-level API, `Introspect.Dyn.view` converts any value into a structured view that can be traversed programmatically, enabling custom formatters and debug tools.

**Design considerations:**

- Works in bytecode and native mode; the compilation scheme is designed such that overhead should be negligible in bytecode and nonexistent in native.
- Does not work on 32-bit architectures.
- Does not work with Flambda.
- Metadata are stored in reserved header bits; this limits the maximum size of OCaml objects. This switch reserves 22 bits, such that the maximum lengths are 4 billion elements for OCaml arrays and 32GB for strings.
- The scheme is probabilistic: sometimes metadata cannot be recovered or are ambiguous; in exchange, we get zero-overhead native instrumentation, separate compilation, and preserved FFI-compatibility.

This is an alpha preview. This work is funded by the [Ahrefs Grant Program for OCaml](https://discuss.ocaml.org/t/ahrefs-grant-program-for-ocaml).