### PR TITLE
[new release] sqlite3 (5.4.2)

### DIFF
--- a/packages/sqlite3/sqlite3.5.4.2/opam
+++ b/packages/sqlite3/sqlite3.5.4.2/opam
@@ -1,0 +1,49 @@
+opam-version: "2.0"
+synopsis: "SQLite3 bindings for OCaml"
+description: """
+sqlite3-ocaml is an OCaml library with bindings to the SQLite3 client API.
+Sqlite3 is a self-contained, serverless, zero-configuration, transactional SQL
+database engine with outstanding performance for many use cases."""
+maintainer: ["Markus Mottl <markus.mottl@gmail.com>"]
+authors: [
+  "Markus Mottl <markus.mottl@gmail.com>"
+  "Christian Szegedy <csdontspam@metamatix.com>"
+]
+license: "MIT"
+tags: ["clib:sqlite3"]
+homepage: "https://mmottl.github.io/sqlite3-ocaml"
+doc: "https://mmottl.github.io/sqlite3-ocaml/api"
+bug-reports: "https://github.com/mmottl/sqlite3-ocaml/issues"
+depends: [
+  "dune" {>= "2.7"}
+  "ocaml" {>= "4.12"}
+  "dune-compiledb"
+  "dune-configurator"
+  "conf-sqlite3" {build}
+  "ppx_inline_test" {with-test}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/mmottl/sqlite3-ocaml.git"
+url {
+  src:
+    "https://github.com/mmottl/sqlite3-ocaml/releases/download/5.4.2/sqlite3-5.4.2.tbz"
+  checksum: [
+    "sha256=32f68f078f4beaed51ebc279fef46145205fd98cf6c79fe955218601f202621c"
+    "sha512=92835354d7343ee8c26e574e555b1e83b936f2ccf41e53a64f4b29edb53d38254dd7e570e95ee0b11bf808ad16d78a4b3ba393fc48d0ff2ed51f0e86913fbc07"
+  ]
+}
+x-commit-hash: "104cb85009068b1deb6d7bb86ec4b24621efa0f6"


### PR DESCRIPTION
SQLite3 bindings for OCaml

- Project page: <a href="https://mmottl.github.io/sqlite3-ocaml">https://mmottl.github.io/sqlite3-ocaml</a>
- Documentation: <a href="https://mmottl.github.io/sqlite3-ocaml/api">https://mmottl.github.io/sqlite3-ocaml/api</a>

##### CHANGES:

### Fixed

- Fixed OCaml GC rooting across runtime-released SQLite calls, preventing
  statement and database wrappers from being finalized while their explicit C
  primitives are blocked inside SQLite.
