### PR TITLE
Package floatml.0.1.0

### DIFF
--- a/packages/floatml/floatml.0.1.0/opam
+++ b/packages/floatml/floatml.0.1.0/opam
@@ -33,9 +33,9 @@ build: [
 ]
 dev-repo: "git+https://github.com/N1ark/floatml.git"
 url {
-  src: "https://github.com/N1ark/floatml/archive/refs/tags/v0.1.0.tar.gz"
+  src: "https://github.com/N1ark/floatml/archive/refs/tags/v0.2.0.tar.gz"
   checksum: [
-    "md5=ba325262f905dbef198f9578dcd0e405"
-    "sha512=eb3425af485031c7fb17a747e5ee35364acb9dbe027016d1b862c5e7199dcb14dde8f9184d06a04db138d5ab2c5f1d49bf2bbc5ae3e25c7de866a94d128335c6"
+    "md5=4079b88ec376ce9c6c65a4eb36dd53cf"
+    "sha512=9f468c1906391378f53fb013b88c7144f07df3ed874f69cdd3fc547bbb430a09190a6682ed198e1c62b43e1ee9013aaf484951a302859693f3b808838a0dc320"
   ]
 }


### PR DESCRIPTION
### `floatml.0.1.0`
Floats (f16, f32, f64, f128) for OCaml
Deterministic, IEEE-754-compliant interface for floating point operators over f16, f32, f64 and f128, backed by Rust's rustc_apfloat. Requires a Rust toolchain (cargo, 1.77 or newer) to build.



---
* Homepage: https://github.com/N1ark/floatml
* Source repo: git+https://github.com/N1ark/floatml.git
* Bug tracker: https://github.com/N1ark/floatml/issues

---
:camel: Pull-request generated by opam-publish v3.0.1