### PR TITLE
Solo5 v0.12.1

### DIFF
--- a/packages/solo5-cross-aarch64/solo5-cross-aarch64.0.12.1/opam
+++ b/packages/solo5-cross-aarch64/solo5-cross-aarch64.0.12.1/opam
@@ -1,0 +1,46 @@
+opam-version: "2.0"
+maintainer: "martin@lucina.net"
+authors: [
+  "Dan Williams <djwillia@us.ibm.com>"
+  "Martin Lucina <martin@lucina.net>"
+  "Ricardo Koller <kollerr@us.ibm.com>"
+]
+homepage: "https://github.com/solo5/solo5"
+bug-reports: "https://github.com/solo5/solo5/issues"
+license: "ISC"
+dev-repo: "git+https://github.com/solo5/solo5.git"
+build: [
+  ["env" "TARGET_CC=aarch64-linux-gnu-gcc" "TARGET_LD=aarch64-linux-gnu-ld" "TARGET_OBJCOPY=aarch64-linux-gnu-objcopy" "./configure.sh" "--prefix=%{prefix}%"]
+  [make "V=1"]
+]
+install: [make "V=1" "install-toolchain"]
+depends: [
+  "conf-pkg-config" {build & os = "linux"}
+  "conf-libseccomp" {build & os = "linux"}
+  "solo5" {= version}
+]
+depexts: [
+  ["linux-headers"] {os-distribution = "alpine"}
+  ["kernel-headers"] {os-distribution = "fedora"}
+  ["kernel-headers"] {os-distribution = "rhel"}
+  ["linux-libc-dev"] {os-family = "debian"}
+  ["gcc-aarch64-linux-gnu"] {os-family = "debian"}
+]
+available: [
+  (arch != "arm64") &
+  (os = "linux" & os-family = "debian")
+]
+synopsis: "Solo5 sandboxed execution environment"
+description: """
+Solo5 is a sandboxed execution environment primarily intended
+for, but not limited to, running applications built using various
+unikernels (a.k.a.  library operating systems).
+
+This package provides the Solo5 components needed to cross-build
+MirageOS unikernels for the aarch64 architecture.
+"""
+x-maintenance-intent: [ "(latest)" ]
+url {
+  src: "https://github.com/Solo5/solo5/releases/download/v0.12.1/solo5-v0.12.1.tar.gz"
+  checksum: "sha512=168026cce7ffceabe5f90a6c85f915f33ab30332ee81338bc4e08560917036910fdb386484579d4ae29f5bf90744a39d025c729e88098d495f0409626be94914"
+}

--- a/packages/solo5/solo5.0.12.0/opam
+++ b/packages/solo5/solo5.0.12.0/opam
@@ -35,7 +35,7 @@ conflicts: [
 ]
 available: [
   (arch = "x86_64" | arch = "arm64" | arch = "ppc64") &
-  (os = "linux" | os = "freebsd" | os = "openbsd")
+  (os = "linux" | os = "freebsd" | os = "openbsd" | os = "dragonfly")
 ]
 synopsis: "Solo5 sandboxed execution environment"
 description: """

--- a/packages/solo5/solo5.0.12.1/opam
+++ b/packages/solo5/solo5.0.12.1/opam
@@ -35,7 +35,7 @@ conflicts: [
 ]
 available: [
   (arch = "x86_64" | arch = "arm64" | arch = "ppc64") &
-  (os = "linux" | os = "freebsd" | os = "openbsd")
+  (os = "linux" | os = "freebsd" | os = "openbsd" | os = "dragonfly")
 ]
 synopsis: "Solo5 sandboxed execution environment"
 description: """

--- a/packages/solo5/solo5.0.12.1/opam
+++ b/packages/solo5/solo5.0.12.1/opam
@@ -1,0 +1,54 @@
+opam-version: "2.0"
+maintainer: "martin@lucina.net"
+authors: [
+  "Dan Williams <djwillia@us.ibm.com>"
+  "Martin Lucina <martin@lucina.net>"
+  "Ricardo Koller <kollerr@us.ibm.com>"
+]
+homepage: "https://github.com/solo5/solo5"
+bug-reports: "https://github.com/solo5/solo5/issues"
+license: "ISC"
+dev-repo: "git+https://github.com/solo5/solo5.git"
+build: [
+  ["./configure.sh" "--prefix=%{prefix}%"]
+  [make "V=1"]
+]
+install: [make "V=1" "install"]
+depends: [
+  "conf-pkg-config" {build & os = "linux"}
+  "conf-libseccomp" {build & os = "linux"}
+]
+depexts: [
+  ["linux-headers"] {os-distribution = "alpine"}
+  ["kernel-headers"] {os-distribution = "fedora"}
+  ["kernel-headers"] {os-distribution = "rhel"}
+  ["linux-libc-dev"] {os-family = "debian"}
+]
+conflicts: [
+  "ocaml-freestanding" {< "0.7.0"}
+  "solo5-bindings-hvt"
+  "solo5-bindings-spt"
+  "solo5-bindings-virtio"
+  "solo5-bindings-muen"
+  "solo5-bindings-genode"
+  "solo5-bindings-xen"
+]
+available: [
+  (arch = "x86_64" | arch = "arm64" | arch = "ppc64") &
+  (os = "linux" | os = "freebsd" | os = "openbsd")
+]
+synopsis: "Solo5 sandboxed execution environment"
+description: """
+Solo5 is a sandboxed execution environment primarily intended
+for, but not limited to, running applications built using various
+unikernels (a.k.a.  library operating systems).
+
+This package provides the Solo5 components needed to build and
+run MirageOS unikernels on the host system.
+"""
+x-maintenance-intent: [ "(latest)" ]
+x-ci-accept-failures: [ "centos-7" "opensuse-15.6" ] # too old GCC compiler (OpenSUSE uses GCC 7 and we require GCC 10)
+url {
+  src: "https://github.com/Solo5/solo5/releases/download/v0.12.1/solo5-v0.12.1.tar.gz"
+  checksum: "sha512=168026cce7ffceabe5f90a6c85f915f33ab30332ee81338bc4e08560917036910fdb386484579d4ae29f5bf90744a39d025c729e88098d495f0409626be94914"
+}


### PR DESCRIPTION
- roundup the memory for the ringbuffer to have the unikernel memory page-aligned (solo5/solo5#660 @dinosaure, fixes solo5/solo5#659 by @pocopepe)
- muen: update sinfo to 05, ABI version to 4 (solo5/solo5#654 @reet-)
- configure.sh: add "--disable-elftool" option (solo5/solo5#657 @shym)
- remove dead seccomp code (from hvt on linux) (solo5/solo5#661 @pocopepe)
- Makefile: install virtio support scripts only if virtio is enabled (solo5/solo5#655 @shym)
- docs: fix broken links in architecture.md (solo5/solo5#662 @danila-permogorskii)
- Makefile: set SUBDIRS appropriately and use it (solo5/solo5#655 @shym)
- configure.sh: remove dead code, TARGET_CC is always initialised earlier (solo5/solo5#655 @shym)
- configure.sh: fix parsing of `--prefix` when the path contains a '=' (solo5/solo5#655 @shym)
- configure.sh: replace "echo -n" with "printf" (solo5/solo5#655 @shym)
- CI: deduplicate runs (solo5/solo5#655 @shym)
- Remove travis.yml, remove build.sh and mentions of no-longer running surf build CI (solo5/solo5#651 solo5/solo5#663 @hannesm)