### PR TITLE
Package dune-rpc-eio.0.1.0

### DIFF
--- a/packages/dune-rpc-eio/dune-rpc-eio.0.1.0/opam
+++ b/packages/dune-rpc-eio/dune-rpc-eio.0.1.0/opam
@@ -1,0 +1,43 @@
+opam-version: "2.0"
+synopsis: "Client for dune's RPC server using Eio"
+description:
+  "Speaks dune's RPC protocol over its build socket: spawn or attach to a dune server, build paths and aliases, run tests, read diagnostics and promote files, from any Eio program."
+maintainer: "Anil Madhavapeddy <anil@recoil.org>"
+authors: "Anil Madhavapeddy"
+license: "ISC"
+tags: ["org:blacksun" "dune" "rpc" "eio"]
+homepage: "https://tangled.org/anil.recoil.org/dune-rpc-eio"
+bug-reports: "https://tangled.org/anil.recoil.org/dune-rpc-eio/issues"
+depends: [
+  "dune" {>= "3.23"}
+  "ocaml" {>= "5.2.0"}
+  "dune-rpc" {>= "3.24"}
+  "csexp" {>= "1.5"}
+  "eio" {>= "1.4"}
+  "eio_main" {with-test}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://tangled.org/anil.recoil.org/dune-rpc-eio"
+url {
+  src:
+    "https://tangled.org/anil.recoil.org/dune-rpc-eio/tags/85fa8ef6e5245dee2ab745eda6263c917f62209c/download/dune-rpc-eio-0.1.0.tbz"
+  checksum: [
+    "md5=5e2dc3cc049957ff80ce391eab708aa9"
+    "sha512=b6eb708b87bb511b7096b3cb9b8f3e1495562f2c41aca8c56aa59df8faf87a2d7ff3afaae5cce894cde7b02e21ef87d0bfeb8b95ca99043fbab82ecd94ca3f97"
+  ]
+}
+x-maintenance-intent: ["(latest)"]


### PR DESCRIPTION
### `dune-rpc-eio.0.1.0`
Client for dune's RPC server using Eio
Speaks dune's RPC protocol over its build socket: spawn or attach to a dune server, build paths and aliases, run tests, read diagnostics and promote files, from any Eio program.



---
* Homepage: https://tangled.org/anil.recoil.org/dune-rpc-eio
* Source repo: git+https://tangled.org/anil.recoil.org/dune-rpc-eio
* Bug tracker: https://tangled.org/anil.recoil.org/dune-rpc-eio/issues

---
:camel: Pull-request generated by opam-publish v3.0.1