### PR TITLE
[new release] fsevents (2 packages) (0.4.0)

### DIFF
--- a/packages/fsevents-lwt/fsevents-lwt.0.4.0/opam
+++ b/packages/fsevents-lwt/fsevents-lwt.0.4.0/opam
@@ -1,0 +1,43 @@
+opam-version: "2.0"
+synopsis: "Lwt interface to macOS FSEvents"
+description: """
+An Lwt interface to the macOS FSEvents framework, using the
+`cf-lwt` library for the low-level bindings."""
+maintainer: ["Thomas Gazagnaire"]
+authors: ["David Sheets" "Thomas Gazagnaire"]
+license: "ISC"
+homepage: "https://github.com/mirage/ocaml-fsevents"
+bug-reports: "https://github.com/mirage/ocaml-fsevents/issues"
+depends: [
+  "dune" {>= "2.8"}
+  "fsevents" {= version}
+  "cf-lwt"
+  "cmdliner" {>= "1.1.0"}
+  "alcotest" {with-test}
+  "lwt" {>= "5.0.0"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/mirage/ocaml-fsevents.git"
+url {
+  src:
+    "https://github.com/mirage/ocaml-fsevents/releases/download/0.4.0/fsevents-0.4.0.tbz"
+  checksum: [
+    "sha256=6e71330fdc04dba0871500c99406dd1f8de220249ccc3743d4d49eddbccb5807"
+    "sha512=f9eb5d3824f7a157177bb8c502a9b73aa80b3cef4a30779983ed559580fba5cc72451c1801436e7523454f24935f1ac10dc0b661d08716da1de1f551ee427882"
+  ]
+}
+x-commit-hash: "91f8f3e1518a3fd0836694bea2e6d3d4eb86fb7c"

--- a/packages/fsevents/fsevents.0.4.0/opam
+++ b/packages/fsevents/fsevents.0.4.0/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+synopsis: "OCaml bindings to macOS FSEvents"
+description: """
+These bindings use [ctypes](https://github.com/ocamllabs/ocaml-ctypes)
+for type-safe stub generation."""
+maintainer: ["Thomas Gazagnaire"]
+authors: ["David Sheets" "Thomas Gazagnaire"]
+license: "ISC"
+homepage: "https://github.com/mirage/ocaml-fsevents"
+bug-reports: "https://github.com/mirage/ocaml-fsevents/issues"
+depends: [
+  "dune" {>= "2.8"}
+  "cf" {>= "0.4"}
+  "ctypes" {>= "0.4.0"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/mirage/ocaml-fsevents.git"
+url {
+  src:
+    "https://github.com/mirage/ocaml-fsevents/releases/download/0.4.0/fsevents-0.4.0.tbz"
+  checksum: [
+    "sha256=6e71330fdc04dba0871500c99406dd1f8de220249ccc3743d4d49eddbccb5807"
+    "sha512=f9eb5d3824f7a157177bb8c502a9b73aa80b3cef4a30779983ed559580fba5cc72451c1801436e7523454f24935f1ac10dc0b661d08716da1de1f551ee427882"
+  ]
+}
+x-commit-hash: "91f8f3e1518a3fd0836694bea2e6d3d4eb86fb7c"


### PR DESCRIPTION
OCaml bindings to macOS FSEvents

- Project page: <a href="https://github.com/mirage/ocaml-fsevents">https://github.com/mirage/ocaml-fsevents</a>

##### CHANGES:

- Remove `base-bytes` dependency (@Leonidas-from-XIV, mirage/ocaml-fsevents#1)
- Update GitHUb actions scripts (@samoht, mirage/ocaml-fsevents#4)
- Update to `cmdliner.1.1.0` (@samoht, mirage/ocaml-fsevents#5)
- Apply `ocamlformat.0.27.0` (@MisterDA, @samoht, mirage/ocaml-fsevents#3)
