### PR TITLE
[new release] ppx_expect_nobase (0.17.3.2)

### DIFF
--- a/packages/ppx_expect_nobase/ppx_expect_nobase.0.17.3.2/opam
+++ b/packages/ppx_expect_nobase/ppx_expect_nobase.0.17.3.2/opam
@@ -1,0 +1,44 @@
+opam-version: "2.0"
+synopsis: "Cram like framework for OCaml (with stripped dependencies)"
+description: """
+Testing framework: fork of ppx_expect, but with less dependecies.
+Original ppx_expect is a part of the Jane Street's PPX rewriters collection."""
+maintainer: ["Jane Street Group, LLC" "Dmitrii Kosarev a.k.a. Kakadu"]
+authors: ["Jane Street Group, LLC"]
+license: "MIT"
+homepage: "https://github.com/Kakadu/ppx_expect_nobase"
+bug-reports: "https://github.com/Kakadu/ppx_expect_nobase/issues"
+depends: [
+  "dune" {>= "3.23"}
+  "ocaml" {>= "4.14.2" & < "5.0.0" | >= "5.3.0" & < "5.6.0"}
+  "ppx_inline_test_nobase" {>= "v0.17.0.3"}
+  "sexplib"
+  "ppxlib" {>= "0.35.0"}
+  "dune-build-info"
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/Kakadu/ppx_expect_nobase.git"
+x-maintenance-intent: ["0.17.3.2" "(latest)"]
+url {
+  src:
+    "https://github.com/Kakadu/ppx_expect_nobase/releases/download/0.17.3.2/ppx_expect_nobase-0.17.3.2.tbz"
+  checksum: [
+    "sha256=d918035e8cc2765e691c1e9d22bda5983569ec7bc7c2da60424b4207c7c71aae"
+    "sha512=b708a075e154adc51494d84a88a120c759929fb021c3993dcfe6037c9ba143a379a8dc2550970e1134c744e0a9eec62df6f92bf5764d845164510a191b85d0f7"
+  ]
+}
+x-commit-hash: "5128c29f8f1c0879d699af933e4f56f2233c5907"

--- a/packages/ppx_expect_nobase/ppx_expect_nobase.v0.17.2.2/opam
+++ b/packages/ppx_expect_nobase/ppx_expect_nobase.v0.17.2.2/opam
@@ -29,4 +29,4 @@ url {
   src: "https://github.com/Kakadu/ppx_expect_nobase/archive/refs/tags/v0.17+nobase-2.tar.gz"
   checksum: "sha256=877bb0bf36fcc78566f6022d28d4ac1b67441b01cdac9a848fa942f21f969302"
 }
-x-maintenance-intent: [ "(latest)" ]
+x-maintenance-intent: ["0.17.3"] # Because I expect that "v0..." version will be archived sooner or later

--- a/packages/ppx_expect_nobase/ppx_expect_nobase.v0.17.3.0/opam
+++ b/packages/ppx_expect_nobase/ppx_expect_nobase.v0.17.3.0/opam
@@ -32,7 +32,8 @@ build: [
   ]
 ]
 dev-repo: "git+https://github.com/Kakadu/ppx_expect_nobase.git"
-x-maintenance-intent: ["(latest)"]
+x-maintenance-intent: ["0.17.3"] # Because I expect that "v0..." version will be archived sooner or later
+
 url {
   src:
     "https://github.com/Kakadu/ppx_expect_nobase/releases/download/v0.17.3.0/ppx_expect_nobase-0.17.3.0.tbz"


### PR DESCRIPTION
Cram like framework for OCaml (with stripped dependencies)

- Project page: <a href="https://github.com/Kakadu/ppx_expect_nobase">https://github.com/Kakadu/ppx_expect_nobase</a>

##### CHANGES:

* Remove dependecy on opam-core
