### PR TITLE
[new release] git-kv (2 packages) (0.2.3)

### DIFF
--- a/packages/git-kv/git-kv.0.2.3/opam
+++ b/packages/git-kv/git-kv.0.2.3/opam
@@ -1,0 +1,51 @@
+opam-version: "2.0"
+maintainer: "Robur Team <team@robur.coop>"
+authors: [ "Robur Team <team@robur.coop>" ]
+license: "MIT"
+homepage: "https://github.com/robur-coop/git-kv"
+dev-repo: "git+https://github.com/robur-coop/git-kv"
+bug-reports: "https://github.com/robur-coop/git-kv/issues"
+synopsis: "A Mirage_kv implementation using git"
+
+depends: [
+  "ocaml" {>= "4.12.0"}
+  "dune" {>= "3.0.0"}
+  "ke" {>= "0.6"}
+  "fmt" {>= "0.10.0"}
+  "uri" {>= "4.4.0"}
+  "lwt" {>= "5.9.0"}
+  "hxd"
+  "psq" {>= "0.2.1"}
+  "bstr"
+  "logs" {>= "0.7.0"}
+  "mimic" {>= "0.0.6"}
+  "emile" {>= "1.1"}
+  "fpath" {>= "0.7.3"}
+  "base64" {>= "3.5.0"}
+  "carton" {>= "1.1.0"}
+  "carton-git-lwt"
+  "encore" {>= "0.8.1"}
+  "digestif" {>= "1.3.0"}
+  "decompress" {>= "1.6.0"}
+  "ptime"
+  "mirage-kv" {>= "6.0.0"}
+  "cstruct" {>= "6.0.0"}
+  "mirage-ptime"
+  "alcotest" {with-test}
+]
+
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test & os != "fedora" & os != "alpine" & os != "opensuse"}
+]
+x-maintenance-intent: [ "(latest)" ]
+url {
+  src:
+    "https://github.com/robur-coop/git-kv/releases/download/v0.2.3/git-kv-0.2.3.tbz"
+  checksum: [
+    "sha256=f157c963642c427d5d4993109eeffebe1797ba149e0076afca07a2e589988bce"
+    "sha512=f2b6dc52c6e09bf2d9959b5eb8f8312441ff5f0e575416c5fd8794c46dea8b17e106cd874e9a5f07c4b362f6b15347467e8b49184293677795145c03a18f5eb7"
+  ]
+}
+x-commit-hash: "47cb488b2e10a67885967b0466227b45ec0ed283"

--- a/packages/git-net/git-net.0.2.3/opam
+++ b/packages/git-net/git-net.0.2.3/opam
@@ -23,6 +23,7 @@ depends: [
   "mimic-happy-eyeballs"
   "happy-eyeballs-lwt"
   "alcotest" {with-test}
+  "conf-git-daemon" {with-test}
 ]
 
 build: [

--- a/packages/git-net/git-net.0.2.3/opam
+++ b/packages/git-net/git-net.0.2.3/opam
@@ -45,3 +45,4 @@ url {
   ]
 }
 x-commit-hash: "47cb488b2e10a67885967b0466227b45ec0ed283"
+x-ci-accept-failures: ["macos-homebrew"]

--- a/packages/git-net/git-net.0.2.3/opam
+++ b/packages/git-net/git-net.0.2.3/opam
@@ -1,0 +1,46 @@
+opam-version: "2.0"
+maintainer: "Robur Team <team@robur.coop>"
+authors: [ "Robur Team <team@robur.coop>" ]
+license: "MIT"
+homepage: "https://github.com/robur-coop/git-kv"
+dev-repo: "git+https://github.com/robur-coop/git-kv"
+bug-reports: "https://github.com/robur-coop/git-kv/issues"
+synopsis: "A Mirage_kv implementation using git"
+
+depends: [
+  "ocaml" {>= "4.12.0"}
+  "dune" {>= "3.0.0"}
+  "git-kv" {= version}
+  "ca-certs-nss"
+  "h1"
+  "paf" {>= "0.8.0"}
+  "uri"
+  "tls" {>= "2.0.0"}
+  "tls-mirage"
+  "awa-mirage" {>= "0.5.2"}
+  "mimic" {>= "0.0.6"}
+  "tcpip"
+  "mimic-happy-eyeballs"
+  "happy-eyeballs-lwt"
+  "alcotest" {with-test}
+]
+
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs]
+    {with-test & os-distribution != "fedora"
+               & os-distribution != "alpine"
+               & os-distribution != "opensuse"}
+]
+x-maintenance-intent: [ "(latest)" ]
+x-ci-accept-failures: [ "alpine-3.21" "fedora-41" "fedora-42" "opensuse-15.6" "opensuse-tumbleweed" ]
+url {
+  src:
+    "https://github.com/robur-coop/git-kv/releases/download/v0.2.3/git-kv-0.2.3.tbz"
+  checksum: [
+    "sha256=f157c963642c427d5d4993109eeffebe1797ba149e0076afca07a2e589988bce"
+    "sha512=f2b6dc52c6e09bf2d9959b5eb8f8312441ff5f0e575416c5fd8794c46dea8b17e106cd874e9a5f07c4b362f6b15347467e8b49184293677795145c03a18f5eb7"
+  ]
+}
+x-commit-hash: "47cb488b2e10a67885967b0466227b45ec0ed283"

--- a/packages/git-net/git-net.0.2.3/opam
+++ b/packages/git-net/git-net.0.2.3/opam
@@ -11,7 +11,7 @@ depends: [
   "ocaml" {>= "4.12.0"}
   "dune" {>= "3.0.0"}
   "git-kv" {= version}
-  "ca-certs-nss"
+  "ca-certs-nss" {>= "3.126"}
   "h1"
   "paf" {>= "0.8.0"}
   "uri"


### PR DESCRIPTION
A Mirage_kv implementation using git

- Project page: <a href="https://github.com/robur-coop/git-kv">https://github.com/robur-coop/git-kv</a>

##### CHANGES:

- Fix tests and remove the usage of lsof (@mtelvers, @dinosaure, [robur-coop/git-kv#16][g16])
- Lint OPAM files and use warning names instead of numbers (@hannesm, [!23][23])
- Update `git-kv` with the last version of `decompress` (@dinosaure, ef176a5)

[g16]: https://github.com/robur-coop/git-kv/pull/16
[23]: https://git.robur.coop/robur/git-kv/pulls/23
