### PR TITLE
[new release] httpcats (0.3.1)

### DIFF
--- a/packages/httpcats/httpcats.0.3.1/opam
+++ b/packages/httpcats/httpcats.0.3.1/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+maintainer: "Robur <team@robur.coop>"
+authors: ["Robur <team@robur.coop>"]
+homepage: "https://github.com/robur-coop/httpcats"
+dev-repo: "git+https://github.com/robur-coop/httpcats.git"
+bug-reports: "https://github.com/robur-coop/httpcats/issues"
+license: "BSD-3-clause"
+
+depends: [
+  "ocaml" {>= "5.0.0"}
+  "dune" {>= "2.8.0"}
+  "logs" {with-test}
+  "miou" {>= "0.6.0"}
+  "fmt" {>= "0.9.0" & with-test}
+  "h2" {>= "0.13.0"}
+  "h1" {>= "1.1.0"}
+  "ca-certs"
+  "bstr"
+  "tls-miou-unix" {>= "1.0.1"}
+  "dns-client-miou-unix" {>= "9.0.0"}
+  "happy-eyeballs-miou-unix"
+  "mirage-crypto-rng" {with-test & >= "1.1.0"}
+  "alcotest" {>= "1.8.0" & with-test}
+  "digestif" {with-test & >= "1.2.0"}
+]
+conflicts: [ "result" {< "1.5"} ]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+synopsis: "A simple HTTP client / server using h1, h2, and miou"
+available: [ arch != "x86_32" ]
+url {
+  src:
+    "https://github.com/robur-coop/httpcats/releases/download/v0.3.1/httpcats-0.3.1.tbz"
+  checksum: [
+    "sha256=e41ca6a32252e49ca44e749e7b41e148acdb1e46fc8fa08eb98eed66d1831a1d"
+    "sha512=7e736d5c0ecc2f1c63c39ce39b322cd88b85c9d50eda2021e20043b0c855e7d61107605434e14f7186d4b8488f8c1e1048058bce5c0b1195d5bb16b84999107c"
+  ]
+}
+x-commit-hash: "c1b3003b98ee09b9f8ce02c95657a12fa918c0cb"


### PR DESCRIPTION
A simple HTTP client / server using h1, h2, and miou

- Project page: <a href="https://github.com/robur-coop/httpcats">https://github.com/robur-coop/httpcats</a>

##### CHANGES:

- Use `mirage-crypto-rng.unix` instead of `mirage-crypto-rng-miou-unix`
  (@hannesm, @dinosaure, robur-coop/httpcats#63)
- Fix typo on documentation (@mneumann, robur-coop/httpcats#64)
- Compute once the authenticator when it's needed (@dinosaure, robur-coop/httpcats#65)
