### PR TITLE
[new release] modelkit (0.2.1)

### DIFF
--- a/packages/modelkit/modelkit.0.2.1/opam
+++ b/packages/modelkit/modelkit.0.2.1/opam
@@ -1,0 +1,43 @@
+opam-version: "2.0"
+synopsis: "Portable classical machine learning workflows for OCaml"
+description:
+  "ModelKit is a native OCaml library for cohesive classical machine learning workflows. It is designed around immutable estimator specifications, leakage-safe pipelines, deterministic evaluation, and portable fitted artifacts."
+maintainer: ["Asara developers <devs@asara.io>"]
+authors: ["Asara"]
+license: "Apache-2.0"
+tags: ["data-science" "machine-learning"]
+homepage: "https://github.com/asara-io/ModelKit"
+bug-reports: "https://github.com/asara-io/ModelKit/issues"
+depends: [
+  "dune" {>= "3.23"}
+  "ocaml" {>= "5.2"}
+  "alcotest" {with-test & >= "1.9.0"}
+  "mdx" {with-test & >= "2.4.0"}
+  "qcheck-core" {with-test & >= "0.90"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/asara-io/ModelKit.git"
+x-maintenance-intent: ["(latest)"]
+url {
+  src:
+    "https://github.com/asara-io/ModelKit/releases/download/0.2.1/modelkit-0.2.1.tbz"
+  checksum: [
+    "sha256=ec5be6fc4f47f7a73fae676e730b9c66400327320231a61f0d2044d8d46aab59"
+    "sha512=e63baf8958b95f9b57f27ae42c6fb434674db18d278af7d60b74cac239407cddef57a16fab99101c9087561f9c7d826340505f449e99629c86f708ab89840946"
+  ]
+}
+x-commit-hash: "d27910e89c33025e3f3bc45421047b470de06336"


### PR DESCRIPTION
Portable classical machine learning workflows for OCaml

- Project page: <a href="https://github.com/asara-io/ModelKit">https://github.com/asara-io/ModelKit</a>

##### CHANGES:

- Restore package builds on OCaml 5.5 by making typed target accessor specializations explicit.
- Test OCaml 5.5 on Linux, macOS, and Windows in addition to the existing OCaml 5.2 and 5.3 matrix.
