### PR TITLE
[new release]: shakuhachi - 0.3.2

### DIFF
--- a/packages/shakuhachi/shakuhachi.0.3.2/opam
+++ b/packages/shakuhachi/shakuhachi.0.3.2/opam
@@ -1,0 +1,54 @@
+opam-version: "2.0"
+synopsis: "A music collection manager"
+description: """
+shakuhachi is mainly a music collection manager but it's also a music tagger.
+ It aims to be a rather simple collection manager extensible by plugins."""
+maintainer: ["EruEri <nayinayu@mailo.com>"]
+authors: ["EruEri <nayinayu@mailo.com>"]
+license: "GPL-3.0-or-later AND MPL-2.0"
+tags: ["music collection" "music tagger"]
+homepage: "https://codeberg.org/EruEri/shakuhachi"
+bug-reports: "https://codeberg.org/EruEri/shakuhachi/issues"
+depends: [
+  "dune" {>= "3.17.2"}
+  "ocaml" {>= "4.14.0"}
+  "xdg"
+  "angstrom" {>= "0.15.0"}
+  "cmdliner" {>= "1.1.0"}
+  "sqlite3" {>= "5.1.0"}
+  "re" {>= "1.10.3"}
+  "otaglibc" {>= "0.1.0"}
+  "uunf" {>= "15.1.0"}
+  "magic-mime" {>= "1.3.0"}
+  "ppx_deriving_yojson" {>= "3.5.3"}
+  "yojson" {>= "2.0.0"}
+  "qcheck" {>= "0.90" & with-test}
+  "qcheck-alcotest" {with-test}
+  "alcotest" {with-test}
+  "fmt" {with-test}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://codeberg.org/EruEri/shakuhachi.git"
+x-maintenance-intent: ["(latest)"]
+
+url {
+  src: "https://codeberg.org/EruEri/shakuhachi/archive/0.3.2.tar.gz"
+  checksum: [
+    "sha256=c72807d303de137441b643fec1c7630c930ebc792b576783c7961b237c2114db"
+    "sha512=770f878bbdac8033d90e904ce8e9c84fc75331c7ff9b35e2204fafe3746f432f2664296dac91942a788b82a2da07478d91b76ed85cd880758d2def8a55144840"
+  ]
+}


### PR DESCRIPTION
Dear maintainers,

shakuhachi : Still a music collection manager

## CHANGES

- doc : Add examples to commands + add man_xrefs
- fix : [skhc-modify]: Album-mode - also modify album-participant.
- fix : Add music participants to the corresponding album even if the album already exists.