### PR TITLE
[new release] mirage-crypto (6 packages) (2.3.0)

### DIFF
--- a/packages/mirage-crypto-ec/mirage-crypto-ec.2.3.0/opam
+++ b/packages/mirage-crypto-ec/mirage-crypto-ec.2.3.0/opam
@@ -1,0 +1,62 @@
+opam-version: "2.0"
+synopsis: "Elliptic Curve Cryptography with primitives taken from Fiat"
+description: """
+An implementation of key exchange (ECDH) and digital signature (ECDSA/EdDSA)
+algorithms using code from Fiat (<https://github.com/mit-plv/fiat-crypto>).
+
+The curves P256 (SECP256R1), P384 (SECP384R1),
+P521 (SECP521R1), and 25519 (X25519, Ed25519) are implemented by this package.
+"""
+maintainer: "Hannes Mehnert <hannes@mehnert.org>"
+authors: [
+  "Hannes Mehnert <hannes@mehnert.org>"
+  "Nathan Rebours <nathan.p.rebours@gmail.com>"
+  "Clément Pascutto <clement@tarides.com>"
+  "Etienne Millon <me@emillon.org>"
+  "Virgile Robles <virgile.robles@protonmail.ch>"
+# and from the fiat-crypto AUTHORS file
+  "Andres Erbsen <andreser@mit.edu>"
+  "Google Inc."
+  "Jade Philipoom <jadep@mit.edu> <jade.philipoom@gmail.com>"
+  "Massachusetts Institute of Technology"
+  "Zoe Paraskevopoulou <zoe.paraskevopoulou@gmail.com>"
+]
+license: "MIT"
+homepage: "https://github.com/mirage/mirage-crypto"
+doc: "https://mirage.github.io/mirage-crypto/doc"
+bug-reports: "https://github.com/mirage/mirage-crypto/issues"
+depends: [
+  "dune" {>= "2.7"}
+  "ocaml" {>= "4.13.0"}
+  "dune-configurator"
+  "eqaf" {>= "0.7"}
+  "mirage-crypto-rng" {=version}
+  "digestif" {>= "1.2.0"}
+  "alcotest" {with-test & >= "0.8.1"}
+  "ppx_deriving_yojson" {with-test}
+  "ppx_deriving" {with-test}
+  "yojson" {with-test & >= "1.6.0"}
+  "asn1-combinators" {with-test & >= "0.3.1"}
+  "ohex" {with-test & >= "0.2.0"}
+  "ounit2" {with-test}
+]
+conflicts: [
+  "ocaml-freestanding"
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/mirage/mirage-crypto.git"
+tags: ["org:mirage"]
+x-maintenance-intent: [ "(latest)" ]
+url {
+  src:
+    "https://github.com/mirage/mirage-crypto/releases/download/v2.3.0/mirage-crypto-2.3.0.tbz"
+  checksum: [
+    "sha256=840fbf4136605b4a1f1dd5c0611932a274fe3bf97464c82a6b3a9731a68e208e"
+    "sha512=8b983bf9e7fc03f3442b9e00f8ec562d6f0ae18702d10a9ca79182e135f85d1c264393d4033c78e51b945dbe4eb7f436a25ccfedeb0c1f9cdb4c46927cd94fbf"
+  ]
+}
+x-commit-hash: "00ed1238df988c6c109c753cedb87388d352a60c"

--- a/packages/mirage-crypto-pk/mirage-crypto-pk.2.3.0/opam
+++ b/packages/mirage-crypto-pk/mirage-crypto-pk.2.3.0/opam
@@ -1,0 +1,43 @@
+opam-version: "2.0"
+homepage:     "https://github.com/mirage/mirage-crypto"
+dev-repo:     "git+https://github.com/mirage/mirage-crypto.git"
+bug-reports:  "https://github.com/mirage/mirage-crypto/issues"
+doc:          "https://mirage.github.io/mirage-crypto/doc"
+authors:      ["David Kaloper <dk505@cam.ac.uk>" "Hannes Mehnert <hannes@mehnert.org>" ]
+maintainer:   "Hannes Mehnert <hannes@mehnert.org>"
+license:      "ISC"
+synopsis:     "Simple public-key cryptography for the modern age"
+
+build: [ ["dune" "subst"] {dev}
+         ["dune" "build" "-p" name "-j" jobs ]
+         ["dune" "runtest" "-p" name "-j" jobs] {with-test} ]
+
+depends: [
+  "conf-gmp-powm-sec" {build}
+  "ocaml" {>= "4.13.0"}
+  "dune" {>= "2.7"}
+  "ounit2" {with-test}
+  "randomconv" {with-test & >= "0.2.0"}
+  "ohex" {with-test & >= "0.2.0"}
+  "mirage-crypto" {=version}
+  "mirage-crypto-rng" {=version}
+  "digestif" {>= "1.2.0"}
+  "zarith" {>= "1.13"}
+  "eqaf" {>= "0.8"}
+]
+conflicts: [
+  "ocaml-freestanding"
+]
+description: """
+Mirage-crypto-pk provides public-key cryptography (RSA, DSA, DH).
+"""
+x-maintenance-intent: [ "(latest)" ]
+url {
+  src:
+    "https://github.com/mirage/mirage-crypto/releases/download/v2.3.0/mirage-crypto-2.3.0.tbz"
+  checksum: [
+    "sha256=840fbf4136605b4a1f1dd5c0611932a274fe3bf97464c82a6b3a9731a68e208e"
+    "sha512=8b983bf9e7fc03f3442b9e00f8ec562d6f0ae18702d10a9ca79182e135f85d1c264393d4033c78e51b945dbe4eb7f436a25ccfedeb0c1f9cdb4c46927cd94fbf"
+  ]
+}
+x-commit-hash: "00ed1238df988c6c109c753cedb87388d352a60c"

--- a/packages/mirage-crypto-rng-mirage/mirage-crypto-rng-mirage.2.3.0/opam
+++ b/packages/mirage-crypto-rng-mirage/mirage-crypto-rng-mirage.2.3.0/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+homepage:     "https://github.com/mirage/mirage-crypto"
+dev-repo:     "git+https://github.com/mirage/mirage-crypto.git"
+bug-reports:  "https://github.com/mirage/mirage-crypto/issues"
+doc:          "https://mirage.github.io/mirage-crypto/doc"
+authors:      ["David Kaloper <dk505@cam.ac.uk>" "Hannes Mehnert <hannes@mehnert.org>" ]
+maintainer:   "Hannes Mehnert <hannes@mehnert.org>"
+license:      "BSD-2-Clause"
+synopsis:     "Entropy collection for a cryptographically secure PRNG"
+
+build: [ ["dune" "subst"] {dev}
+         ["dune" "build" "-p" name "-j" jobs ]
+         ["dune" "runtest" "-p" name "-j" jobs] {with-test} ]
+
+depends: [
+  "ocaml" {>= "4.13.0"}
+  "dune" {>= "2.7"}
+  "mirage-crypto-rng" {=version}
+  "duration"
+  "logs"
+  "lwt" {>= "4.0.0"}
+  "mirage-runtime" {>= "3.8.0"}
+  "mirage-sleep" {>= "4.0.0"}
+  "mirage-mtime" {>= "4.0.0"}
+  "mirage-unix" {with-test & >= "5.0.0"}
+  "ohex" {with-test & >= "0.2.0"}
+]
+description: """
+Mirage-crypto-rng-mirage provides entropy collection code for the RNG.
+"""
+x-maintenance-intent: [ "(latest)" ]
+url {
+  src:
+    "https://github.com/mirage/mirage-crypto/releases/download/v2.3.0/mirage-crypto-2.3.0.tbz"
+  checksum: [
+    "sha256=840fbf4136605b4a1f1dd5c0611932a274fe3bf97464c82a6b3a9731a68e208e"
+    "sha512=8b983bf9e7fc03f3442b9e00f8ec562d6f0ae18702d10a9ca79182e135f85d1c264393d4033c78e51b945dbe4eb7f436a25ccfedeb0c1f9cdb4c46927cd94fbf"
+  ]
+}
+x-commit-hash: "00ed1238df988c6c109c753cedb87388d352a60c"

--- a/packages/mirage-crypto-rng-mkernel/mirage-crypto-rng-mkernel.2.3.0/opam
+++ b/packages/mirage-crypto-rng-mkernel/mirage-crypto-rng-mkernel.2.3.0/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+homepage:     "https://github.com/mirage/mirage-crypto"
+dev-repo:     "git+https://github.com/mirage/mirage-crypto.git"
+bug-reports:  "https://github.com/mirage/mirage-crypto/issues"
+doc:          "https://mirage.github.io/mirage-crypto/doc"
+authors:      ["Romain Calascibetta <romain.calascibetta@gmail.com>" ]
+maintainer:   "Romain Calascibetta <romain.calascibetta@gmail.com>"
+license:      "ISC"
+synopsis:     "Feed the entropy source in a mkernel friendly way"
+
+build: [ ["dune" "subst"] {dev}
+         ["dune" "build" "-p" name "-j" jobs ]
+         ["dune" "runtest" "-p" name "-j" jobs] {with-test} ]
+
+depends: [
+  "ocaml" {>= "5.0.0"}
+  "dune" {>= "2.7"}
+  "miou" {>= "0.2.0"}
+  "logs"
+  "mirage-crypto-rng" {=version}
+  "duration"
+  "digestif" {>= "1.2.0"}
+  "mkernel"
+  "ohex" {with-test & >= "0.2.0"}
+]
+description: """
+Mirage-crypto-rng-mkernel feeds the entropy source for Mirage_crypto_rng-based
+random number generator implementations, in a mkernel friendly way.
+"""
+x-maintenance-intent: [ "(latest)" ]
+url {
+  src:
+    "https://github.com/mirage/mirage-crypto/releases/download/v2.3.0/mirage-crypto-2.3.0.tbz"
+  checksum: [
+    "sha256=840fbf4136605b4a1f1dd5c0611932a274fe3bf97464c82a6b3a9731a68e208e"
+    "sha512=8b983bf9e7fc03f3442b9e00f8ec562d6f0ae18702d10a9ca79182e135f85d1c264393d4033c78e51b945dbe4eb7f436a25ccfedeb0c1f9cdb4c46927cd94fbf"
+  ]
+}
+x-commit-hash: "00ed1238df988c6c109c753cedb87388d352a60c"

--- a/packages/mirage-crypto-rng/mirage-crypto-rng.2.3.0/opam
+++ b/packages/mirage-crypto-rng/mirage-crypto-rng.2.3.0/opam
@@ -1,0 +1,42 @@
+opam-version: "2.0"
+homepage:     "https://github.com/mirage/mirage-crypto"
+dev-repo:     "git+https://github.com/mirage/mirage-crypto.git"
+bug-reports:  "https://github.com/mirage/mirage-crypto/issues"
+doc:          "https://mirage.github.io/mirage-crypto/doc"
+authors:      ["David Kaloper <dk505@cam.ac.uk>" "Hannes Mehnert <hannes@mehnert.org>" ]
+maintainer:   "Hannes Mehnert <hannes@mehnert.org>"
+license:      "BSD-2-Clause"
+synopsis:     "A cryptographically secure PRNG"
+
+build: [ ["dune" "subst"] {dev}
+         ["dune" "build" "-p" name "-j" jobs ]
+         ["dune" "runtest" "-p" name "-j" jobs] {with-test} ]
+
+depends: [
+  "ocaml" {>= "4.14.0"}
+  "dune" {>= "2.7"}
+  "dune-configurator" {>= "2.0.0"}
+  "duration"
+  "logs"
+  "mirage-crypto" {=version}
+  "digestif" {>= "1.1.4"}
+  "ounit2" {with-test}
+  "randomconv" {with-test & >= "0.2.0"}
+  "ohex" {with-test & >= "0.2.0"}
+]
+conflicts: [ "mirage-runtime" {< "3.8.0"} ]
+description: """
+Mirage-crypto-rng provides a random number generator interface, and
+implementations: Fortuna, HMAC-DRBG, getrandom/getentropy based (in the unix
+sublibrary)
+"""
+x-maintenance-intent: [ "(latest)" ]
+url {
+  src:
+    "https://github.com/mirage/mirage-crypto/releases/download/v2.3.0/mirage-crypto-2.3.0.tbz"
+  checksum: [
+    "sha256=840fbf4136605b4a1f1dd5c0611932a274fe3bf97464c82a6b3a9731a68e208e"
+    "sha512=8b983bf9e7fc03f3442b9e00f8ec562d6f0ae18702d10a9ca79182e135f85d1c264393d4033c78e51b945dbe4eb7f436a25ccfedeb0c1f9cdb4c46927cd94fbf"
+  ]
+}
+x-commit-hash: "00ed1238df988c6c109c753cedb87388d352a60c"

--- a/packages/mirage-crypto/mirage-crypto.2.3.0/opam
+++ b/packages/mirage-crypto/mirage-crypto.2.3.0/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+homepage:     "https://github.com/mirage/mirage-crypto"
+dev-repo:     "git+https://github.com/mirage/mirage-crypto.git"
+bug-reports:  "https://github.com/mirage/mirage-crypto/issues"
+doc:          "https://mirage.github.io/mirage-crypto/doc"
+authors:      ["David Kaloper <dk505@cam.ac.uk>" "Hannes Mehnert <hannes@mehnert.org>" ]
+maintainer:   "Hannes Mehnert <hannes@mehnert.org>"
+license:      "ISC"
+synopsis:     "Simple symmetric cryptography for the modern age"
+
+build: [ ["dune" "subst"] {dev}
+         ["dune" "build" "-p" name "-j" jobs ]
+         ["dune" "runtest" "-p" name "-j" jobs] {with-test} ]
+
+depends: [
+  "ocaml" {>= "4.13.0"}
+  "dune" {>= "2.7"}
+  "dune-configurator" {>= "2.0.0"}
+  "ounit2" {with-test}
+  "ohex" {with-test & >= "0.2.0"}
+  "eqaf" {>= "0.8"}
+]
+conflicts: [
+  "ocaml-freestanding"
+  "result" {< "1.5"}
+]
+description: """
+Mirage-crypto provides symmetric ciphers (DES, AES, RC4, ChaCha20/Poly1305).
+"""
+x-maintenance-intent: [ "(latest)" ]
+url {
+  src:
+    "https://github.com/mirage/mirage-crypto/releases/download/v2.3.0/mirage-crypto-2.3.0.tbz"
+  checksum: [
+    "sha256=840fbf4136605b4a1f1dd5c0611932a274fe3bf97464c82a6b3a9731a68e208e"
+    "sha512=8b983bf9e7fc03f3442b9e00f8ec562d6f0ae18702d10a9ca79182e135f85d1c264393d4033c78e51b945dbe4eb7f436a25ccfedeb0c1f9cdb4c46927cd94fbf"
+  ]
+}
+x-commit-hash: "00ed1238df988c6c109c753cedb87388d352a60c"


### PR DESCRIPTION
Simple symmetric cryptography for the modern age

- Project page: <a href="https://github.com/mirage/mirage-crypto">https://github.com/mirage/mirage-crypto</a>
- Documentation: <a href="https://mirage.github.io/mirage-crypto/doc">https://mirage.github.io/mirage-crypto/doc</a>

##### CHANGES:

- mirage-crypto-pk: RSA: avoid Invalid_argument when message is < 2, instead
  raise Insufficient_key which is already documented and caught by clients
  (OSEC-2026-14, report by @samoht,
  fix a0f59a0c90eb067505b55a03d3bb104eacd6dd33 by @hannesm)
- mirage-crypto-ec: NIST: add bounds check for compressed public keys (both for
  Dsa.pub_of_octets and Dh.key_exchange) (OSEC-2026-15, reported by @samoht,
  fix 1f0bf67044e67cf6e46911fcd77a0ff706b6c3e7 by @hannesm)
- mirage-crypto: count_16_be_4: avoid unaligned access that causes bus error on
  armhf (mirage/mirage-crypto#292 @glondu)
- mirage-crypto-rng: remove `[@@noalloc]` annotations on `getrandom` - it
  eventually calls `uerror` (mirage/mirage-crypto#287 @samoht)
- mirage-crypto-rng: avoid zero-length `getentropy` call on BSD and macOS
  (mirage/mirage-crypto#288 @samoht)
- mirage-crypto-pk: Dsa.sign: avoid division by 0 when k is 0 (mirage/mirage-crypto#289 @samoht)
- mirage-crypto: add checks that length is positive in AEAD cipher modes
  (mirage/mirage-crypto#290 @samoht)
- mirage-crypto-pk: blind Dsa using (k * b) ^ -1 instead of k ^ -1 * b ^ -1
  to avoid expensive inversion (mirage/mirage-crypto#294 @hannesm)
- install proper licenses for packages (mirage/mirage-crypto#293 @hannesm)
