### PR TITLE
Add constraint OCaml < 5.2 for qrencode 0.2

### DIFF
--- a/packages/conf-qrencode/conf-qrencode.0.2/opam
+++ b/packages/conf-qrencode/conf-qrencode.0.2/opam
@@ -1,0 +1,33 @@
+opam-version: "2.0"
+maintainer: "vb@luminar.eu.org"
+authors: ["Vincent Bernardoff"]
+homepage: "https://github.com/vbmithr/qrencode-ocaml"
+
+license: "LGPL-2.1-or-later"
+bug-reports: "https://github.com/vbmithr/qrencode-ocaml/issues"
+
+build: [
+  ["sh" "-exc" "echo \"#include  \\\"qrencode.h\\\"\" > test.c"]
+  ["sh" "-exc" "cc -c $CFLAGS test.c"] {os != "macos" & os != "freebsd" }
+  [
+    "sh"
+    "-exc"
+    "cc -c $CFLAGS -I/opt/homebrew/include -I/opt/local/include -I/usr/local/include test.c"
+  ] { os = "macos" | os = "freebsd" }
+]
+
+depexts: [
+  [ "libqrencode-dev"  ] {os-family = "debian"}
+  [ "qrencode"  ] { os-distribution = "arch" | os-distribution = "msys2" }
+  [ "qrencode" "qrencode-devel" ] { os-family = "fedora" }
+  [ "qrencode-devel" ] { os-family = "suse" | os-family = "opensuse"}
+  [ "epel-release" "qrencode-devel" ] { os-distribution = "centos" }
+  [ "qrencode" ] { os-distribution = "homebrew" }
+  [ "libqrencode" ] { os = "freebsd" }
+  [ "libqrencode-dev" ] { os-distribution = "alpine" }
+  [ "libqrencode-devel" ] { os-distribution = "cygwin" }
+]
+
+synopsis: "Virtual package relying on a libqrencode system installation"
+
+flags: conf

--- a/packages/qrencode/qrencode.0.2-1/opam
+++ b/packages/qrencode/qrencode.0.2-1/opam
@@ -3,17 +3,17 @@ maintainer: "vb@luminar.eu.org"
 authors: ["Vincent Bernardoff"]
 homepage: "https://github.com/vbmithr/qrencode-ocaml"
 build: ["dune" "build" "-p" name "-j" jobs]
+license: "LGPL-2.1-or-later"
 
 depends: [
   "conf-pkg-config"
+  "conf-qrencode"
+  "conf-libpng"
   "dune" {>= "1.10"}
   "dune-configurator"
   "ocaml"
 ]
-depexts: [
-  ["libqrencode-dev" "libpng-dev"] {os-family = "debian"}
-  ["qrencode" "libpng"] {os-distribution = "arch"}
-]
+
 dev-repo: "git+https://github.com/vbmithr/qrencode-ocaml"
 bug-reports: "https://github.com/vbmithr/qrencode-ocaml/issues"
 synopsis: "Binding to libqrencode (QR-code encoding library)"
@@ -24,11 +24,30 @@ Code symbol, a 2D symbology that can be scanned by handy terminals
 such as a mobile phone with CCD. The capacity of QR Code is up to 7000
 digits or 4000 characters and has high robustness."
 """
+
 url {
   src:
     "https://github.com/vbmithr/qrencode-ocaml/releases/download/0.2/qrencode-0.2.tbz"
   checksum: [
     "sha256=2058669f169bace743f09ce03ce0227e49548e6e77a1d3852aebab287bab721b"
     "sha512=7fabfe4c9e03af13a0d296014416c740c66f6a57498f984294b83348e4d0e98e00261711d862a568c7b5e6803d5ed40ff02e4c57ea08ee66075c02686c004b29"
+  ]
+}
+patches: [
+  "ubuntu.patch" { os-distribution = "ubuntu" }
+  "alloc_custom.patch"
+]
+extra-source "ubuntu.patch" {
+  src:
+    "https://raw.githubusercontent.com/ocaml/opam-source-archives/refs/heads/main/patches/qrencode/ubuntu.patch"
+  checksum: [
+    "sha256=f829d7818e381f8e35a2f25990f0406f3ceeb31269eaedb4caa6d12b6b31aab4"
+  ]
+}
+extra-source "alloc_custom.patch" {
+  src:
+    "https://raw.githubusercontent.com/ocaml/opam-source-archives/refs/heads/main/patches/qrencode/alloc_custom.patch"
+  checksum: [
+    "sha256=4663ef867858d10e2f022a5ab0e16fff15ca2c7ebe6405b51b573b4221dcb5bf"
   ]
 }

--- a/packages/qrencode/qrencode.0.2/opam
+++ b/packages/qrencode/qrencode.0.2/opam
@@ -3,17 +3,17 @@ maintainer: "vb@luminar.eu.org"
 authors: ["Vincent Bernardoff"]
 homepage: "https://github.com/vbmithr/qrencode-ocaml"
 build: ["dune" "build" "-p" name "-j" jobs]
+license: "LGPL-2.1-or-later"
 
 depends: [
   "conf-pkg-config"
+  "conf-qrencode"
+  "conf-libpng"
   "dune" {>= "1.10"}
   "dune-configurator"
   "ocaml"
 ]
-depexts: [
-  ["libqrencode-dev" "libpng-dev"] {os-family = "debian"}
-  ["qrencode" "libpng"] {os-distribution = "arch"}
-]
+
 dev-repo: "git+https://github.com/vbmithr/qrencode-ocaml"
 bug-reports: "https://github.com/vbmithr/qrencode-ocaml/issues"
 synopsis: "Binding to libqrencode (QR-code encoding library)"
@@ -24,11 +24,30 @@ Code symbol, a 2D symbology that can be scanned by handy terminals
 such as a mobile phone with CCD. The capacity of QR Code is up to 7000
 digits or 4000 characters and has high robustness."
 """
+
 url {
   src:
     "https://github.com/vbmithr/qrencode-ocaml/releases/download/0.2/qrencode-0.2.tbz"
   checksum: [
     "sha256=2058669f169bace743f09ce03ce0227e49548e6e77a1d3852aebab287bab721b"
     "sha512=7fabfe4c9e03af13a0d296014416c740c66f6a57498f984294b83348e4d0e98e00261711d862a568c7b5e6803d5ed40ff02e4c57ea08ee66075c02686c004b29"
+  ]
+}
+patches: [
+  "ubuntu.patch" { os-distribution = "ubuntu" }
+  "alloc_custom.patch"
+]
+extra-source "ubuntu.patch" {
+  src:
+    "https://raw.githubusercontent.com/ocaml/opam-source-archives/refs/heads/main/patches/qrencode/ubuntu.patch"
+  checksum: [
+    "sha256=f829d7818e381f8e35a2f25990f0406f3ceeb31269eaedb4caa6d12b6b31aab4"
+  ]
+}
+extra-source "alloc_custom.patch" {
+  src:
+    "https://raw.githubusercontent.com/ocaml/opam-source-archives/refs/heads/main/patches/qrencode/alloc_custom.patch"
+  checksum: [
+    "sha256=4663ef867858d10e2f022a5ab0e16fff15ca2c7ebe6405b51b573b4221dcb5bf"
   ]
 }


### PR DESCRIPTION
https://check.ci.ocaml.org says that last compilable version of 4.14
CC @vbmithr