### PR TITLE
[new release] mirage-qubes (2 packages) (2.0.1)

### DIFF
--- a/packages/mirage-qubes-ipv4/mirage-qubes-ipv4.2.0.1/opam
+++ b/packages/mirage-qubes-ipv4/mirage-qubes-ipv4.2.0.1/opam
@@ -1,0 +1,35 @@
+opam-version: "2.0"
+maintainer:   "talex@gmail.com"
+authors:      ["Thomas Leonard"]
+license:      "BSD-2-Clause"
+homepage:     "https://github.com/mirage/mirage-qubes"
+bug-reports:  "https://github.com/mirage/mirage-qubes/issues"
+dev-repo:     "git+https://github.com/mirage/mirage-qubes.git"
+doc:          "https://mirage.github.io/mirage-qubes"
+
+build: [
+  [ "dune" "subst"] {dev}
+  [ "dune" "build" "-p" name "-j" jobs ]
+]
+
+depends: [
+  "dune"  {>= "1.0"}
+  "mirage-qubes" {= version}
+  "tcpip" { >= "9.0.0" }
+  "ethernet" {>= "3.0.0"}
+  "arp" {>= "3.0.0"}
+  "ipaddr" { >= "3.0.0" }
+  "lwt" { >= "5.7.0" }
+  "ocaml" { >= "4.06.0" }
+]
+synopsis: "Implementations of IPv4 stack which reads configuration from QubesDB for MirageOS"
+x-maintenance-intent: [ "(latest)" ]
+url {
+  src:
+    "https://github.com/mirage/mirage-qubes/releases/download/v2.0.1/mirage-qubes-2.0.1.tbz"
+  checksum: [
+    "sha256=c0eb2d41472ca9b3b3a4a2663a40ac79d9f9883dfbe3ff944182fcf2e2590a66"
+    "sha512=f8dcd866d351db433bc4280cd251c7b65bafc36cb14247c382aeff63200f19e982fac7af8961d6f887a9a16d5fb8d473248511ed9d66de898e20b17e02adb344"
+  ]
+}
+x-commit-hash: "bf145202e3a01a44984a8a25217e66bac5eab8ae"

--- a/packages/mirage-qubes/mirage-qubes.2.0.1/opam
+++ b/packages/mirage-qubes/mirage-qubes.2.0.1/opam
@@ -1,0 +1,42 @@
+opam-version: "2.0"
+maintainer:   "talex@gmail.com"
+authors:      ["Thomas Leonard"]
+homepage:     "https://github.com/mirage/mirage-qubes"
+bug-reports:  "https://github.com/mirage/mirage-qubes/issues"
+dev-repo:     "git+https://github.com/mirage/mirage-qubes.git"
+doc:          "https://mirage.github.io/mirage-qubes"
+license:      "BSD-2-Clause"
+
+build: [
+  [ "dune" "subst"] {dev}
+  [ "dune" "build" "-p" name "-j" jobs ]
+]
+
+depends: [
+  "dune"  {>= "1.0"}
+  "cstruct" { >= "6.0.0" }
+  "vchan-xen" { >= "6.0.0" }
+  "mirage-xen" { >= "8.0.0" }
+  "lwt" { >= "5.7.0" }
+  "logs" { >= "0.5.0" }
+  "ocaml" { >= "4.08.0" }
+  "ohex" { >= "0.2.0" }
+  "fmt" {>= "0.8.5"}
+]
+synopsis: "Implementations of various Qubes protocols for MirageOS"
+description: """
+Implementations of various Qubes protocols:
+
+- Qubes.RExec: provide services to other VMs
+- Qubes.GUI: just enough of the GUI protocol so that Qubes accepts the AppVM
+- Qubes.DB: read and write the VM's QubesDB database"""
+x-maintenance-intent: [ "(latest)" ]
+url {
+  src:
+    "https://github.com/mirage/mirage-qubes/releases/download/v2.0.1/mirage-qubes-2.0.1.tbz"
+  checksum: [
+    "sha256=c0eb2d41472ca9b3b3a4a2663a40ac79d9f9883dfbe3ff944182fcf2e2590a66"
+    "sha512=f8dcd866d351db433bc4280cd251c7b65bafc36cb14247c382aeff63200f19e982fac7af8961d6f887a9a16d5fb8d473248511ed9d66de898e20b17e02adb344"
+  ]
+}
+x-commit-hash: "bf145202e3a01a44984a8a25217e66bac5eab8ae"


### PR DESCRIPTION
Implementations of various Qubes protocols for MirageOS

- Project page: <a href="https://github.com/mirage/mirage-qubes">https://github.com/mirage/mirage-qubes</a>
- Documentation: <a href="https://mirage.github.io/mirage-qubes">https://mirage.github.io/mirage-qubes</a>

##### CHANGES:

- add default handler for commands, change the API for listen (mirage/mirage-qubes#76, @palainp, reviewed by @hannesm)
- use quick_stat to check the free memory available all the time (mirage/mirage-qubes#77, @palainp, reviewed by @hannesm)
