### PR TITLE
git-net < 0.2.3: restrict to decompress < 1.6.0

### DIFF
--- a/packages/git-net/git-net.0.2.0/opam
+++ b/packages/git-net/git-net.0.2.0/opam
@@ -35,7 +35,7 @@ build: [
                & os-distribution != "opensuse"}
 ]
 x-maintenance-intent: [ "(latest)" ]
-x-ci-accept-failures: [ "alpine-3.21" "fedora-41" "fedora-42" "opensuse-15.6" "opensuse-tumbleweed" ]
+x-ci-accept-failures: [ "alpine-3.21" "fedora-41" "fedora-42" "opensuse-15.6" "opensuse-tumbleweed" "opensuse-16.0" "centos-9" "centos-10" ]
 url {
   src:
     "https://github.com/robur-coop/git-kv/releases/download/v0.2.0/git-kv-0.2.0.tbz"

--- a/packages/git-net/git-net.0.2.0/opam
+++ b/packages/git-net/git-net.0.2.0/opam
@@ -23,6 +23,7 @@ depends: [
   "mimic-happy-eyeballs"
   "happy-eyeballs-lwt"
   "alcotest" {with-test}
+  "decompress" {< "1.6.0"}
 ]
 
 build: [

--- a/packages/git-net/git-net.0.2.1/opam
+++ b/packages/git-net/git-net.0.2.1/opam
@@ -35,7 +35,7 @@ build: [
                & os-distribution != "opensuse"}
 ]
 x-maintenance-intent: [ "(latest)" ]
-x-ci-accept-failures: [ "centos-9" "alpine-3.21" "fedora-41" "fedora-42" "opensuse-15.6" "opensuse-16.0" "opensuse-tumbleweed" ]
+x-ci-accept-failures: [ "centos-9" "alpine-3.21" "fedora-41" "fedora-42" "opensuse-15.6" "opensuse-16.0" "opensuse-tumbleweed" "centos-10" ]
 url {
   src:
     "https://github.com/robur-coop/git-kv/releases/download/v0.2.1/git-kv-0.2.1.tbz"

--- a/packages/git-net/git-net.0.2.1/opam
+++ b/packages/git-net/git-net.0.2.1/opam
@@ -23,6 +23,7 @@ depends: [
   "mimic-happy-eyeballs"
   "happy-eyeballs-lwt"
   "alcotest" {with-test}
+  "decompress" {< "1.6.0"}
 ]
 
 build: [

--- a/packages/git-net/git-net.0.2.2/opam
+++ b/packages/git-net/git-net.0.2.2/opam
@@ -24,6 +24,7 @@ depends: [
   "happy-eyeballs-lwt"
   "alcotest" {with-test}
   "conf-git-daemon" {with-test}
+  "decompress" {< "1.6.0"}
 ]
 
 build: [


### PR DESCRIPTION
```
=== ERROR while compiling git-net.0.2.0 ======================================#
 context              2.6.0~alpha1 | linux/x86_64 | ocaml-base-compiler.4.14.4 | file:///home/opam/opam-repository
 path                 ~/.opam/4.14/.opam-switch/build/git-net.0.2.0
 command              ~/.opam/opam-init/hooks/sandbox.sh build dune runtest -p git-net -j 71
 exit-code            1
 env-file             ~/.opam/log/git-net-7-5865cd.env
 output-file          ~/.opam/log/git-net-7-5865cd.out
 ## output ###
 File "test/simple.t", line 1, characters 0-0:
 /usr/bin/git --no-pager diff --no-index --color=always -u _build/default/test/simple.t _build/default/test/simple.t.corrected
 diff --git a/_build/default/test/simple.t b/_build/default/test/simple.t.corrected
 index 9c1549d..372a8bb 100644
 --- a/_build/default/test/simple.t
 +++ b/_build/default/test/simple.t.corrected
 @@ -21,8 +21,8 @@ Simple test of our Git Key-Value store
    > EOF
    00000000: 4865 6c6c 6f20 576f 726c 6421 0a         Hello World!.
    $ tail -c20 db.pack | hxd.xxd
 -  00000000: e4b2 3437 2e7e 3d7e 8508 3912 3d87 11cd  ..47.~=~..9.=...
 -  00000010: 9942 7147                                .BqG
 +  00000000: fa62 0e75 0472 30de 07c2 2f17 6a20 b052  .b.u.r0.../.j .R
 +  00000010: 5c72 8519                                \r..
    $ mgit git://localhost/simple db.pack <<EOF
    > get /foo
    > quit
 (cd _build/default/test && ./tests.exe)
 Testing `Git-KV alcotest tests'.
 This run has ID `66OILF1Q'.

   [OK]          Basic tests          0   Read in change_and_push.
   [OK]          Basic tests          1   Set outside change_and_push.
   [OK]          Basic tests          2   Remove in change_and_push.
   [OK]          Basic tests          3   Last modified in change_and_push.
   [OK]          Basic tests          4   Digest in change_and_push.
   [OK]          Basic tests          5   Multiple change_and_push.

 Full test results in `~/.opam/4.14/.opam-switch/build/git-net.0.2.0/_build/default/test/_build/_tests/Git-KV alcotest tests'.
 Test Successful in 0.052s. 6 tests run.
```