### PR TITLE
[new release] lambda-term (3.4.1)

### DIFF
--- a/packages/lambda-term/lambda-term.3.4.1/opam
+++ b/packages/lambda-term/lambda-term.3.4.1/opam
@@ -1,0 +1,49 @@
+opam-version: "2.0"
+synopsis: "Terminal manipulation library for OCaml"
+description: """
+Lambda-term is a cross-platform library for manipulating the terminal. It
+provides an abstraction for keys, mouse events, colors, as well as a set of
+widgets to write curses-like applications. The main objective of lambda-term is
+to provide a higher level functional interface to terminal manipulation than,
+for example, ncurses, by providing a native OCaml interface instead of bindings
+to a C library. Lambda-term integrates with zed to provide text edition
+facilities in console applications."""
+maintainer: ["ZAN DoYe <zandoye+ocaml@gmail.com>"]
+authors: ["Jérémie Dimino"]
+license: "BSD-3-Clause"
+homepage: "https://github.com/ocaml-community/lambda-term"
+bug-reports: "https://github.com/ocaml-community/lambda-term/issues"
+depends: [
+  "dune" {>= "3.0"}
+  "ocaml" {>= "4.08.0"}
+  "logs"
+  "lwt" {>= "4.2.0"}
+  "lwt_react"
+  "mew_vi" {>= "0.5.0" & < "0.6.0"}
+  "react"
+  "zed" {>= "3.2.0" & < "4.0"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/ocaml-community/lambda-term.git"
+url {
+  src:
+    "https://github.com/ocaml-community/lambda-term/archive/refs/tags/3.4.1.tar.gz"
+  checksum: [
+    "sha512=db56672833bf8c85d64f1b6e6b22bc8d98a4bd1abc00499f5baa5db18f1fe39d3e9c27d60a3ba3227215706055bccc7f160b4e46553c707bf6e14a5b2c419b48"
+  ]
+}
+x-commit-hash: "033cff70925879431bf116f63d450d4d9781d994"


### PR DESCRIPTION
3.4.1 (2026-08-12)
------------------

* `LTerm_vi`: fix `prev_word'`, resolve an issue that vi commands `b` words backward and `B` WORDS backward may behave improperly in some cases