### PR TITLE
Put pxshot.0.1.2 into opam-source-archives

### DIFF
--- a/packages/pxshot/pxshot.0.1.2/opam
+++ b/packages/pxshot/pxshot.0.1.2/opam
@@ -37,7 +37,7 @@ build: [
 dev-repo: "git+https://github.com/faiscadev/pxshot-ocaml.git"
 url {
   src:
-    "https://github.com/faiscadev/pxshot-ocaml/releases/download/v0.1.2/pxshot-0.1.2.tbz"
+    "https://github.com/ocaml/opam-source-archives/raw/refs/heads/main/pxshot.0.1.2.tbz"
   checksum: [
     "sha256=3af9325059bfa07d0445b01528a538bf600d76187871e3ae93d409b7f0dd62ff"
     "sha512=e7954e56968a9bf73171377b3dec641fd99a9fb8b0fc91e4f3971b3cf19f39937fe21e4163eb1d9646ff913ac751c947fdd319a3b00edc76317dadb51ad02369"


### PR DESCRIPTION
CI has no chance until merging https://github.com/ocaml/opam-source-archives/pull/61