### PR TITLE
conf-capnproto.2: add OpenBSD depext

### DIFF
--- a/packages/conf-capnproto/conf-capnproto.2/opam
+++ b/packages/conf-capnproto/conf-capnproto.2/opam
@@ -24,6 +24,7 @@ depexts: [
   ["capnproto"] {os-distribution = "macports" & os = "macos"}
   ["capnproto" "libcapnp-devel"] {os-family = "suse" | os-family = "opensuse"}
   ["capnproto"] {os = "freebsd"}
+  ["capnproto"] {os = "openbsd"}
   ["capnproto"] {os-distribution = "nixos"}
 ]
 x-ci-accept-failures: [


### PR DESCRIPTION
`conf-capnproto.2` has no `openbsd` entry in its `depexts`, so on OpenBSD opam installs nothing and the `capnp --version` build check fails.