### PR TITLE
ocluster 0.2.1/0.3.0: do not run the test suites in opam-repo

### DIFF
--- a/packages/ocluster/ocluster.0.2.1/opam
+++ b/packages/ocluster/ocluster.0.2.1/opam
@@ -59,7 +59,6 @@ build: [
     "-j"
     jobs
     "@install"
-    "@runtest" {with-test}
     "@doc" {with-doc}
   ]
 ]

--- a/packages/ocluster/ocluster.0.3.0/opam
+++ b/packages/ocluster/ocluster.0.3.0/opam
@@ -68,7 +68,6 @@ build: [
     "-j"
     jobs
     "@install"
-    "@runtest" {with-test}
     "@doc" {with-doc}
   ]
 ]


### PR DESCRIPTION
These test suites started failing due to the expect test behaviour changing, but there's not much value in keeping the tests. The later versions of ocluster are fine.

Noticed in #30452