### PR TITLE
[new release] html_of_jsx (0.1.0)

### DIFF
--- a/packages/html_of_jsx/html_of_jsx.0.1.0/opam
+++ b/packages/html_of_jsx/html_of_jsx.0.1.0/opam
@@ -1,0 +1,55 @@
+opam-version: "2.0"
+synopsis: "Render HTML with JSX"
+description:
+  "html_of_jsx is a JSX transformation and a library to write HTML declaratively in OCaml (mlx) and Reason."
+maintainer: ["David Sancho <dsnxmoreno@gmail.com>"]
+authors: ["David Sancho <dsnxmoreno@gmail.com>"]
+license: "MIT"
+homepage: "https://github.com/davesnx/html_of_jsx"
+bug-reports: "https://github.com/davesnx/html_of_jsx/issues"
+depends: [
+  "dune" {>= "3.24"}
+  "ocaml" {>= "4.14"}
+  "ppxlib" {>= "0.25.0"}
+  "pretty_expressive" {>= "0.5"}
+  "odoc" {with-doc}
+  "odoc-parser" {with-doc}
+  "alcotest" {with-test}
+  "benchmark" {with-test}
+  "reason" {>= "3.10.0" & with-test}
+  "ocamlformat" {>= "0.26.1" & (with-dev-setup | with-test)}
+  "mlx" {with-test | with-dev-setup}
+  "ocamlformat-mlx" {with-dev-setup | with-test}
+  "ocaml-lsp-server" {with-dev-setup}
+  "tiny_httpd" {with-dev-setup}
+  "yocaml" {with-dev-setup}
+  "yocaml_unix" {with-dev-setup}
+  "ochre" {with-dev-setup}
+  "tm-grammars" {with-dev-setup}
+  "omd" {with-dev-setup}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/davesnx/html_of_jsx.git"
+x-maintenance-intent: ["(latest)"]
+url {
+  src:
+    "https://github.com/davesnx/html_of_jsx/releases/download/0.1.0/html_of_jsx-0.1.0.tbz"
+  checksum: [
+    "sha256=a62b73fe66b6e40196cc06cc0771184d42923e9c571183ecc793cd58f0b407dd"
+    "sha512=b25ba1321a5413942bf781aa9a8cacdc92eb03c1099a4c564a061b32cc57bbae571465d123d98548aba1cc78c3bb79fbf415e29934a8318c15ab9ffc0ea8cceb"
+  ]
+}
+x-commit-hash: "3e23949ad27cc497cbc08478a4b365b377bbf99e"


### PR DESCRIPTION
Render HTML with JSX

- Project page: <a href="https://github.com/davesnx/html_of_jsx">https://github.com/davesnx/html_of_jsx</a>

##### CHANGES:

- [BREAKING] Component invocations now group multiple children with `JSX.list`, so components receive `JSX.element` for both single and multiple children. `JSX.fragment` now accepts `JSX.element` to follow the same convention. (@davesnx)
- [BREAKING] Renamed `JSX.stringf` -> `JSX.format` (@davesnx)
- Massive PPX compile-time improvement: the HTML attribute database is now built once instead of being reconstructed on every attribute lookup (6-8x faster on attribute-heavy files) (@davesnx)
- Fix escaping of constant `JSX.string` children inside fragments: `<> {JSX.string("<script>")} </>` was inlined without HTML-encoding (@davesnx)
- [BREAKING] Fix ill-typed generated code for optional booleanish attributes (e.g. `?spellcheck`) when the static optimization is disabled (@davesnx)
- Fragments now use the same optimized buffer codegen as elements: constant children collapse at compile time and dynamic children are spliced into a single buffer instead of allocating a `JSX.list` (@davesnx)
- `JSX.render_streaming` now streams for real: chunks are emitted incrementally every `?chunk_size` bytes (default 4096) instead of buffering the whole document (@davesnx)
- `JSX.escape` copies runs of clean characters in bulk instead of char-by-char after the first escape; `JSX.render` returns clean strings and int/float elements without buffer copies (@davesnx)
- The unoptimized attribute path (`-disable-static-opt` or fallback) no longer allocates `Some`/`filter_map` wrappers when no optional attribute is present (@davesnx)
- Benchmarks: scenarios now construct elements inside the timed function (several scenarios previously measured rendering of a prebuilt static string, i.e. a no-op); added a `large-mixed` compile-time fixture that guards against PPX attribute-lookup regressions (@davesnx)
- Add zero-copy fast path in `JSX.render`: `Unsafe`/`Null`/`String` elements skip the intermediate buffer entirely, making rendering of fully optimized trees free (@davesnx)
- PPX buffer splicing: nested JSX elements now write directly into the parent's buffer instead of materializing an intermediate buffer and string per element, cutting render time up to ~50% and allocations up to ~60% on dynamic pages (@davesnx)
