### PR TITLE
Add: affect.0.0.0

### DIFF
--- a/packages/affect/affect.0.0.0/opam
+++ b/packages/affect/affect.0.0.0/opam
@@ -1,0 +1,53 @@
+opam-version: "2.0"
+synopsis: "Streamlined and natural concurrency model for OCaml"
+description: """\
+Affect is a streamlined and natural concurrency model for OCaml.
+
+It provides parallel asynchronous functions and first-class
+synchronous actions to orchestrate them. The resulting [concurrency
+model] has structured cooperative concurrency, structured cancellation
+and structured effect handling.
+
+Affect is distributed under the ISC license. The base library has no
+dependencies. It optionally depends on the [`cmdliner`] library and
+the OCaml `unix` library.
+
+Homepage: <https://erratique.ch/software/affect/>
+
+[`cmdliner`]: <http://erratique.ch/software/cmdliner>
+[concurrency model]: https://erratique.ch/software/affect/doc/concurrency_model.html"""
+maintainer: "Daniel Bünzli <daniel.buenzl i@erratique.ch>"
+authors: "The affect programmers"
+license: "ISC"
+tags: [
+  "effects" "concurrency" "parallelism" "fibers" "org:erratique" "cml" "unix"
+]
+homepage: "https://erratique.ch/software/affect"
+doc: "https://erratique.ch/software/affect/doc"
+bug-reports: "https://github.com/dbuenzli/affect/issues"
+depends: [
+  "ocaml" {>= "5.5.0"}
+  "ocamlfind" {build}
+  "ocamlbuild" {build}
+  "topkg" {build & >= "1.1.0"}
+]
+depopts: ["cmdliner"]
+conflicts: [
+  "cmdliner" {< "2.0.0"}
+]
+build: [
+  "ocaml"
+  "pkg/pkg.ml"
+  "build"
+  "--dev-pkg"
+  "%{dev}%"
+  "--with-cmdliner"
+  "%{cmdliner:installed}%"
+]
+dev-repo: "git+https://erratique.ch/repos/affect.git"
+url {
+  src: "https://erratique.ch/software/affect/releases/affect-0.0.0.tbz"
+  checksum:
+    "sha512=b328f6696e60c489da8cc2e8fad0537ca6634a39fc0c5de5840d4f98561f110617ef79ba8285ee8427dd99908c6b3d39114973598cddc5ded91abcce3b91b9a6"
+}
+x-maintenance-intent: ["(latest)"]


### PR DESCRIPTION
* Add: `affect.0.0.0` [home](https://erratique.ch/software/affect), [doc](https://erratique.ch/software/affect/doc), [issues](https://github.com/dbuenzli/affect/issues)  
  *Streamlined and natural concurrency model for OCaml*


---

#### `affect` v0.0.0 2026-08-12 Zagreb


First release.

Supported by a grant from the OCaml Software Foundation.


---

Use `b0 -- .opam publish affect.0.0.0` to update the pull request.