### PR TITLE
Package floatml.0.1.0

### DIFF
--- a/packages/floatml/floatml.0.1.0/opam
+++ b/packages/floatml/floatml.0.1.0/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+synopsis: "Floats (f16, f32, f64, f128) for OCaml"
+description:
+  "Deterministic, IEEE-754-compliant interface for floating point operators over f16, f32, f64 and f128, backed by Rust's rustc_apfloat. Requires a Rust toolchain (cargo) to build."
+maintainer: "opale.sjostedt@gmail.com"
+authors: "Opale Sjöstedt"
+license: "MIT"
+homepage: "https://github.com/N1ark/floatml"
+bug-reports: "https://github.com/N1ark/floatml/issues"
+depends: [
+  "ocaml" {>= "4.14.0"}
+  "dune" {>= "3.0" & >= "3.0"}
+  "zarith"
+  "conf-rust-2021" {build}
+  "odoc" {with-doc}
+]
+available:
+  arch != "arm32" & arch != "ppc64" & arch != "s390x" & arch != "x86_32" &
+  os != "win32"
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/N1ark/floatml.git"
+url {
+  src: "https://github.com/N1ark/floatml/archive/refs/tags/v0.1.0.tar.gz"
+  checksum: [
+    "md5=c942b3d6f5df50ef6287c7458c44efb6"
+    "sha512=65850e82ef62f1cd65597d311f0a1b92e2c78da68cbccf9dbffe0dfff00eb129ab5cf36a7669bdad380a57cf9977d4b5076c79541dd4dde09342e0862d0dfdda"
+  ]
+}


### PR DESCRIPTION
### `floatml.0.1.0`
Floats (f16, f32, f64, f128) for OCaml
Deterministic, IEEE-754-compliant interface for floating point operators over f16, f32, f64 and f128, backed by Rust's rustc_apfloat. Requires a Rust toolchain (cargo) to build.



---
* Homepage: https://github.com/N1ark/floatml
* Source repo: git+https://github.com/N1ark/floatml.git
* Bug tracker: https://github.com/N1ark/floatml/issues

---
:camel: Pull-request generated by opam-publish v3.0.1