### PR TITLE
Add constraint for tplib 1.3 about OCaml < 5

### DIFF
--- a/packages/tplib/tplib.1.3-1/opam
+++ b/packages/tplib/tplib.1.3-1/opam
@@ -17,7 +17,7 @@ remove: [
   [make "uninstall"]
 ]
 depends: [
-  "ocaml" {>= "3.12.0" & < "5" }
+  "ocaml" {>= "3.12.0"}
   "ocamlfind"
   "ocamlbuild" {build}
   "num"

--- a/packages/tplib/tplib.1.3-1/opam
+++ b/packages/tplib/tplib.1.3-1/opam
@@ -1,0 +1,73 @@
+opam-version: "2.0"
+maintainer: "xavier.allamigeon (at) inria.fr"
+authors: ["Xavier ALLAMIGEON"]
+homepage: "https://gforge.inria.fr/projects/tplib/"
+bug-reports: "https://gforge.inria.fr/tracker/?group_id=3286"
+dev-repo: "git+https://scm.gforge.inria.fr/anonscm/git/tplib/tplib.git"
+license: "LGPL-2.1-only"
+build: [
+  ["./configure" "--prefix" prefix]
+  [make]
+]
+install: [
+  [make "install"]
+]
+remove: [
+  ["./configure" "--prefix" prefix]
+  [make "uninstall"]
+]
+depends: [
+  "ocaml" {>= "3.12.0" & < "5" }
+  "ocamlfind"
+  "ocamlbuild" {build}
+  "num"
+]
+depopts: [
+  "zarith"
+  "mlgmp"
+]
+conflicts: [
+  "mlgmpidl"
+]
+synopsis: "TPLib: Tropical Polyhedra Library"
+description: """
+TPLib implements several algorithms to manipulate tropical polyhedra. Among
+others, it allows to compute:
+* the extreme points and rays of tropical polyhedra,
+* tropical polar cones,
+* the minimal representations by means of half-spaces,
+* the tropical complex associated with a tropical polytope.
+
+TPLib also provides abstract operations over tropical polyhedra (intersections,
+convex hull of unions, etc), which are typically useful in applications to
+formal verification."""
+
+url {
+  src:
+    "https://github.com/ocaml/opam-source-archives/raw/main/tplib-1.3.tar.gz"
+  checksum: [
+    "sha256=17f62ac4ace4be573ec9cb1fae1aaf12d0d31bc907df3fa5b6cf5eb8e2923312"
+    "md5=861bde89a6790b78474c5578f821aea4"
+  ]
+}
+
+patches: [
+  "fix-makefile.patch"
+  "fix-bindings-install.patch"
+]
+
+extra-source "fix-makefile.patch" {
+  src:
+    "https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/tplib/fix-makefile.diff"
+  checksum: [
+    "sha256=76fc3470ac62ac8d092a9ad647a20ff032308e38717f5b1f1d0c9e107c4174f6"
+    "md5=4d6c16c0d8c001c09afd8d9ddb8493f0"
+  ]
+}
+extra-source "fix-bindings-install.patch" {
+  src:
+    "https://gist.githubusercontent.com/mseri/6137405c32def0d884b9b3b86e21d0a7/raw/1f27ffa35dda7765a4559790374c79217234adab/fix-bindings-install.diff"
+  checksum: [
+    "sha256=d866f2f9a1289e5c02dcf339accc034b117c21de4e82db5f123b5d0e57342d1d"
+  ]
+}

--- a/packages/tplib/tplib.1.3-1/opam
+++ b/packages/tplib/tplib.1.3-1/opam
@@ -66,7 +66,7 @@ extra-source "fix-makefile.patch" {
 }
 extra-source "fix-bindings-install.patch" {
   src:
-    "https://gist.githubusercontent.com/mseri/6137405c32def0d884b9b3b86e21d0a7/raw/1f27ffa35dda7765a4559790374c79217234adab/fix-bindings-install.diff"
+    "https://raw.githubusercontent.com/ocaml/opam-source-archives/refs/heads/main/patches/tplib/fix-bindings-install.diff"
   checksum: [
     "sha256=d866f2f9a1289e5c02dcf339accc034b117c21de4e82db5f123b5d0e57342d1d"
   ]

--- a/packages/tplib/tplib.1.3/opam
+++ b/packages/tplib/tplib.1.3/opam
@@ -4,6 +4,7 @@ authors: ["Xavier ALLAMIGEON"]
 homepage: "https://gforge.inria.fr/projects/tplib/"
 bug-reports: "https://gforge.inria.fr/tracker/?group_id=3286"
 dev-repo: "git+https://scm.gforge.inria.fr/anonscm/git/tplib/tplib.git"
+license: "LGPL-2.1-only"
 build: [
   ["./configure" "--prefix" prefix]
   [make]
@@ -16,7 +17,7 @@ remove: [
   [make "uninstall"]
 ]
 depends: [
-  "ocaml" {>= "3.12.0"}
+  "ocaml" {>= "3.12.0" & < "5" }
   "ocamlfind"
   "ocamlbuild" {build}
   "num"

--- a/packages/tplib/tplib.1.3/opam
+++ b/packages/tplib/tplib.1.3/opam
@@ -4,7 +4,6 @@ authors: ["Xavier ALLAMIGEON"]
 homepage: "https://gforge.inria.fr/projects/tplib/"
 bug-reports: "https://gforge.inria.fr/tracker/?group_id=3286"
 dev-repo: "git+https://scm.gforge.inria.fr/anonscm/git/tplib/tplib.git"
-license: "LGPL-2.1-only"
 build: [
   ["./configure" "--prefix" prefix]
   [make]
@@ -17,7 +16,7 @@ remove: [
   [make "uninstall"]
 ]
 depends: [
-  "ocaml" {>= "3.12.0" & < "5" }
+  "ocaml" {>= "3.12.0"}
   "ocamlfind"
   "ocamlbuild" {build}
   "num"

--- a/packages/tplib/tplib.1.3/opam
+++ b/packages/tplib/tplib.1.3/opam
@@ -16,7 +16,7 @@ remove: [
   [make "uninstall"]
 ]
 depends: [
-  "ocaml" {>= "3.12.0"}
+  "ocaml" {>= "3.12.0" & < "5"}
   "ocamlfind"
   "ocamlbuild" {build}
   "num"


### PR DESCRIPTION
Looking at https://check.ci.ocaml.org/?comp=4.14&comp=5.2&comp=5.4&comp=5.5&available=4.14&available=5.2&available=5.4&available=5.5&show-only=partial&show-only=bad&show-only=internal-failure&show-latest-only=true&packages=tplib&maintainers=+&logsearch=&logsearch_comp=4.14 it seems that tplib has not chance to compile in OCaml 5. The package is very old, https://github.com/ocaml/opam-repository/pull/462 so, I beleive it is undermaintaned and I used my bravery to add a constraint. CC @nhojem