### PR TITLE
[new package] smaji_glyph_path (0.1.0)

### DIFF
--- a/packages/smaji_glyph_path/smaji_glyph_path.0.1.0/opam
+++ b/packages/smaji_glyph_path/smaji_glyph_path.0.1.0/opam
@@ -1,0 +1,38 @@
+opam-version: "2.0"
+synopsis: "Smaji Glyph Path"
+description: """
+An OCaml library for manipulation of font glyph outlines. It provides a suite of tools for analyzing, transforming, composing, and converting glyph paths between different formats.
+"""
+maintainer: ["ZAN DoYe <zandoye+ocaml@gmail.com>"]
+authors: ["ZAN DoYe"]
+license: "GPL-2.0-only"
+homepage: "https://github.com/smaji-org/smaji_glyph_path"
+bug-reports: "https://github.com/smaji-org/smaji_glyph_path/issues"
+depends: [
+  "dune" {>= "1.6"}
+  "ocaml" {>= "4.08.0"}
+  "ezxmlm"
+  "ppx_expect" {with-test}
+  "odoc" {with-doc}
+]
+build: [
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/smaji-org/smaji_glyph_path.git"
+url {
+  src: "https://github.com/smaji-org/smaji_glyph_path/archive/refs/tags/0.1.0.tar.gz"
+  checksum: [
+    "sha256=905aeaaf51ce3e7aa77ff1880b7b0712a67c19fe80b2dd0923da8bb78583daa8"
+    "sha512=0ec4fc71bd758b64da9156d249d55eee3fbaa6190bb85ced9d48b51c04eb140b259168d74d59e1f6f6f705204ef68265537f98d7a5e8ec7e07e3d250e3a21154"
+  ]
+}


### PR DESCRIPTION
# Smaji Glyph Path

An OCaml library for manipulation of font glyph outlines. It provides a suite of tools for analyzing, transforming, composing, and converting glyph paths between different formats.

## 0.1.0

Initial release, including modules:

* Point: Provides fundamental 2D vector arithmetic (addition, scaling, rotation, distance calculation, etc.).
* Matrix: 2x2 matrix transformations for handling rotation and coordinate system changes.
* Bezier: Provides Bézier curve interpolation algorithms to convert curves into point sequences.
* Line: Handles line intersection calculations and vector-based line segment operations.
* Path: Defines basic path data types (supporting Line, Qcurve, Ccurve, etc.) and provides core geometric algorithms such as translation, scaling, and bounding box fitting.
* Svg\_path: Handles the mapping and conversion between SVG path commands (e.g., M, L, C, Q, A) and the internal Path structure.
* Svg: Manages SVG container structures. Note: Only supports `<path>` element, its `d` attribute, and optional `<g>` container. Provides ViewBox auto-reset and fitting functionality.
* Glif: UFO Glif Path Module. Specifically designed to parse glyph path data from the Unified Font Object (UFO) format and convert them into the internal path model.
