### PR TITLE
Package ninja_utils.2.0.0

### DIFF
--- a/packages/ninja_utils/ninja_utils.2.0.0/opam
+++ b/packages/ninja_utils/ninja_utils.2.0.0/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+synopsis:
+  "Small library used to generate Ninja build files"
+description:
+  "This library contains the implementations of utility functions used to generate Ninja build files -- see https://ninja-build.org. It's currently used by the Catala build system (see https://github.com/CatalaLang/catala/tree/master/build_system)"
+maintainer: ["contact@catala-lang.org"]
+authors: ["Emile Rolley"]
+license: "Apache-2.0"
+homepage: "https://github.com/CatalaLang/ninja_utils"
+bug-reports: "https://github.com/CatalaLang/ninja_utils/issues"
+depends: [
+  "dune" {>= "2.8"}
+  "ocaml" {>= "4.12.0"}
+  "re" {>= "1.10.3"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/CatalaLang/ninja_utils.git"
+url {
+  src:
+    "https://github.com/CatalaLang/ninja_utils/archive/refs/tags/2.0.0.tar.gz"
+  checksum: [
+    "md5=2e72b0f32b610cdeb94979af1b12da58"
+    "sha512=597761a4f34b4c63ca37da1fdc9585217d1f5ab70c83d35ff0a916c05e0bb84cbfd67a6e85c85581de341e4cd7c68b53f38255b5cf1e9ef2825820db27b63f34"
+  ]
+}


### PR DESCRIPTION
### `ninja_utils.2.0.0`
Small library used to generate Ninja build files
This library contains the implementations of utility functions used to generate Ninja build files -- see https://ninja-build.org. It's currently used by the Catala build system (see https://github.com/CatalaLang/catala/tree/master/build_system)



---
* Homepage: https://github.com/CatalaLang/ninja_utils
* Source repo: git+https://github.com/CatalaLang/ninja_utils.git
* Bug tracker: https://github.com/CatalaLang/ninja_utils/issues

---
:camel: Pull-request generated by opam-publish v2.5.1