### PR TITLE
[new release] dscheck (0.6.0)

### DIFF
--- a/packages/dscheck/dscheck.0.6.0/opam
+++ b/packages/dscheck/dscheck.0.6.0/opam
@@ -1,0 +1,38 @@
+opam-version: "2.0"
+synopsis: "Traced Atomics"
+maintainer: ["Sadiq Jaffer"]
+authors: ["Sadiq Jaffer"]
+license: "ISC"
+homepage: "https://github.com/ocaml-multicore/dscheck"
+bug-reports: "https://github.com/ocaml-multicore/dscheck/issues"
+depends: [
+  "ocaml" {>= "5.2.0"}
+  "dune" {>= "3.9"}
+  "alcotest" {>= "1.6.0" & with-test}
+  "cmdliner"
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/ocaml-multicore/dscheck.git"
+url {
+  src:
+    "https://github.com/ocaml-multicore/dscheck/releases/download/0.6.0/dscheck-0.6.0.tbz"
+  checksum: [
+    "sha256=fff962e3eed8d645a3539577b93505d642d9afe33b29e24f90e671d3750e7bac"
+    "sha512=831f47696a5ccaf0522a41c7cafe29f05f2ffbd51e08004af53160030cd2d09577aac5c4af7e68be6ea6d40be74f12271bbeaf2b09222662482dbc2559c6619d"
+  ]
+}
+x-commit-hash: "45406eca007f391dc9764b949f23b0cfed343a9b"


### PR DESCRIPTION
Traced Atomics

- Project page: <a href="https://github.com/ocaml-multicore/dscheck">https://github.com/ocaml-multicore/dscheck</a>

##### CHANGES:

- switch to Dynarray to remove non-stdlib dependencies (ocaml-multicore/dscheck#32 @avsm @sadiqj)
- remove stray dependency on tsort (ocaml-multicore/dscheck#32 ocaml-multicore/dscheck#31 @avsm, reported by @glondu)
- minimum dependency is now ocaml 5.2.0+ and also works with oxcaml (@avsm)
