### PR TITLE
Add par.0.8.2

### DIFF
--- a/packages/par/par.0.8.2/opam
+++ b/packages/par/par.0.8.2/opam
@@ -1,0 +1,70 @@
+opam-version: "2.0"
+synopsis: "Programmable Agent Runtime — type-safe agent SDK for OCaml 5.4+"
+description: """
+PAR is a modular agent runtime: ReAct engine, multi-provider LLM support
+(OpenAI / Anthropic / Ollama / custom), workflow orchestration, SQLite
+persistence, HITL approval, parallel multi-agent dispatch, and Python
+ctypes bindings.
+"""
+maintainer: ["P-A-R Contributors"]
+authors: ["P-A-R Contributors"]
+license: "MIT"
+tags: ["agents" "llm" "runtime" "ffi"]
+homepage: "https://github.com/jcz2020/par"
+bug-reports: "https://github.com/jcz2020/par/issues"
+dev-repo: "git+https://github.com/jcz2020/par.git"
+depends: [
+  "ocaml" {>= "5.4.0"}
+  "dune" {>= "3.16"}
+  "base"
+  "yojson"
+  "eio"
+  "eio_main"
+  "uuidm"
+  "ppx_deriving"
+  "ppx_deriving_yojson"
+  "ppx_deriving_jsonschema" {= "0.0.1"}
+  "ppx_sexp_conv"
+  "ppx_compare"
+  "sqlite3"
+  "logs"
+  "tls-eio"
+  "cohttp-eio"
+  "lambdasoup"
+  "ca-certs"
+  "x509"
+  "mirage-crypto-rng"
+  "base64"
+  "digestif"
+  "yaml"
+  "omd"
+  "camlpdf"
+  "camlzip"
+  "xmlm"
+  "csv"
+  "sexplib0"
+  "ctypes"
+  "alcotest" {with-test}
+  "jsonschema-validation"
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src:
+    "https://github.com/jcz2020/par/releases/download/v0.8.2/par-0.8.2.tar.gz"
+  checksum: [
+    "sha256=bd592936b6de7f56dfb55917fe181fba769e9c908661cafc131a97750e901b62"
+  ]
+}


### PR DESCRIPTION
Type-safe agent runtime for OCaml 5.4+ — ReAct engine, multi-provider LLM support (OpenAI / Anthropic / Ollama), workflow orchestration, SQLite persistence, HITL approval, parallel multi-agent dispatch.

Previous submission (#30086) was closed; that PR targeted v0.4.8 and included a `par_cli` package that has since been removed. This PR contains only `par` at v0.8.2 (current stable).

- Package: `par`
- Version: `0.8.2`
- License: MIT
- Dependencies: OCaml ≥ 5.4.0, dune ≥ 3.16, and 26 standard opam packages (full list in opam file)
- Homepage: https://github.com/jcz2020/par
- Docs: https://jcz2020.github.io/par

Build verified on Ubuntu 22.04 and macOS 14 (arm64). 1500+ tests passing.