### PR TITLE
[new release] Caqti 3.0.1 (2 driver packages)

### DIFF
--- a/packages/caqti-driver-mariadb/caqti-driver-mariadb.3.0.1/opam
+++ b/packages/caqti-driver-mariadb/caqti-driver-mariadb.3.0.1/opam
@@ -1,0 +1,34 @@
+opam-version: "2.0"
+maintainer: "Petter A. Urkedal <paurkedal@gmail.com>"
+x-maintenance-intent: ["(latest)"]
+authors: "Petter A. Urkedal <paurkedal@gmail.com>"
+license: "LGPL-3.0-or-later WITH LGPL-3.0-linking-exception"
+homepage: "https://github.com/paurkedal/ocaml-caqti/"
+doc: "https://paurkedal.github.io/ocaml-caqti/index.html"
+bug-reports: "https://github.com/paurkedal/ocaml-caqti/issues"
+depends: [
+  "alcotest" {with-test & >= "1.5.0"}
+  "ocaml"
+  "caqti" {>= "3.0.0" & < "3.1.0~"}
+  "cmdliner" {with-test & >= "1.1.0"}
+  "dune" {>= "3.23.1"}
+  "integers"
+  "mariadb" {>= "2.0.0"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+  ["dune" "build" "@doc" "-p" name "-j" jobs] {with-doc}
+]
+dev-repo: "git+https://github.com/paurkedal/ocaml-caqti.git"
+synopsis: "MariaDB driver for Caqti using C bindings"
+url {
+  src:
+    "https://github.com/paurkedal/ocaml-caqti/releases/download/v3.0.1/caqti-v3.0.1.tbz"
+  checksum: [
+    "sha256=da396b2a0e7ad29939535a544c083aacaefb14a71bf847196004b60be94fdb2b"
+    "sha512=f2191e91c6104ffdd9c6e6a698f29ef87e284af239390a3c9529befe1e2a05e991a08564ceecf913df39b49474e354ce3893bb078f7ad92a2ce4ad93ab70700d"
+  ]
+}
+x-commit-hash: "2aa215f78dfecaf3790c1cc8d8b8340cbc8083cb"

--- a/packages/caqti-driver-postgresql/caqti-driver-postgresql.3.0.1/opam
+++ b/packages/caqti-driver-postgresql/caqti-driver-postgresql.3.0.1/opam
@@ -35,3 +35,4 @@ url {
   ]
 }
 x-commit-hash: "2aa215f78dfecaf3790c1cc8d8b8340cbc8083cb"
+x-ci-accept-failures: [ "fedora-43" "fedora-44" ]

--- a/packages/caqti-driver-postgresql/caqti-driver-postgresql.3.0.1/opam
+++ b/packages/caqti-driver-postgresql/caqti-driver-postgresql.3.0.1/opam
@@ -35,4 +35,3 @@ url {
   ]
 }
 x-commit-hash: "2aa215f78dfecaf3790c1cc8d8b8340cbc8083cb"
-x-ci-accept-failures: [ "fedora-43" "fedora-44" ]

--- a/packages/caqti-driver-postgresql/caqti-driver-postgresql.3.0.1/opam
+++ b/packages/caqti-driver-postgresql/caqti-driver-postgresql.3.0.1/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+maintainer: "Petter A. Urkedal <paurkedal@gmail.com>"
+x-maintenance-intent: ["(latest)"]
+authors: [
+  "Petter A. Urkedal <paurkedal@gmail.com>"
+  "James Owen <james@cryptosense.com>"
+]
+license: "LGPL-3.0-or-later WITH LGPL-3.0-linking-exception"
+homepage: "https://github.com/paurkedal/ocaml-caqti/"
+doc: "https://paurkedal.github.io/ocaml-caqti/index.html"
+bug-reports: "https://github.com/paurkedal/ocaml-caqti/issues"
+depends: [
+  "alcotest" {with-test & >= "1.5.0"}
+  "ocaml"
+  "caqti" {>= "3.0.0" & < "3.1.0~"}
+  "cmdliner" {with-test & >= "1.1.0"}
+  "dune" {>= "3.23.1"}
+  "odoc" {with-doc}
+  "postgresql" {>= "5.0.0"}
+  "uri" {>= "4.0.0"}
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+  ["dune" "build" "@doc" "-p" name "-j" jobs] {with-doc}
+]
+dev-repo: "git+https://github.com/paurkedal/ocaml-caqti.git"
+synopsis: "PostgreSQL driver for Caqti based on C bindings"
+url {
+  src:
+    "https://github.com/paurkedal/ocaml-caqti/releases/download/v3.0.1/caqti-v3.0.1.tbz"
+  checksum: [
+    "sha256=da396b2a0e7ad29939535a544c083aacaefb14a71bf847196004b60be94fdb2b"
+    "sha512=f2191e91c6104ffdd9c6e6a698f29ef87e284af239390a3c9529befe1e2a05e991a08564ceecf913df39b49474e354ce3893bb078f7ad92a2ce4ad93ab70700d"
+  ]
+}
+x-commit-hash: "2aa215f78dfecaf3790c1cc8d8b8340cbc8083cb"


### PR DESCRIPTION
This release fixes a reconnect bug in the PostgreSQL driver and prepares the MariaDB driver for new 64 bit integer field types (mariadb.2.0.0).