### PR TITLE
[new release] mirage-nat (3.1.0)

### DIFF
--- a/packages/mirage-nat/mirage-nat.3.1.0/opam
+++ b/packages/mirage-nat/mirage-nat.3.1.0/opam
@@ -1,0 +1,45 @@
+opam-version: "2.0"
+maintainer: "Mindy Preston <meetup@yomimono.org>"
+authors: "Mindy Preston <meetup@yomimono.org>"
+homepage: "https://github.com/mirage/mirage-nat"
+bug-reports: "https://github.com/mirage/mirage-nat/issues/"
+dev-repo: "git+https://github.com/mirage/mirage-nat.git"
+doc: "https://mirage.github.io/mirage-nat/"
+license: "ISC"
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "ipaddr"
+  "cstruct" {>= "6.0.0"}
+  "lru" {>= "0.3.0"}
+  "dune" {>= "1.0"}
+  "tcpip" { >= "8.0.0" }
+  "ethernet" { >= "3.0.0" }
+  "alcotest" {with-test}
+  "mirage-clock-unix" {with-test}
+  "fmt" {with-test & >= "0.8.7"}
+  "logs" {with-test}
+]
+conflicts: [ "result" {< "1.5"} ]
+synopsis: "Mirage-nat is a library for network address translation to be used with MirageOS"
+description: """
+Mirage-nat is a library for [network address
+translation](https://tools.ietf.org/html/rfc2663).  It is intended for use in
+[MirageOS](https://mirage.io) and makes extensive use of
+[tcpip](https://github.com/mirage/mirage-tcpip), the network stack used by
+default in MirageOS unikernels.
+"""
+x-maintenance-intent: [ "(latest)" ]
+url {
+  src:
+    "https://github.com/mirage/mirage-nat/releases/download/v3.1.0/mirage-nat-3.1.0.tbz"
+  checksum: [
+    "sha256=bb58d254c755f5b7dc7db7ad37ecf04545a531281ca63101bc9940c83642aef0"
+    "sha512=01bd6f4dafdf96eb09fff8ca951f6309b01289b0894e49a496784aca38abb89983784e4db00801afdb5fd70ac95f9c81985bab383fd57502a56b9ea11bf47782"
+  ]
+}
+x-commit-hash: "ef7b7b616e39eee1af921398e65284eda253c2f0"


### PR DESCRIPTION
Mirage-nat is a library for network address translation to be used with MirageOS

- Project page: <a href="https://github.com/mirage/mirage-nat">https://github.com/mirage/mirage-nat</a>
- Documentation: <a href="https://mirage.github.io/mirage-nat/">https://mirage.github.io/mirage-nat/</a>

##### CHANGES:

- fix for packets without payload (mirage/mirage-nat#53 @palainp)
- fix that DF flag is preserved (mirage/mirage-nat#55 @palainp, fixes mirage/mirage-nat#52)
- add "length" function (mirage/mirage-nat#54 @palainp)
- various fixes to the example unikernel
