### PR TITLE
[new release] albatross (2.8.0)

### DIFF
--- a/packages/albatross/albatross.2.8.0/opam
+++ b/packages/albatross/albatross.2.8.0/opam
@@ -1,0 +1,71 @@
+opam-version: "2.0"
+maintainer: "Hannes Mehnert <hannes@mehnert.org>"
+authors: ["Hannes Mehnert <hannes@mehnert.org>"]
+homepage: "https://github.com/robur-coop/albatross"
+dev-repo: "git+https://github.com/robur-coop/albatross.git"
+bug-reports: "https://github.com/robur-coop/albatross/issues"
+license: "ISC"
+
+depends: [
+  "ocaml" {>= "4.14.0"}
+  "dune" {>= "2.7.0"}
+  "dune-configurator"
+  "conf-pkg-config" {build}
+  "conf-libnl3" {os = "linux"}
+  "conf-libev"
+  "lwt" {>= "3.0.0"}
+  "ipaddr" {>= "5.3.0"}
+  "logs"
+  "bos" {>= "0.2.0"}
+  "ptime" {>= "1.1.0"}
+  "cmdliner" {>= "1.1.0"}
+  "fmt" {>= "0.8.7"}
+  "x509" {>= "1.0.0"}
+  "tls" {>= "1.0.2"}
+  "tls-lwt" {>= "1.0.2"}
+  "asn1-combinators" {>= "0.3.0"}
+  "duration"
+  "decompress" {>= "1.3.0"}
+  "bigstringaf" {>= "0.2.0"}
+  "metrics" {>= "0.5.0"}
+  "metrics-lwt" {>= "0.2.0"}
+  "metrics-influx" {>= "0.2.0"}
+  "metrics-rusage"
+  "ohex" {>= "0.2.0"}
+  "http-lwt-client" {>= "0.3.0"}
+  "happy-eyeballs-lwt"
+  "solo5-elftool" {>= "0.4.0"}
+  "cachet" {>= "0.0.3"}
+  "bstr"
+  "fpath" {>= "0.7.3"}
+  "logs-syslog" {>= "0.4.1"}
+  "digestif" {>= "1.2.0"}
+  "alcotest" {with-test}
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+  ["sh" "-ex" "packaging/FreeBSD/create_package.sh"] {os = "freebsd"}
+  ["sh" "-ex" "packaging/debian/create_package.sh"] {os-family = "debian" | os-family = "ubuntu"}
+]
+available: os != "openbsd"
+synopsis: "Albatross - orchestrate and manage MirageOS unikernels with Solo5"
+description: """
+The goal of albatross is robust deployment of [MirageOS](https://mirage.io)
+unikernels using [Solo5](https://github.com/solo5/solo5). Resources managed
+by albatross are network interfaces of kind `tap`, which are connected to
+already existing bridges, block devices, memory, and CPU. Each unikernel is
+pinned (`cpuset` / `taskset`) to a specific core.
+"""
+depexts: ["linux-headers"] {os-family = "alpine"}
+x-maintenance-intent: [ "(latest)" ]
+url {
+  src:
+    "https://github.com/robur-coop/albatross/releases/download/v2.8.0/albatross-2.8.0.tbz"
+  checksum: [
+    "sha256=4f1ee56d8a5ab6071b0f201102f4a14b626a340ca5af2faf11c298bed6799c3f"
+    "sha512=5e4c7656bddb4de90b925202b6bc7a2068b807cbc3d20f59ad5cafda7f9cf0313796eff5f55c42282850868926ee9c0c57bee0ed48e0f0dbc2853315ad71652d"
+  ]
+}
+x-commit-hash: "e93f68dcb293de5885ae579b460f0839da182fc3"


### PR DESCRIPTION
Albatross - orchestrate and manage MirageOS unikernels with Solo5

- Project page: <a href="https://github.com/robur-coop/albatross">https://github.com/robur-coop/albatross</a>

##### CHANGES:

- Embed influx output into albatross_stats, albatross_influx is no more
  (robur-coop/albatross#283 @hannesm)
- Remove bhyve statistics gathering (robur-coop/albatross#283 @hannesm, fixes robur-coop/albatross#258)
- Add "logging service", which reports of vm creation and destroyal (all
  in-memory, served by albatross-daemon) (robur-coop/albatross#280 @hannesm)
- Adjust restarting for cmdliner exit code, and --help/--version (robur-coop/albatross#282 @hannesm,
  fixes robur-coop/albatross#279)
- `restart` command: respect memory; numcpus ; linux_boot_partition
  (robur-coop/albatross#276 @hannesm, fixes robur-coop/albatross#275)
- FreeBSD packaging: pass `-t` to `pkg create` to preserve mtime
  (2eb7551630fe3fb7cc7ff0e9811fdd286ef6b097 @hannesm)
