### PR TITLE
[new release] merlin (4 packages) (5.8.1-505)

### DIFF
--- a/packages/dot-merlin-reader/dot-merlin-reader.5.8.1-505/opam
+++ b/packages/dot-merlin-reader/dot-merlin-reader.5.8.1-505/opam
@@ -1,0 +1,31 @@
+opam-version: "2.0"
+maintainer:   "defree@gmail.com"
+authors:      "The Merlin team"
+synopsis:     "Reads config files for merlin"
+homepage:     "https://github.com/ocaml/merlin"
+bug-reports:  "https://github.com/ocaml/merlin/issues"
+dev-repo:     "git+https://github.com/ocaml/merlin.git"
+license:      "MIT"
+x-maintenance-intent: ["(latest)"]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "ocaml" {>= "5.2" }
+  "dune" {>= "3.0.0"}
+  "merlin-lib" {= version}
+  "ocamlfind" {>= "1.6.0"}
+]
+description:
+  "Helper process: reads .merlin files and outputs the normalized content to
+  stdout."
+url {
+  src:
+    "https://github.com/ocaml/merlin/releases/download/v5.8.1-505/merlin-5.8.1-505.tbz"
+  checksum: [
+    "sha256=b8fb32bc0fc092af2fd6bdc831cb966057f2e3fd7b99a172b705e96ba8082583"
+    "sha512=01ca96f8167d062ba24036e43f650ff958fb157d44867bd52eb7999b7d19bf9fc97cdcd46c04b6979f0e1149d5041047723eed5913b03c4404d7acb116183bee"
+  ]
+}
+x-commit-hash: "a46ee0b7abad3079ec9eccbfcc3dc1ce14d4ce61"

--- a/packages/merlin-lib/merlin-lib.5.8.1-505/opam
+++ b/packages/merlin-lib/merlin-lib.5.8.1-505/opam
@@ -1,0 +1,36 @@
+opam-version: "2.0"
+maintainer:   "defree@gmail.com"
+authors:      "The Merlin team"
+homepage:     "https://github.com/ocaml/merlin"
+bug-reports:  "https://github.com/ocaml/merlin/issues"
+dev-repo:     "git+https://github.com/ocaml/merlin.git"
+license:      "MIT"
+x-maintenance-intent: ["(latest)"]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "ocaml" {>="5.5" & <"5.6"}
+  "dune" {>= "3.0.0"}
+  "csexp" {>= "1.5.1"}
+  "alcotest" {with-test & >= "1.3.0" }
+  "menhir"    {dev & >= "20230608"}
+  "menhirLib" {dev & >= "20230608"}
+  "menhirSdk" {dev & >= "20230608"}
+]
+synopsis:
+  "Merlin's libraries"
+description:
+  "These libraries provides access to low-level compiler interfaces and the
+  standard higher-level merlin protocol. The library is provided as-is, is not
+  thoroughly documented, and its public API might break with any new release."
+url {
+  src:
+    "https://github.com/ocaml/merlin/releases/download/v5.8.1-505/merlin-5.8.1-505.tbz"
+  checksum: [
+    "sha256=b8fb32bc0fc092af2fd6bdc831cb966057f2e3fd7b99a172b705e96ba8082583"
+    "sha512=01ca96f8167d062ba24036e43f650ff958fb157d44867bd52eb7999b7d19bf9fc97cdcd46c04b6979f0e1149d5041047723eed5913b03c4404d7acb116183bee"
+  ]
+}
+x-commit-hash: "a46ee0b7abad3079ec9eccbfcc3dc1ce14d4ce61"

