### PR TITLE
Add par.0.8.4

### DIFF
--- a/packages/par/par.0.8.4/opam
+++ b/packages/par/par.0.8.4/opam
@@ -1,0 +1,70 @@
+opam-version: "2.0"
+synopsis: "Programmable Agent Runtime — type-safe agent SDK for OCaml 5.4+"
+description: """
+PAR is a modular agent runtime: ReAct engine, multi-provider LLM support
+(OpenAI / Anthropic / Ollama / custom), workflow orchestration, SQLite
+persistence, HITL approval, parallel multi-agent dispatch, and Python
+ctypes bindings.
+"""
+maintainer: ["P-A-R Contributors"]
+authors: ["P-A-R Contributors"]
+license: "MIT"
+tags: ["agents" "llm" "runtime" "ffi"]
+homepage: "https://github.com/jcz2020/par"
+bug-reports: "https://github.com/jcz2020/par/issues"
+dev-repo: "git+https://github.com/jcz2020/par.git"
+depends: [
+  "ocaml" {>= "5.4.0"}
+  "dune" {>= "3.16"}
+  "base"
+  "yojson"
+  "eio"
+  "eio_main"
+  "uuidm"
+  "ppx_deriving"
+  "ppx_deriving_yojson"
+  "ppx_deriving_jsonschema" {= "0.0.1"}
+  "ppx_sexp_conv"
+  "ppx_compare"
+  "sqlite3"
+  "logs"
+  "tls-eio"
+  "cohttp-eio"
+  "lambdasoup"
+  "ca-certs"
+  "x509"
+  "mirage-crypto-rng"
+  "base64"
+  "digestif"
+  "yaml"
+  "omd"
+  "camlpdf"
+  "camlzip"
+  "xmlm"
+  "csv"
+  "sexplib0"
+  "ctypes"
+  "alcotest" {with-test}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src:
+    "https://github.com/jcz2020/par/releases/download/v0.8.4/par-0.8.4.tar.gz"
+  checksum: [
+    "sha256=c7af980ff44791c9e36c881188b48d8ffe548b2dbe4ad35c44c204577bc6ac99"
+    "sha512=24cd0f15543920e9b412e581c88ac9a6a36ab8b4745ba380cfa37611de6cfcccd15df1ba9cee32034c1fe18ed4b5336ed51bb6eb34f5178f1105df003f2557f2"
+  ]
+}


### PR DESCRIPTION
Type-safe agent runtime for OCaml 5.4+ — ReAct engine, multi-provider LLM support (OpenAI / Anthropic / Ollama), workflow orchestration, SQLite persistence, HITL approval, parallel multi-agent dispatch.

Supersedes #30417 (v0.8.3). v0.8.4 is a single-bugfix PATCH on top of v0.8.3:

- **Fixed**: `test_mcp_runtime` mock-server path resolution. The previous tarball contained a hardcoded absolute path fallback (`/root/dev/PAR/_build/default/test/mcp_mock_server.exe`) that broke four MCP-runtime tests outside the developer's machine — caught by @Sudha247's review of #30417. Fix: resolve `mcp_mock_server.exe` as a sibling of `Sys.executable_name` (dune builds both into the same directory). Verified by simulating a tarball-build environment: 10/10 `test_mcp_runtime` cases pass.

The three v0.8.3 user-facing bug fixes (reasoning model support, scope plumbing, streaming usage) are unchanged and inherited.

- **Package**: `par` (single package)
- **Version**: `0.8.4`
- **License**: MIT
- **Dependencies**: OCaml ≥ 5.4.0, dune ≥ 3.16, and ~25 standard opam packages. `alcotest` is `{with-test}`; `ppx_deriving_jsonschema` is pinned-justified in the upstream dune-project (≥0.0.6 changed PPX code generation; ≥0.0.7 added melange + server-reason-react as hard deps — inappropriate for a pure native OCaml project).

Note on the cygwin failure that may recur here: camlpdf (a transitive dep via PAR's PDF loader) fails to compile its `flatestubs.o` C stub under the cygwin toolchain. This is upstream from PAR — the msys2 build of the same dependency tree is green. Deferring to maintainer judgement on whether `available: [os != "cygwin"]` or similar is the right call here, or whether this is something camlpdf needs to fix.

- **Homepage**: https://github.com/jcz2020/par
- **Docs**: https://jcz2020.github.io/par