### PR TITLE
Put vecosek to opam source archives. 

### DIFF
--- a/packages/vecosek-engine/vecosek-engine.0.0.0/opam
+++ b/packages/vecosek-engine/vecosek-engine.0.0.0/opam
@@ -24,7 +24,7 @@ with arbitrarily *complex* music.
 
 vecosek-engine is a library containing Vecosek's sequencer."""
 url {
-  src: "https://gitlab.com/smondet/vecosek/-/archive/0.0.0/vecosek-0.0.0.zip"
+  src: "https://github.com/ocaml/opam-source-archives/raw/refs/heads/main/vecosek.0.0.0.zip"
   checksum: [
     "sha256=837cd8046991d74036a7d17aa601bcd2e311d9ffef140f708b30cc317ca72eb2"
     "md5=bf77dc7c5a8d8efeff67b8eb43ef2dd0"

--- a/packages/vecosek-engine/vecosek-engine.0.0.0/opam
+++ b/packages/vecosek-engine/vecosek-engine.0.0.0/opam
@@ -17,7 +17,7 @@ depends: [
   "nonstd" {>= "0.0.2"}
   "vecosek-scene"
 ]
-synopsis: ""
+synopsis: "Very Controllable Sequencer (engine)"
 description: """
 Vecosek is a MIDI sequencer designed for live, interactive performance settings,
 with arbitrarily *complex* music. 

--- a/packages/vecosek-scene/vecosek-scene.0.0.0/opam
+++ b/packages/vecosek-scene/vecosek-scene.0.0.0/opam
@@ -27,7 +27,7 @@ with arbitrarily *complex* music.
 vecosek-scene is a library defining the scene format (JSON & Biniou)
 as a well as basic contructors to build scenes from an EDSL."""
 url {
-  src: "https://gitlab.com/smondet/vecosek/-/archive/0.0.0/vecosek-0.0.0.zip"
+  src: "https://github.com/ocaml/opam-source-archives/raw/refs/heads/main/vecosek.0.0.0.zip"
   checksum: [
     "sha256=837cd8046991d74036a7d17aa601bcd2e311d9ffef140f708b30cc317ca72eb2"
     "md5=bf77dc7c5a8d8efeff67b8eb43ef2dd0"

--- a/packages/vecosek-scene/vecosek-scene.0.0.0/opam
+++ b/packages/vecosek-scene/vecosek-scene.0.0.0/opam
@@ -19,7 +19,7 @@ depends: [
   "yojson" {< "2.0.0"}
   "atdgen" {< "2.10.0"}
 ]
-synopsis: ""
+synopsis: "Very Controllable Sequencer: a collection of (looping) tracks"
 description: """
 Vecosek is a MIDI sequencer designed for live, interactive performance settings,
 with arbitrarily *complex* music. 

--- a/packages/vecosek/vecosek.0.0.0/opam
+++ b/packages/vecosek/vecosek.0.0.0/opam
@@ -24,7 +24,7 @@ depends: [
   "misuja"
   "cmdliner" {< "2.0.0"}
 ]
-synopsis: ""
+synopsis: "Very Controllable Sequencer"
 description: """
 Vecosek is a MIDI sequencer designed for live, interactive performance settings,
 with arbitrarily *complex* music. 

--- a/packages/vecosek/vecosek.0.0.0/opam
+++ b/packages/vecosek/vecosek.0.0.0/opam
@@ -31,7 +31,8 @@ with arbitrarily *complex* music.
 
 The vecosek package contains the sequencer executable."""
 url {
-  src: "https://gitlab.com/smondet/vecosek/-/archive/0.0.0/vecosek-0.0.0.zip"
+  #src: "https://gitlab.com/smondet/vecosek/-/archive/0.0.0/vecosek-0.0.0.zip"
+  src: "https://github.com/ocaml/opam-source-archives/raw/refs/heads/main/vecosek.0.0.0.zip"
   checksum: [
     "sha256=837cd8046991d74036a7d17aa601bcd2e311d9ffef140f708b30cc317ca72eb2"
     "md5=bf77dc7c5a8d8efeff67b8eb43ef2dd0"


### PR DESCRIPTION
See https://github.com/ocaml/opam-repository/issues/30240

CI has no chance until merging https://github.com/ocaml/opam-source-archives/pull/63