### PR TITLE
[new release] grace (0.4.1)

### DIFF
--- a/packages/grace/grace.0.4.1/opam
+++ b/packages/grace/grace.0.4.1/opam
@@ -1,0 +1,46 @@
+opam-version: "2.0"
+synopsis:
+  "A fancy diagnostics library that allows your compilers to exit with grace"
+maintainer: ["alistair.obrien@trili.tech"]
+authors: ["Alistair O'Brien"]
+license: "MIT"
+homepage: "https://github.com/johnyob/grace"
+bug-reports: "https://github.com/johnyob/grace/issues"
+depends: [
+  "ocaml" {>= "4.14.0"}
+  "dune" {>= "3.4"}
+  "yojson" {>= "2.1.0"}
+  "fmt" {>= "0.8.7"}
+  "iter"
+  "sexplib"
+  "ppx_sexp_conv"
+  "dedent" {with-test}
+  "core" {with-test}
+  "core_unix" {with-test}
+  "ppx_jane" {with-test}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/johnyob/grace.git"
+url {
+  src:
+    "https://github.com/johnyob/grace/releases/download/0.4.1/grace-0.4.1.tbz"
+  checksum: [
+    "sha256=d49754224206de44855590848b3a5a6cc1d5c46cf99a4e5810ca3041d436a28e"
+    "sha512=2984b5a6284bf8bbd05419cf850c15c34bc19c19f0c8928b83cc1be1c0bfc84aafef6d992e7435c2f48ba361a6f3aab679abd02f0e6472361c8cec7d497bc405"
+  ]
+}
+x-commit-hash: "a03f7da053d6b57bb01f19f642c1f280253bb702"


### PR DESCRIPTION
A fancy diagnostics library that allows your compilers to exit with grace

- Project page: <a href="https://github.com/johnyob/grace">https://github.com/johnyob/grace</a>

##### CHANGES:

- fix(renderer): adjust margin for messages near end of line ([johnyob/grace#97](https://github.com/johnyob/grace/pull/97))
- fix(renderer): remove extra space in trailing labels ([johnyob/grace#98](https://github.com/johnyob/grace/pull/98))
- fix(renderer): error recovery on invalid UTF-8 strings ([johnyob/grace#99](https://github.com/johnyob/grace/pull/99))
