### PR TITLE
Add constraint OCaml < 5.2 for oclock 0.4

### DIFF
--- a/packages/oclock/oclock.0.4.0/opam
+++ b/packages/oclock/oclock.0.4.0/opam
@@ -5,7 +5,7 @@ homepage: ["http://micdel.fr/oclock.html"]
 license: "ISC"
 build: [make "all"]
 remove: [["ocamlfind" "remove" "oclock"]]
-depends: ["ocaml" {< "5.2"} "ocamlfind"]
+depends: ["ocaml" {< "5.0"} "ocamlfind"]
 dev-repo: "git+https://github.com/polazarus/oclock"
 bug-reports: "https://github.com/polazarus/oclock/issues"
 

--- a/packages/oclock/oclock.0.4.0/opam
+++ b/packages/oclock/oclock.0.4.0/opam
@@ -5,7 +5,11 @@ homepage: ["http://micdel.fr/oclock.html"]
 license: "ISC"
 build: [make "all"]
 remove: [["ocamlfind" "remove" "oclock"]]
-depends: ["ocaml" {< "5.0"} "ocamlfind"]
+depends: [
+  "ocaml" {< "5.0"}
+  "ocamlfind"
+  "conf-which"
+]
 dev-repo: "git+https://github.com/polazarus/oclock"
 bug-reports: "https://github.com/polazarus/oclock/issues"
 

--- a/packages/oclock/oclock.0.4.0/opam
+++ b/packages/oclock/oclock.0.4.0/opam
@@ -5,8 +5,10 @@ homepage: ["http://micdel.fr/oclock.html"]
 license: "ISC"
 build: [make "all"]
 remove: [["ocamlfind" "remove" "oclock"]]
-depends: ["ocaml" "ocamlfind"]
+depends: ["ocaml" {< "5.2"} "ocamlfind"]
 dev-repo: "git+https://github.com/polazarus/oclock"
+bug-reports: "https://github.com/polazarus/oclock/issues"
+
 install: [make "install"]
 available: os != "macos"
 synopsis: "Oclock: Precise POSIX clock for OCaml"


### PR DESCRIPTION
It looks like package is not updated for current OCaml. Discovered on https://check.ci.ocaml.org/

See https://github.com/polazarus/oclock/issues/6

CC @polazarus