### PR TITLE
[new release] chatoyant (0.13.0)

### DIFF
--- a/packages/chatoyant/chatoyant.0.13.0/opam
+++ b/packages/chatoyant/chatoyant.0.13.0/opam
@@ -1,0 +1,67 @@
+opam-version: "2.0"
+synopsis: "OCaml-first LLM SDK with Melange-generated JavaScript"
+description:
+  "Chatoyant is an OCaml-first SDK for LLM providers. It exposes an Eio native API, typed JSON Schema and tool definitions, raw provider clients for OpenAI/Anthropic/xAI/OpenRouter/local inference, and a Melange-generated JavaScript package."
+maintainer: ["Anonyfox <max@anonyfox.com>"]
+authors: ["Anonyfox <max@anonyfox.com>"]
+license: "MIT"
+tags: [
+  "llm"
+  "ai"
+  "openai"
+  "anthropic"
+  "xai"
+  "openrouter"
+  "json-schema"
+  "eio"
+  "melange"
+  "typesafe"
+]
+homepage: "https://github.com/Anonyfox/chatoyant"
+doc: "https://anonyfox.github.io/chatoyant"
+bug-reports: "https://github.com/Anonyfox/chatoyant/issues"
+depends: [
+  "ocaml" {>= "5.3"}
+  "dune" {>= "3.23"}
+  "melange" {>= "6.0.0"}
+  "ca-certs" {>= "1.0.0"}
+  "base64"
+  "cohttp-eio" {>= "6.0.0"}
+  "digestif"
+  "domain-name"
+  "eio" {>= "1.0"}
+  "eio_main" {with-test}
+  "http" {>= "6.0.0"}
+  "mirage-crypto-rng" {>= "1.0.0"}
+  "ppxlib" {build}
+  "tls" {>= "1.0.0"}
+  "tls-eio" {>= "1.0.0"}
+  "uri"
+  "x509" {>= "1.0.0"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/Anonyfox/chatoyant.git"
+x-maintenance-intent: ["(latest)"]
+url {
+  src:
+    "https://github.com/Anonyfox/chatoyant/releases/download/v0.13.0/chatoyant-v0.13.0.tbz"
+  checksum: [
+    "sha256=1f84c5229b2d58ec6264dd651a58f2686130afa6e91989f110aa7aaf10bba0f5"
+    "sha512=49142e122dbb44b03f7f27b52839492800332207d0efeacc7451173827c899a9b965b671a3d9028cc05250aaebbc6789d3815a6cf356f4319bc0c1b0454c68dd"
+  ]
+}
+x-commit-hash: "5971db2485019e855df954644c591999a63b6787"


### PR DESCRIPTION
Release of **chatoyant** 0.13.0: an OCaml-first SDK for LLM providers
(OpenAI, Anthropic, xAI, OpenRouter, local OpenAI-compatible servers) with an
Eio native API, typed tools and structured outputs, streaming, and token/cost
accounting.

- Sources: https://github.com/Anonyfox/chatoyant
- Changes: https://github.com/Anonyfox/chatoyant/blob/main/CHANGELOG.md
- Tests run offline (`with-test` needs no network or API keys).

🤖 Generated with [Claude Code](https://claude.com/claude-code)