### PR TITLE
[new release] bisect_ppx_ng (3.0.0)

### DIFF
--- a/packages/bisect_ppx_ng/bisect_ppx_ng.3.0.0/opam
+++ b/packages/bisect_ppx_ng/bisect_ppx_ng.3.0.0/opam
@@ -1,0 +1,62 @@
+opam-version: "2.0"
+synopsis: "Code coverage for OCaml"
+maintainer: ["Dmitrii Kosarev a.k.a. Kakadu <kakadu.hafanana@gmail.com"]
+authors: [
+  "Xavier Clerc <bisect@x9c.fr>"
+  "Leonid Rozenberg <leonidr@gmail.com>"
+  "Anton Bachin <antonbachin@yahoo.com>"
+]
+license: "MIT"
+homepage: "https://github.com/Kakadu/bisect_ppx_ng"
+doc: "https://github.com/Kakadu/bisect_ppx_ng"
+bug-reports: "https://github.com/Kakadu/bisect_ppx_ng"
+depends: [
+  "dune" {>= "3.18"}
+  "ocaml" {>= "4.14.2" & < "5.0.0" | >= "5.3.0"}
+  "ppxlib" {>= "0.36.0"}
+  "cmdliner" {>= "1.3.0"}
+  "js_of_ocaml" {with-test}
+  "js_of_ocaml-compiler" {with-test}
+  "reason" {with-test}
+  "odoc" {with-doc}
+]
+x-maintenance-intent: ["(latest)"]
+description: "Bisect_ppx_ng/bisect_ppx helps you test thoroughly.
+It is a small preprocessor that inserts instrumentation at places in your code,
+such as if-then-else and match expressions.
+After you run tests, Bisect_ppx gives a nice HTML report
+showing which places were visited and which were missed.
+
+Usage is simple - add package bisect_ppx_ng when building tests, run your tests,
+then run the Bisect_ppx report tool on the generated visitation files.
+
+Bisect_ppx_ng is a for of bisect_ppx (the latest version before forking is 2.8.3).
+The project was undermaintained and for introduced support of 5.3 < OCaml <= 5.5.
+"
+
+dev-repo: "git+https://github.com/Kakadu/bisect_ppx_ng.git"
+
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    # Bisect_ppx prints OCaml code a lot while testing and it is shaky between compiler versions
+    "@runtest" {with-test & ocaml:version >= "5.3.0" }
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src:
+    "https://github.com/Kakadu/bisect_ppx_ng/releases/download/3.0.0/bisect_ppx_ng-3.0.0.tbz"
+  checksum: [
+    "sha256=df5e4451dec5fcc71eb6bb423515bba5a9110c31cd51f8bb970ab16ab3334bed"
+    "sha512=e35f9009aaa55c7b13e76a65945e2cf62d63789b13336d12169e9e394e2b3ee48e0dfa3f21d8c67deb6950d86e412b6a4b9ed3843ccaad5e0786e1f5122ace2b"
+  ]
+}
+x-commit-hash: "4232dbe9f71ba3c205c3fc3dbba6220db13d682d"

--- a/packages/bisect_ppx_ng/bisect_ppx_ng.3.0.0/opam
+++ b/packages/bisect_ppx_ng/bisect_ppx_ng.3.0.0/opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
 synopsis: "Code coverage for OCaml - fork of bisect_ppx"
-maintainer: ["Dmitrii Kosarev a.k.a. Kakadu <kakadu.hafanana@gmail.com"]
+maintainer: ["Dmitrii Kosarev a.k.a. Kakadu <kakadu.hafanana@gmail.com>"]
 authors: [
   "Xavier Clerc <bisect@x9c.fr>"
   "Leonid Rozenberg <leonidr@gmail.com>"
@@ -30,9 +30,8 @@ showing which places were visited and which were missed.
 Usage is simple - add package bisect_ppx_ng when building tests, run your tests,
 then run the Bisect_ppx report tool on the generated visitation files.
 
-Bisect_ppx_ng is a for of bisect_ppx (the latest version before forking is 2.8.3).
-The project was undermaintained and for introduced support of 5.3 < OCaml <= 5.5.
-"
+Bisect_ppx_ng is a fork of bisect_ppx (the latest version before forking is 2.8.3).
+The project was undermaintained and then fork introduced support of  OCaml > 5.3."
 
 dev-repo: "git+https://github.com/Kakadu/bisect_ppx_ng.git"
 

--- a/packages/bisect_ppx_ng/bisect_ppx_ng.3.0.0/opam
+++ b/packages/bisect_ppx_ng/bisect_ppx_ng.3.0.0/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-synopsis: "Code coverage for OCaml"
+synopsis: "Code coverage for OCaml - fork of bisect_ppx"
 maintainer: ["Dmitrii Kosarev a.k.a. Kakadu <kakadu.hafanana@gmail.com"]
 authors: [
   "Xavier Clerc <bisect@x9c.fr>"


### PR DESCRIPTION
Code coverage for OCaml

- Project page: <a href="https://github.com/Kakadu/bisect_ppx_ng">https://github.com/Kakadu/bisect_ppx_ng</a>
- Documentation: <a href="https://github.com/Kakadu/bisect_ppx_ng">https://github.com/Kakadu/bisect_ppx_ng</a>

##### CHANGES:

  Changes

  - OCaml 5.5 support
  - Move project to another maintainer while aantron is busy
  - rename bisect_ppx -> bisect_ppx_ng
