### PR TITLE
[new release] prometheus (3 packages) (1.4)

### DIFF
--- a/packages/current/current.0.5/opam
+++ b/packages/current/current.0.5/opam
@@ -26,7 +26,7 @@ depends: [
   "cmdliner"
   "sqlite3"
   "duration"
-  "prometheus"
+  "prometheus" {< "1.4"}
   "dune" {>= "2.0"}
   "re" {>= "1.9.0"}
   "lwt-dllist"

--- a/packages/current/current.0.6.2/opam
+++ b/packages/current/current.0.6.2/opam
@@ -27,7 +27,7 @@ depends: [
   "cmdliner" {>= "1.1.0"}
   "sqlite3"
   "duration"
-  "prometheus"
+  "prometheus" {< "1.4"}
   "dune" {>= "2.9"}
   "re" {>= "1.9.0"}
   "lwt-dllist"

--- a/packages/current/current.0.7.1/opam
+++ b/packages/current/current.0.7.1/opam
@@ -59,7 +59,7 @@ depends: [
   "lwt" {>= "5.7"}
   "lwt-dllist"
   "ppx_deriving"
-  "prometheus"
+  "prometheus" {< "1.4"}
   "re" {>= "1.9.0"}
   "result" {>= "1.5"}
   "sqlite3"

--- a/packages/current/current.0.7.2/opam
+++ b/packages/current/current.0.7.2/opam
@@ -59,7 +59,7 @@ depends: [
   "lwt" {>= "5.7"}
   "lwt-dllist"
   "ppx_deriving"
-  "prometheus"
+  "prometheus" {< "1.4"}
   "re" {>= "1.9.0"}
   "result" {>= "1.5"}
   "sqlite3"

--- a/packages/current/current.0.7.3/opam
+++ b/packages/current/current.0.7.3/opam
@@ -59,7 +59,7 @@ depends: [
   "lwt" {>= "5.7"}
   "lwt-dllist"
   "ppx_deriving"
-  "prometheus"
+  "prometheus" {< "1.4"}
   "re" {>= "1.9.0"}
   "result" {>= "1.5"}
   "sqlite3"

--- a/packages/current/current.0.7.4/opam
+++ b/packages/current/current.0.7.4/opam
@@ -59,7 +59,7 @@ depends: [
   "lwt" {>= "5.7"}
   "lwt-dllist"
   "ppx_deriving"
-  "prometheus"
+  "prometheus" {< "1.4"}
   "re" {>= "1.9.0"}
   "result" {>= "1.5"}
   "sqlite3"

--- a/packages/current/current.0.7.5/opam
+++ b/packages/current/current.0.7.5/opam
@@ -65,7 +65,7 @@ depends: [
   "sqlite3"
   "alcotest" {with-test & >= "1.2.0"}
   "alcotest-lwt" {with-test & >= "1.2.0"}
-  "prometheus-app" {with-test & >= "1.2"}
+  "prometheus-app" {with-test & >= "1.2" & < "1.4"}
   "odoc" {with-doc}
 ]
 build: [

--- a/packages/current_web/current_web.0.7.5/opam
+++ b/packages/current_web/current_web.0.7.5/opam
@@ -66,7 +66,7 @@ depends: [
   "ppx_deriving_yojson" {>= "3.5.1"}
   "ppx_sexp_conv" {>= "v0.14.1"}
   "prometheus" {>= "0.7"}
-  "prometheus-app" {>= "1.2"}
+  "prometheus-app" {>= "1.2" & < "1.4"}
   "re" {>= "1.9.0"}
   "result" {>= "1.5"}
   "routes" {>= "2.0.0"}

--- a/packages/ocluster/ocluster.0.1/opam
+++ b/packages/ocluster/ocluster.0.1/opam
@@ -16,7 +16,7 @@ homepage: "https://github.com/ocurrent/ocluster"
 bug-reports: "https://github.com/ocurrent/ocluster/issues"
 depends: [
   "dune" {>= "2.5"}
-  "prometheus"
+  "prometheus" {< "1.4"}
   "ppx_sexp_conv"
   "dune-build-info"
   "ocluster-api" {= version}

--- a/packages/ocluster/ocluster.0.2.1/opam
+++ b/packages/ocluster/ocluster.0.2.1/opam
@@ -37,7 +37,7 @@ depends: [
   "obuilder" {>= "0.5.1" & < "0.6.0"}
   "ppx_expect" {>= "v0.14.1"}
   "ppx_sexp_conv"
-  "prometheus"
+  "prometheus" {< "1.4"}
   "prometheus-app" {>= "1.2"}
   "psq" {>= "0.2.1"}
   "sqlite3"

--- a/packages/ocluster/ocluster.0.2/opam
+++ b/packages/ocluster/ocluster.0.2/opam
@@ -18,7 +18,7 @@ bug-reports: "https://github.com/ocurrent/ocluster/issues"
 depends: [
   "dune" {>= "3.3" & < "3.6.0"}
   "ppx_expect" {>= "v0.14.1"}
-  "prometheus" {>= "1.2"}
+  "prometheus" {>= "1.2" & < "1.4"}
   "ppx_sexp_conv"
   "dune-build-info"
   "ocluster-api" {= version}

--- a/packages/ocluster/ocluster.0.3.0/opam
+++ b/packages/ocluster/ocluster.0.3.0/opam
@@ -46,7 +46,7 @@ depends: [
   "obuilder" {>= "0.6.0" & < "0.7.0"}
   "ppx_expect" {>= "v0.14.1"}
   "ppx_sexp_conv"
-  "prometheus"
+  "prometheus" {< "1.4"}
   "prometheus-app" {>= "1.2"}
   "psq" {>= "0.2.1"}
   "sqlite3"

--- a/packages/ocluster/ocluster.0.4.0/opam
+++ b/packages/ocluster/ocluster.0.4.0/opam
@@ -47,7 +47,7 @@ depends: [
   "ppx_expect" {>= "v0.14.1"}
   "ppx_sexp_conv"
   "prometheus"
-  "prometheus-app" {>= "1.2"}
+  "prometheus-app" {>= "1.2" & "1.4"}
   "psq" {>= "0.2.1"}
   "sqlite3"
   "winsvc" {>= "1.0.1" & os = "win32"}

--- a/packages/prometheus-app/prometheus-app.1.4/opam
+++ b/packages/prometheus-app/prometheus-app.1.4/opam
@@ -1,0 +1,54 @@
+opam-version: "2.0"
+synopsis: "Client library for Prometheus monitoring"
+description: """\
+Applications can enable metric reporting using the `prometheus-app` opam package.
+This depends on cohttp and can serve the metrics collected above over HTTP.
+
+The `prometheus-app.unix` ocamlfind library provides the `Prometheus_unix` module,
+which includes a cmdliner option and pre-configured web-server.
+See the `examples/example.ml` program for an example, which can be run as:
+
+```shell
+$ dune exec -- examples/example.exe --listen-prometheus=9090
+If run with the option --listen-prometheus=9090, this program serves metrics at
+http://localhost:9090/metrics
+Tick!
+Tick!
+...
+```
+
+Unikernels can use `Prometheus_app` instead of `Prometheus_unix` to avoid the `Unix` dependency."""
+maintainer: "talex5@gmail.com"
+authors: ["Thomas Leonard" "David Scott"]
+license: "Apache-2.0"
+homepage: "https://github.com/mirage/prometheus"
+doc: "https://mirage.github.io/prometheus/"
+bug-reports: "https://github.com/mirage/prometheus/issues"
+depends: [
+  "ocaml" {>= "4.11.0"}
+  "dune" {>= "2.3"}
+  "prometheus" {= version}
+  "fmt" {>= "0.8.7"}
+  "re"
+  "cohttp-lwt" {>= "4.0.0"}
+  "cohttp-lwt-unix" {>= "4.0.0"}
+  "lwt" {>= "2.5.0"}
+  "cmdliner"
+  "alcotest" {with-test}
+  "alcotest-lwt" {with-test}
+  "logs" {>= "0.6.0"}
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/mirage/prometheus.git"
+url {
+  src:
+    "https://github.com/mirage/prometheus/releases/download/v1.4/prometheus-1.4.tbz"
+  checksum: [
+    "sha256=1fd4a3e46bfcae5037209512a3b2d922be61308f43b736e31bed2a5698a00db7"
+    "sha512=54520a6202f9e0925d91fa4460d1256879db2fbcbca5267b90b6f0328c7e7f724dc0df0c5fb20dde973f8f972d8a47ae50e2ef8cb0b5e20bfd1c7128193f91b1"
+  ]
+}
+x-commit-hash: "e480680647fad821729c89928fc1f9bc30bd2a53"

--- a/packages/prometheus-lwt/prometheus-lwt.1.4/opam
+++ b/packages/prometheus-lwt/prometheus-lwt.1.4/opam
@@ -1,0 +1,33 @@
+opam-version: "2.0"
+synopsis: "Lwt support for Prometheus monitoring"
+description: "Lwt collectors and timing helpers for Prometheus metrics."
+maintainer: "talex5@gmail.com"
+authors: ["Thomas Leonard" "Anil Madhavapeddy" "David Scott"]
+license: "Apache-2.0"
+homepage: "https://github.com/mirage/prometheus"
+doc: "https://mirage.github.io/prometheus/"
+bug-reports: "https://github.com/mirage/prometheus/issues"
+depends: [
+  "ocaml" {>= "4.11.0"}
+  "dune" {>= "2.3"}
+  "prometheus" {= version}
+  "lwt" {>= "2.5.0"}
+  "prometheus-app" {= version & with-test}
+  "fmt" {>= "0.8.7" & with-test}
+  "alcotest" {with-test}
+  "alcotest-lwt" {with-test}
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/mirage/prometheus.git"
+url {
+  src:
+    "https://github.com/mirage/prometheus/releases/download/v1.4/prometheus-1.4.tbz"
+  checksum: [
+    "sha256=1fd4a3e46bfcae5037209512a3b2d922be61308f43b736e31bed2a5698a00db7"
+    "sha512=54520a6202f9e0925d91fa4460d1256879db2fbcbca5267b90b6f0328c7e7f724dc0df0c5fb20dde973f8f972d8a47ae50e2ef8cb0b5e20bfd1c7128193f91b1"
+  ]
+}
+x-commit-hash: "e480680647fad821729c89928fc1f9bc30bd2a53"

--- a/packages/prometheus/prometheus.1.4/opam
+++ b/packages/prometheus/prometheus.1.4/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+synopsis: "Client library for Prometheus monitoring"
+maintainer: "talex5@gmail.com"
+authors: ["Thomas Leonard" "David Scott"]
+license: "Apache-2.0"
+homepage: "https://github.com/mirage/prometheus"
+doc: "https://mirage.github.io/prometheus/"
+bug-reports: "https://github.com/mirage/prometheus/issues"
+depends: [
+  "ocaml" {>= "4.11.0"}
+  "dune" {>= "2.3"}
+  "re"
+  "lwt" {>= "2.5.0"}
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/mirage/prometheus.git"
+description: """
+To run services reliably, it is useful if they can report various metrics
+(for example, heap size, queue lengths, number of warnings logged, etc).
+
+A monitoring service can be configured to collect this data regularly.
+The data can be graphed to help understand the performance of the service over time,
+or to help debug problems quickly.
+It can also be used to send alerts if a service is down or behaving poorly.
+"""
+url {
+  src:
+    "https://github.com/mirage/prometheus/releases/download/v1.4/prometheus-1.4.tbz"
+  checksum: [
+    "sha256=1fd4a3e46bfcae5037209512a3b2d922be61308f43b736e31bed2a5698a00db7"
+    "sha512=54520a6202f9e0925d91fa4460d1256879db2fbcbca5267b90b6f0328c7e7f724dc0df0c5fb20dde973f8f972d8a47ae50e2ef8cb0b5e20bfd1c7128193f91b1"
+  ]
+}
+x-commit-hash: "e480680647fad821729c89928fc1f9bc30bd2a53"


### PR DESCRIPTION
Client library for Prometheus monitoring

- Project page: <a href="https://github.com/mirage/prometheus">https://github.com/mirage/prometheus</a>
- Documentation: <a href="https://mirage.github.io/prometheus/">https://mirage.github.io/prometheus/</a>

##### CHANGES:

Core/Lwt split:

- Add a new `prometheus-lwt` metrics package (@avsm @mtelvers @talex5 mirage/prometheus#66, reviewed by @dinosaure)

  This release is not a breaking change, but instead prepares for
  deprecation of Lwt in the core package so a future release can remove Lwt
  from the `prometheus` core. Users of the core's Lwt-typed functions
  should migrate to `Prometheus_lwt` now. Code using the new interface will
  keep working unchanged in future releases.

- Add synchronous variants of the timing helpers to the core. Metric recording
  is synchronous and these will become the only core timing helpers once the
  Lwt-typed ones move to `prometheus-lwt`.

- The replacement time-based functions no longer take a `gettime` argument.
  Instead, this is provided once by the new `Prometheus.init` function,
  which is called automatically when using `Prometheus_unix`.

To migrate existing code, add a dep on `prometheus-lwt` and rename following
the deprecation warnings from the compiler. If you collect metrics but aren't
using `Prometheus_unix` then add a call to `Prometheus.init`.

Bug fixes:

- Format floats with `%.17g` (@samoht @talex5 mirage/prometheus#62).
  The text exposition formatter printed metric values with `%f`,
  so any magnitude below ~5e-7 was reported as 0.000000.

Other changes:

- Remove `Astring` dependency (@talex5 mirage/prometheus#63).

- Remove `Asetmap` dependency (@talex5 mirage/prometheus#64).
  This changes the types of `LabelSetMap` and `MetricFamilyMap` slightly,
  which might affect custom reporters.
