### PR TITLE
release not-ocamlfind 0.15, minor bugfix

### DIFF
--- a/packages/not-ocamlfind/not-ocamlfind.0.15/opam
+++ b/packages/not-ocamlfind/not-ocamlfind.0.15/opam
@@ -33,6 +33,6 @@ dev-repo: "git+https://github.com/chetmurthy/not-ocamlfind"
 url {
   src: "https://github.com/chetmurthy/not-ocamlfind/archive/refs/tags/0.15.tar.gz"
   checksum: [
-    "sha512=fb87bc7e47c63ba79e14bd5248e9ca9f36bac2d638f01159f06c1a1a176ed40455230e5d4c3e9c2a4b009601f351592bda06c8db550e3a0608b6c566dfd93c47"
+    "sha512=31cb7423af6351a1cb6df12ba6f4c744c81f057c12d149397e5760c865088da008901d95b8dd5d4530768258f4e946ba5c04f563a575cf9ae9240d6dcb5cfc08"
   ]
 }

--- a/packages/not-ocamlfind/not-ocamlfind.0.15/opam
+++ b/packages/not-ocamlfind/not-ocamlfind.0.15/opam
@@ -33,6 +33,6 @@ dev-repo: "git+https://github.com/chetmurthy/not-ocamlfind"
 url {
   src: "https://github.com/chetmurthy/not-ocamlfind/archive/refs/tags/0.15.tar.gz"
   checksum: [
-    "sha512=9acacef442cc9902d67bb44ba7f1b9dd5165adcaef8acb729c6c30f8393d58f05d6ef3a6d756f016c038c8293658c574405914d41a8e9b23b7de28fb7af9098e"
+    "sha512=fb87bc7e47c63ba79e14bd5248e9ca9f36bac2d638f01159f06c1a1a176ed40455230e5d4c3e9c2a4b009601f351592bda06c8db550e3a0608b6c566dfd93c47"
   ]
 }

--- a/packages/not-ocamlfind/not-ocamlfind.0.15/opam
+++ b/packages/not-ocamlfind/not-ocamlfind.0.15/opam
@@ -1,0 +1,38 @@
+
+opam-version: "2.0"
+synopsis: "A small frontend for ocamlfind that adds a few useful commands"
+license: "MIT"
+x-maintenance-intent: [ "(latest)" ]
+maintainer: "Chet Murthy <chetsky@gmail.com>"
+
+(* Gerd wrote most of this code; I just modified it (and probably
+introduced bugs.  This is to silence opam *)
+
+authors: "Chet Murthy <chetsky@gmail.com>"
+homepage: "https://github.com/chetmurthy/not-ocamlfind"
+bug-reports: "Chet Murthy <chetsky@gmail.com>"
+depends: [
+  "ocamlfind" {>= "1.9.6"}
+  "camlp-streams"
+  "conf-m4" {build}
+  "fmt" {>= "0.8.8"}
+  "rresult" {>= "0.6.0"}
+  "ocamlgraph" {>= "2.0.0"}
+  "conf-which"
+]
+depexts: [
+  [
+    "xdot"
+  ] {os-family = "debian"}
+]
+build: [
+  [make "all"]
+]
+install: [make "install"]
+dev-repo: "git+https://github.com/chetmurthy/not-ocamlfind"
+url {
+  src: "https://github.com/chetmurthy/not-ocamlfind/archive/refs/tags/0.15.tar.gz"
+  checksum: [
+    "sha512=9acacef442cc9902d67bb44ba7f1b9dd5165adcaef8acb729c6c30f8393d58f05d6ef3a6d756f016c038c8293658c574405914d41a8e9b23b7de28fb7af9098e"
+  ]
+}


### PR DESCRIPTION
This fixes a failure when interacting with ocamlfind 1.9.9-preview.

(1) It consists pretty much in removing the local copy of ocamlfind and using whatever is installed.

(2) I didn't dig into the bug, because the fix was so trivial, and needed doing anyway.

The local copy was there b/c long ago ocamlfind didn't install some CMI files, which made it difficult to use the library in follow-on tools.  That's been rectified, hence this fix is also needed cleanup.