### PR TITLE
[new release] arc (0.0.3)

### DIFF
--- a/packages/arc/arc.0.0.3/opam
+++ b/packages/arc/arc.0.0.3/opam
@@ -1,0 +1,38 @@
+opam-version: "2.0"
+synopsis: "ARC support in OCaml"
+description: "ARC implementation in OCaml"
+maintainer: "Romain Calascibetta <romain.calascibetta@gmail.com>"
+authors: "Romain Calascibetta <romain.calascibetta@gmail.com>"
+license: "MIT"
+homepage: "https://git.robur.coop/robur/ocaml-arc"
+doc: "https://robur-coop.github.io/ocaml-arc/"
+bug-reports: "https://git.robur.coop/robur/ocaml-arc"
+dev-repo: "git+https://github.com/robur-coop/ocaml-arc.git"
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "2.0.0"}
+  "dmarc"
+  "hxd"
+  "fmt"
+  "logs"
+  "dkim" {>= "0.11.0"}
+  "fpath"
+  "cmdliner"
+  "mirage-crypto-rng"
+  "dns-client-miou-unix"
+  "alcotest" {with-test}
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+x-maintenance-intent: [ "(latest)" ]
+url {
+  src:
+    "https://github.com/robur-coop/ocaml-arc/releases/download/v0.0.3/arc-0.0.3.tbz"
+  checksum: [
+    "sha256=95547ca2f7023fa4795daad6c6edb5ed09bca1535565a8423e2a14e55815e293"
+    "sha512=08411fcf6e21fd02ff13352ac01e938e6e97911738e98bcfaba5fd50f3aa6d7a4bd2656a25301c60f80ae6e7a938193ed4fdab62c2230fb0c172a4334d336a3d"
+  ]
+}
+x-commit-hash: "01d3d9016a61a5023c813e65ba383cd4b86e44b6"


### PR DESCRIPTION
ARC support in OCaml

- Project page: <a href="https://git.robur.coop/robur/ocaml-arc">https://git.robur.coop/robur/ocaml-arc</a>
- Documentation: <a href="https://robur-coop.github.io/ocaml-arc/">https://robur-coop.github.io/ocaml-arc/</a>

##### CHANGES:

- Use `mirage-crypto-rng.unix` instead of `mirage-crypto-rng-miou-unix`
  (@hannesm, [!6][6])

[6]: https://git.robur.coop/robur/ocaml-arc/pulls/6
