### PR TITLE
Add: mtime.2.2.0

### DIFF
--- a/packages/mtime/mtime.2.2.0/opam
+++ b/packages/mtime/mtime.2.2.0/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+synopsis: "Monotonic wall-clock time for OCaml"
+description: """\
+Mtime has platform independent support for monotonic wall-clock time
+in pure OCaml. This time increases monotonically and is not subject to
+operating system calendar time adjustments. The library has types to
+represent nanosecond precision timestamps and time spans.
+
+The additional Mtime_clock library provide access to a system
+monotonic clock.
+
+Mtime has a no dependency. Mtime_clock depends on your system library
+or JavaScript runtime system. Mtime and its libraries are distributed
+under the ISC license.
+
+Home page: <http://erratique.ch/software/mtime>"""
+maintainer: "Daniel Bünzli <daniel.buenzl i@erratique.ch>"
+authors: "The mtime programmers"
+license: "ISC"
+tags: ["time" "monotonic" "system" "org:erratique"]
+homepage: "https://erratique.ch/software/mtime"
+doc: "https://erratique.ch/software/mtime/doc/"
+bug-reports: "https://github.com/dbuenzli/mtime/issues"
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "ocamlfind" {build}
+  "ocamlbuild" {build & != "0.9.0"}
+  "topkg" {build & >= "1.1.0"}
+]
+build: ["ocaml" "pkg/pkg.ml" "build" "--dev-pkg" "%{dev}%"]
+dev-repo: "git+https://erratique.ch/repos/mtime.git"
+url {
+  src: "https://erratique.ch/software/mtime/releases/mtime-2.2.0.tbz"
+  checksum:
+    "sha512=c7d0ef764c3cc803b9c06216601057d5092b624ee313780df70f6a0a462f12671986af69c90e811038419cae4648c62acbef71398ceb8d0d3c9dcda6ff0fab80"
+}
+x-maintenance-intent: ["(latest)"]


### PR DESCRIPTION
* Add: `mtime.2.2.0` [home](https://erratique.ch/software/mtime), [doc](https://erratique.ch/software/mtime/doc/), [issues](https://github.com/dbuenzli/mtime/issues)  
  *Monotonic wall-clock time for OCaml*


---

#### `mtime` v2.2.0 2026-08-05 Zagreb

- Add `Mtime.Span.( + )`.
- `Mtime_clock`. Restore compatiblity with MacOS < 10.12. Before 10.12
  we use `mach_absolute_time` instead of `mach_continuous_time` which
  means that sleep time is not taken into account. Thanks to
  Sergey Fedorov for the report and help ([#51](https://github.com/dbuenzli/mtime/issues/51), [#52](https://github.com/dbuenzli/mtime/issues/52)).
- In 2.0.0, `Mtime_clock` was advertised to use `CLOCK_BOOTTIME` on Linux,
  except it seems that only `Mtime_clock.elapsed[_ns]` was updated to
  do so. This is now also used for `Mtime_clock.{now,period}[_ns]`
  ([#10](https://github.com/dbuenzli/mtime/issues/10)).

---

Use `b0 -- .opam publish mtime.2.2.0` to update the pull request.