### PR TITLE
[new release] modelkit (0.1.0)

### DIFF
--- a/packages/modelkit/modelkit.0.1.0/opam
+++ b/packages/modelkit/modelkit.0.1.0/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+synopsis: "Portable classical machine learning workflows for OCaml"
+description:
+  "ModelKit is a native OCaml library for cohesive classical machine learning workflows. It is designed around immutable estimator specifications, leakage-safe pipelines, deterministic evaluation, and portable fitted artifacts."
+maintainer: ["Asara developers <devs@asara.io>"]
+authors: ["Asara"]
+license: "Apache-2.0"
+tags: ["data-science" "machine-learning"]
+homepage: "https://github.com/asara-io/ModelKit"
+bug-reports: "https://github.com/asara-io/ModelKit/issues"
+depends: [
+  "dune" {>= "3.23"}
+  "ocaml" {>= "5.2"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/asara-io/ModelKit.git"
+x-maintenance-intent: ["(latest)"]
+url {
+  src:
+    "https://github.com/asara-io/ModelKit/releases/download/0.1.0/modelkit-0.1.0.tbz"
+  checksum: [
+    "sha256=4308f663e06e97290cd49432c8a128f3cedac9f6c571feb7cc61d3c1f1b1bc1c"
+    "sha512=1468d3f0812f18a0943ed947686ca86b2eef3127b4db9038252f3517aef83dd07158d721f6cd9ba7ce288d3da38ad2fb1f09a7240945e1f8a2b18a7ea4ed74b3"
+  ]
+}
+x-commit-hash: "a0002ad55efd818a8d2cd14ab917f1e3429ca5d8"


### PR DESCRIPTION
Portable classical machine learning workflows for OCaml

- Project page: <a href="https://github.com/asara-io/ModelKit">https://github.com/asara-io/ModelKit</a>

##### CHANGES:

- Establish the initial ModelKit package with an OCaml 5.2 compiler floor and Apache-2.0 licensing.
- Add the portable library skeleton and reserved package boundaries for optional adapters and accelerated backends.
- Add the Dune workspace, generated odoc documentation, formatting checks, and platform-specific opam lock workflow.
- Document project governance, support, and maintenance policies.
