### PR TITLE
[new release] prometheus (3 packages) (1.4)

### DIFF
--- a/packages/prometheus-app/prometheus-app.1.4/opam
+++ b/packages/prometheus-app/prometheus-app.1.4/opam
@@ -1,0 +1,55 @@
+opam-version: "2.0"
+synopsis: "Client library for Prometheus monitoring"
+description: """\
+Applications can enable metric reporting using the `prometheus-app` opam package.
+This depends on cohttp and can serve the metrics collected above over HTTP.
+
+The `prometheus-app.unix` ocamlfind library provides the `Prometheus_unix` module,
+which includes a cmdliner option and pre-configured web-server.
+See the `examples/example.ml` program for an example, which can be run as:
+
+```shell
+$ dune exec -- examples/example.exe --listen-prometheus=9090
+If run with the option --listen-prometheus=9090, this program serves metrics at
+http://localhost:9090/metrics
+Tick!
+Tick!
+...
+```
+
+Unikernels can use `Prometheus_app` instead of `Prometheus_unix` to avoid the `Unix` dependency."""
+maintainer: "talex5@gmail.com"
+authors: ["Thomas Leonard" "David Scott"]
+license: "Apache-2.0"
+homepage: "https://github.com/mirage/prometheus"
+doc: "https://mirage.github.io/prometheus/"
+bug-reports: "https://github.com/mirage/prometheus/issues"
+depends: [
+  "ocaml" {>= "4.11.0"}
+  "dune" {>= "2.3"}
+  "prometheus" {= version}
+  "mirage-mtime" {>= "5.2.0"}
+  "fmt" {>= "0.8.7"}
+  "re"
+  "cohttp-lwt" {>= "4.0.0"}
+  "cohttp-lwt-unix" {>= "4.0.0"}
+  "lwt" {>= "2.5.0"}
+  "cmdliner"
+  "alcotest" {with-test}
+  "alcotest-lwt" {with-test}
+  "logs" {>= "0.6.0"}
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/mirage/prometheus.git"
+url {
+  src:
+    "https://github.com/mirage/prometheus/releases/download/v1.4/prometheus-1.4.tbz"
+  checksum: [
+    "sha256=e63ea943ccf903ca49238ba28bd963c3e5358f4f22466dd3749da830f0ec2d31"
+    "sha512=d7bbaf2fea7334c42e2981ed1ed939966e121865d2e89d42c323cb0f6054b06becfcb012c2342fa73c2eb6e181e52670caf3601be08f1e51809fbda92ea928e5"
+  ]
+}
+x-commit-hash: "3c38fb70226d67bf27628e2cda859d6cd2fadb2d"

--- a/packages/prometheus-lwt/prometheus-lwt.1.4/opam
+++ b/packages/prometheus-lwt/prometheus-lwt.1.4/opam
@@ -1,0 +1,33 @@
+opam-version: "2.0"
+synopsis: "Lwt support for Prometheus monitoring"
+description: "Lwt collectors and timing helpers for Prometheus metrics."
+maintainer: "talex5@gmail.com"
+authors: ["Thomas Leonard" "Anil Madhavapeddy" "David Scott"]
+license: "Apache-2.0"
+homepage: "https://github.com/mirage/prometheus"
+doc: "https://mirage.github.io/prometheus/"
+bug-reports: "https://github.com/mirage/prometheus/issues"
+depends: [
+  "ocaml" {>= "4.11.0"}
+  "dune" {>= "2.3"}
+  "prometheus" {= version}
+  "lwt" {>= "2.5.0"}
+  "prometheus-app" {= version & with-test}
+  "fmt" {>= "0.8.7" & with-test}
+  "alcotest" {with-test}
+  "alcotest-lwt" {with-test}
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/mirage/prometheus.git"
+url {
+  src:
+    "https://github.com/mirage/prometheus/releases/download/v1.4/prometheus-1.4.tbz"
+  checksum: [
+    "sha256=e63ea943ccf903ca49238ba28bd963c3e5358f4f22466dd3749da830f0ec2d31"
+    "sha512=d7bbaf2fea7334c42e2981ed1ed939966e121865d2e89d42c323cb0f6054b06becfcb012c2342fa73c2eb6e181e52670caf3601be08f1e51809fbda92ea928e5"
+  ]
+}
+x-commit-hash: "3c38fb70226d67bf27628e2cda859d6cd2fadb2d"

--- a/packages/prometheus/prometheus.1.4/opam
+++ b/packages/prometheus/prometheus.1.4/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+synopsis: "Client library for Prometheus monitoring"
+maintainer: "talex5@gmail.com"
+authors: ["Thomas Leonard" "David Scott"]
+license: "Apache-2.0"
+homepage: "https://github.com/mirage/prometheus"
+doc: "https://mirage.github.io/prometheus/"
+bug-reports: "https://github.com/mirage/prometheus/issues"
+depends: [
+  "ocaml" {>= "4.11.0"}
+  "dune" {>= "2.3"}
+  "re"
+  "lwt" {>= "2.5.0"}
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/mirage/prometheus.git"
+description: """
+To run services reliably, it is useful if they can report various metrics
+(for example, heap size, queue lengths, number of warnings logged, etc).
+
+A monitoring service can be configured to collect this data regularly.
+The data can be graphed to help understand the performance of the service over time,
+or to help debug problems quickly.
+It can also be used to send alerts if a service is down or behaving poorly.
+"""
+url {
+  src:
+    "https://github.com/mirage/prometheus/releases/download/v1.4/prometheus-1.4.tbz"
+  checksum: [
+    "sha256=e63ea943ccf903ca49238ba28bd963c3e5358f4f22466dd3749da830f0ec2d31"
+    "sha512=d7bbaf2fea7334c42e2981ed1ed939966e121865d2e89d42c323cb0f6054b06becfcb012c2342fa73c2eb6e181e52670caf3601be08f1e51809fbda92ea928e5"
+  ]
+}
+x-commit-hash: "3c38fb70226d67bf27628e2cda859d6cd2fadb2d"


### PR DESCRIPTION
Client library for Prometheus monitoring

- Project page: <a href="https://github.com/mirage/prometheus">https://github.com/mirage/prometheus</a>
- Documentation: <a href="https://mirage.github.io/prometheus/">https://mirage.github.io/prometheus/</a>

##### CHANGES:

Core/Lwt split:

- Add a new `prometheus-lwt` metrics package.
  (@avsm @mtelvers @talex5 mirage/prometheus#66 mirage/prometheus#67 mirage/prometheus#68 mirage/prometheus#69, reviewed by @dinosaure)

  This release is not a breaking change, but instead prepares for
  deprecation of Lwt in the core package so a future release can remove Lwt
  from the `prometheus` core. Users of the core's Lwt-typed functions
  should migrate to `Prometheus_lwt` now. Code using the new interface will
  keep working unchanged in future releases.

- Add synchronous variants of the timing helpers to the core. Metric recording
  is synchronous and these will become the only core timing helpers once the
  Lwt-typed ones move to `prometheus-lwt`.

- The replacement time-based functions no longer take a `gettime` argument.
  Instead, this is provided once by the new `Prometheus.init` function,
  which is called automatically when using `Prometheus_unix`.

To migrate existing code, add a dep on `prometheus-lwt` and rename following
the deprecation warnings from the compiler.

Bug fixes:

- Format floats with `%.17g` (@samoht @talex5 mirage/prometheus#62).
  The text exposition formatter printed metric values with `%f`,
  so any magnitude below ~5e-7 was reported as 0.000000.

Other changes:

- Remove `Astring` dependency (@talex5 mirage/prometheus#63).

- Remove `Asetmap` dependency (@talex5 mirage/prometheus#64).
  This changes the types of `LabelSetMap` and `MetricFamilyMap` slightly,
  which might affect custom reporters.
