### PR TITLE
make playwright.0.1.1 unavailable

### DIFF
--- a/packages/playwright/playwright.0.1.1/opam
+++ b/packages/playwright/playwright.0.1.1/opam
@@ -35,7 +35,7 @@ build: [
   ]
 ]
 dev-repo: "git+https://github.com/dmytro-melno/ocaml-playwright.git"
-available: os = "linux" & (arch = "x86_64" | arch = "arm64")
+available: false # Bad checksum
 url {
   src:
     "https://github.com/dmytro-melno/ocaml-playwright/archive/refs/tags/v0.1.1.tar.gz"


### PR DESCRIPTION
It was added at PR https://github.com/ocaml/opam-repository/pull/30146 but in a month checksum have gone rotten (too fast and suspicious). (Author was mentioned in the link above.)
Because of the timing I couldn't find right archive in https://opam.ocaml.org/cache/sha512/d3/d3e5e4a97415c9fb4c059d36f440202248c97fa24a8961ac28ac29910247573ca999ccdd502f53937c311318bbef9836930ce8876ce5c4083da65745d6795f11