### PR TITLE
Package opam-ed.0.5

### DIFF
--- a/packages/opam-ed/opam-ed.0.5/opam
+++ b/packages/opam-ed/opam-ed.0.5/opam
@@ -1,0 +1,29 @@
+opam-version: "2.0"
+synopsis: "Command-line edition tool for handling the opam file syntax"
+description: """\
+opam-ed can read and write files in the general opam syntax. It provides a small CLI with some useful commands for mechanically extracting or modifying the file contents.
+
+The specification for the syntax itself is available at:
+    http://opam.ocaml.org/doc/Manual.html#Common-file-format"""
+maintainer: "Louis Gesbert <louis.gesbert@ocamlpro.com>"
+authors: "Louis Gesbert <louis.gesbert@ocamlpro.com>"
+license: "LGPL-2.1-only WITH OCaml-LGPL-linking-exception"
+homepage: "https://github.com/AltGr/opam-ed"
+bug-reports: "https://github.com/AltGr/opam-ed/issues"
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "2.0"}
+  "cmdliner" {>= "1.1.0"}
+  "opam-file-format" {>= "2.1.1"}
+]
+build: ["dune" "build" "-p" name "-j" jobs]
+run-test: ["dune" "runtest" "-p" name "-j" jobs]
+dev-repo: "git+https://github.com/AltGr/opam-ed.git"
+url {
+  src:
+    "https://github.com/AltGr/opam-ed/releases/download/0.5/opam-ed-0.5.tar.gz"
+  checksum: [
+    "md5=df787980b5b1ae812673eb9d8c7b8cd9"
+    "sha512=f1aac067d104b7e4ca6a6e1c0b62072f7352c5d511b8c3f7072e38da42ff639c0663816c9c6c9192b8f00fe7823717328933ea31480824daddd1994a2bf676a3"
+  ]
+}

--- a/packages/opam-ed/opam-ed.0.5/opam
+++ b/packages/opam-ed/opam-ed.0.5/opam
@@ -5,11 +5,11 @@ opam-ed can read and write files in the general opam syntax. It provides a small
 
 The specification for the syntax itself is available at:
     http://opam.ocaml.org/doc/Manual.html#Common-file-format"""
-maintainer: "Louis Gesbert <louis.gesbert@ocamlpro.com>"
+maintainer: "Kate <kit-ty-kate@exn.st>"
 authors: "Louis Gesbert <louis.gesbert@ocamlpro.com>"
 license: "LGPL-2.1-only WITH OCaml-LGPL-linking-exception"
-homepage: "https://github.com/AltGr/opam-ed"
-bug-reports: "https://github.com/AltGr/opam-ed/issues"
+homepage: "https://github.com/ocaml-opam/opam-ed"
+bug-reports: "https://github.com/ocaml-opam/opam-ed/issues"
 depends: [
   "ocaml" {>= "4.08.0"}
   "dune" {>= "2.0"}
@@ -18,10 +18,10 @@ depends: [
 ]
 build: ["dune" "build" "-p" name "-j" jobs]
 run-test: ["dune" "runtest" "-p" name "-j" jobs]
-dev-repo: "git+https://github.com/AltGr/opam-ed.git"
+dev-repo: "git+https://github.com/ocaml-opam/opam-ed.git"
 url {
   src:
-    "https://github.com/AltGr/opam-ed/releases/download/0.5/opam-ed-0.5.tar.gz"
+    "https://github.com/ocaml-opam/opam-ed/releases/download/0.5/opam-ed-0.5.tar.gz"
   checksum: [
     "md5=df787980b5b1ae812673eb9d8c7b8cd9"
     "sha512=f1aac067d104b7e4ca6a6e1c0b62072f7352c5d511b8c3f7072e38da42ff639c0663816c9c6c9192b8f00fe7823717328933ea31480824daddd1994a2bf676a3"


### PR DESCRIPTION
### `opam-ed.0.5`
Command-line edition tool for handling the opam file syntax
opam-ed can read and write files in the general opam syntax. It provides a small CLI with some useful commands for mechanically extracting or modifying the file contents.

The specification for the syntax itself is available at:
    http://opam.ocaml.org/doc/Manual.html#Common-file-format



---
* Homepage: https://github.com/AltGr/opam-ed
* Source repo: git+https://github.com/AltGr/opam-ed.git
* Bug tracker: https://github.com/AltGr/opam-ed/issues

---
:camel: Pull-request generated by opam-publish v3.0.1