### PR TITLE
[new release] bisect_ppx (3.0.0)

### DIFF
--- a/packages/bisect_ppx/bisect_ppx.3.0.0/opam
+++ b/packages/bisect_ppx/bisect_ppx.3.0.0/opam
@@ -1,0 +1,57 @@
+opam-version: "2.0"
+synopsis: "Code coverage for OCaml"
+maintainer: ["Dmitrii Kosarev a.k.a. Kakadu <kakadu.hafanana@gmail.com"]
+authors: [
+  "Xavier Clerc <bisect@x9c.fr>"
+  "Leonid Rozenberg <leonidr@gmail.com>"
+  "Anton Bachin <antonbachin@yahoo.com>"
+]
+license: "MIT"
+homepage: "https://github.com/Kakadu/bisect_ppx_ng"
+doc: "https://github.com/Kakadu/bisect_ppx_ng"
+bug-reports: "https://github.com/Kakadu/bisect_ppx_ng"
+depends: [
+  "dune" {>= "3.18"}
+  "ocaml" {>= "4.14.2" & < "5.0.0" | >= "5.3.0"}
+  "ppxlib" {>= "0.36.0"}
+  "cmdliner" {>= "1.3.0"}
+  "js_of_ocaml" {with-test}
+  "js_of_ocaml-compiler" {with-test}
+  "reason" {with-test}
+  "odoc" {with-doc}
+]
+x-maintenance-intent: ["2.8.3" "(latest)"]
+description: "Bisect_ppx helps you test thoroughly. It is a small preprocessor
+that inserts instrumentation at places in your code, such as if-then-else and
+match expressions. After you run tests, Bisect_ppx gives a nice HTML report
+showing which places were visited and which were missed.
+
+Usage is simple - add package bisect_ppx when building tests, run your tests,
+then run the Bisect_ppx report tool on the generated visitation files."
+
+dev-repo: "git+https://github.com/Kakadu/bisect_ppx_ng.git"
+
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    # Bisect_ppx prints OCaml code a lot while testing and it is shaky between compiler versions
+    "@runtest" {with-test & ocaml:version >= "5.3.0" }
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src:
+    "https://github.com/Kakadu/bisect_ppx_ng/releases/download/3.0.0/bisect_ppx-3.0.0.tbz"
+  checksum: [
+    "sha256=6649b9a21c848777a1b6ee90dc9853aa1b70d632ba462678e548ec3b14de4202"
+    "sha512=77532433fa59b2dc4d72bd6d4dd35967805f057c4526f7f1ca834f3272b5268ee9dcd12398d621677aae986b7e48c604b2fcf78ccca833c59a463de38e118b0f"
+  ]
+}
+x-commit-hash: "c39d119e36bfa1d405fab8cfdac6d88b60e797b3"


### PR DESCRIPTION
Code coverage for OCaml

- Project page: <a href="https://github.com/Kakadu/bisect_ppx_ng">https://github.com/Kakadu/bisect_ppx_ng</a>
- Documentation: <a href="https://github.com/Kakadu/bisect_ppx_ng">https://github.com/Kakadu/bisect_ppx_ng</a>

##### CHANGES:

  Additions

  - OCaml 5.5 support
  - Move project to another maintainer while aantron is busy
