### PR TITLE
Add par.0.8.3

### DIFF
--- a/packages/par/par.0.8.3/opam
+++ b/packages/par/par.0.8.3/opam
@@ -1,0 +1,70 @@
+opam-version: "2.0"
+synopsis: "Programmable Agent Runtime — type-safe agent SDK for OCaml 5.4+"
+description: """
+PAR is a modular agent runtime: ReAct engine, multi-provider LLM support
+(OpenAI / Anthropic / Ollama / custom), workflow orchestration, SQLite
+persistence, HITL approval, parallel multi-agent dispatch, and Python
+ctypes bindings.
+"""
+maintainer: ["P-A-R Contributors"]
+authors: ["P-A-R Contributors"]
+license: "MIT"
+tags: ["agents" "llm" "runtime" "ffi"]
+homepage: "https://github.com/jcz2020/par"
+bug-reports: "https://github.com/jcz2020/par/issues"
+dev-repo: "git+https://github.com/jcz2020/par.git"
+depends: [
+  "ocaml" {>= "5.4.0"}
+  "dune" {>= "3.16"}
+  "base"
+  "yojson"
+  "eio"
+  "eio_main"
+  "uuidm"
+  "ppx_deriving"
+  "ppx_deriving_yojson"
+  "ppx_deriving_jsonschema" {= "0.0.1"}
+  "ppx_sexp_conv"
+  "ppx_compare"
+  "sqlite3"
+  "logs"
+  "tls-eio"
+  "cohttp-eio"
+  "lambdasoup"
+  "ca-certs"
+  "x509"
+  "mirage-crypto-rng"
+  "base64"
+  "digestif"
+  "yaml"
+  "omd"
+  "camlpdf"
+  "camlzip"
+  "xmlm"
+  "csv"
+  "sexplib0"
+  "ctypes"
+  "alcotest" {with-test}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src:
+    "https://github.com/jcz2020/par/releases/download/v0.8.3/par-0.8.3.tar.gz"
+  checksum: [
+    "sha256=d160754ee4254150b935aaa0f6637f8e1911b8f8a528b320994769fb6577d2e2"
+    "sha512=9dfba0f17751d7acd6172a0bd9add9c969524b76f98308db6cba1cc90492f3eea0fa77c534a375bbb3b7b5b5fd6dbdc1c3a5700c44c441dd08e529720e4e8285"
+  ]
+}


### PR DESCRIPTION
Type-safe agent runtime for OCaml 5.4+ — ReAct engine, multi-provider LLM support (OpenAI / Anthropic / Ollama), workflow orchestration, SQLite persistence, HITL approval, parallel multi-agent dispatch.

This is the first submission of `par` to opam-repository. A previous attempt at v0.4.8 (#30086) was closed due to malformed submission (multiple empty files per package directory); a second attempt at v0.8.2 (#30406) was closed by the submitter after the source tarball was rebuilt during release-process iteration and the SHA-256 in the opam file no longer matched the published asset.

This submission is for v0.8.3 (released today), which includes three downstream-reported bug fixes on top of v0.8.2: reasoning model support (`reasoning_content` field + `Reasoning_delta` streaming variant), scope plumbing through FFI to Python, and OpenAI streaming usage fix.

- **Package**: `par` (single package; the previous `par_cli` was removed in v0.6.7 and the CLI now lives in a separate repo)
- **Version**: `0.8.3`
- **License**: MIT
- **Dependencies**: OCaml ≥ 5.4.0, dune ≥ 3.16, and ~25 standard opam packages (full list in opam file). `alcotest` is marked `{with-test}` per policy; `ppx_deriving_jsonschema` is pinned-justified in the dune-project comment (mirrored here for reviewer convenience: ≥0.0.6 changed PPX code generation, ≥0.0.7 added melange + server-reason-react as hard deps — inappropriate for pure native OCaml).
- **Homepage**: https://github.com/jcz2020/par
- **Docs**: https://jcz2020.github.io/par

Build verified on Ubuntu 22.04 and macOS 14 (arm64). 1516 OCaml tests passing. `opam lint` Passed.