--- a/packages/merlin/merlin.5.8.1-505/opam
+++ b/packages/merlin/merlin.5.8.1-505/opam
@@ -1,0 +1,42 @@
+opam-version: "2.0"
+maintainer:   "defree@gmail.com"
+authors:      "The Merlin team"
+homepage:     "https://github.com/ocaml/merlin"
+bug-reports:  "https://github.com/ocaml/merlin/issues"
+dev-repo:     "git+https://github.com/ocaml/merlin.git"
+license:      "MIT"
+x-maintenance-intent: ["(latest)"]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+depends: [
+  "dune" {>= "3.0.0"}
+  "merlin-lib" {= version}
+  "dot-merlin-reader" {= version}
+  "ocaml-index" {= version & post}
+  "yojson" {>= "2.0.0"}
+  "conf-jq" {with-test}
+  "ppxlib" {with-test}
+  "ppx_string" {with-test}
+#  "reason" {with-test} Removed temporarily until reason is compatible with 5.5
+]
+conflicts: [
+  "seq" {!= "base"}
+]
+synopsis:
+  "Editor service that provides advanced IDE features for OCaml"
+description:
+  "Merlin is an assistant for editing OCaml code. It aims to provide the features
+  available in modern IDEs: error reporting, auto completion, source browsing and
+  much more. It can be used as a standalone server or through an LSP server."
+url {
+  src:
+    "https://github.com/ocaml/merlin/releases/download/v5.8.1-505/merlin-5.8.1-505.tbz"
+  checksum: [
+    "sha256=b8fb32bc0fc092af2fd6bdc831cb966057f2e3fd7b99a172b705e96ba8082583"
+    "sha512=01ca96f8167d062ba24036e43f650ff958fb157d44867bd52eb7999b7d19bf9fc97cdcd46c04b6979f0e1149d5041047723eed5913b03c4404d7acb116183bee"
+  ]
+}
+x-commit-hash: "a46ee0b7abad3079ec9eccbfcc3dc1ce14d4ce61"

--- a/packages/ocaml-index/ocaml-index.5.8.1-505/opam
+++ b/packages/ocaml-index/ocaml-index.5.8.1-505/opam
@@ -1,0 +1,42 @@
+opam-version: "2.0"
+synopsis: "A tool that indexes value usages from cmt files"
+description:
+  "ocaml-index should integrate with the build system to index codebase and allow tools such as Merlin to perform project-wide occurrences queries."
+maintainer: ["ulysse@tarides.com"]
+authors: ["ulysse@tarides.com"]
+license: "MIT"
+homepage: "https://github.com/ocaml/merlin/ocaml-index"
+bug-reports: "https://github.com/ocaml/merlin/issues"
+x-maintenance-intent: ["(latest)"]
+depends: [
+  "dune" {>= "3.0.0"}
+  "ocaml" {>= "5.4"}
+  "merlin-lib" {= version}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+dev-repo: "git+https://github.com/ocaml/merlin.git"
+url {
+  src:
+    "https://github.com/ocaml/merlin/releases/download/v5.8.1-505/merlin-5.8.1-505.tbz"
+  checksum: [
+    "sha256=b8fb32bc0fc092af2fd6bdc831cb966057f2e3fd7b99a172b705e96ba8082583"
+    "sha512=01ca96f8167d062ba24036e43f650ff958fb157d44867bd52eb7999b7d19bf9fc97cdcd46c04b6979f0e1149d5041047723eed5913b03c4404d7acb116183bee"
+  ]
+}
+x-commit-hash: "a46ee0b7abad3079ec9eccbfcc3dc1ce14d4ce61"


### PR DESCRIPTION
Editor service that provides advanced IDE features for OCaml

- Project page: <a href="https://github.com/ocaml/merlin">https://github.com/ocaml/merlin</a>

##### CHANGES:

Fri Jul 31 11:31:42 CEST 2026

  + merlin library
    - occurrences: fix files modified since the index was built never being
      reported as out-of-sync. (ocaml/merlin#2104)
    - Fix `locate` and `document` on `open` paths in `.mli` files: resolve the
      open path in the environment before the open, so a self-shadowing
      submodule no longer hides the opened module (fixes ocaml/merlin#1748)
    - Fix occurrences staleness detection when the server is not running at the
      project's source root. (ocaml/merlin#2097)
    - Reproduce and fix a load_path staleness issue particularly visible when
      using ocaml-lsp and dune in watch mode (ocaml/merlin#2109)
    - Fix bug in `document` query (ocaml/merlin#2092)
  + ocaml index
    - Fix staleness detection in the presence of ppxes. (ocaml/merlin#2110)
