### PR TITLE
Remove unnecessary dependencies for libbpf

### DIFF
--- a/packages/libbpf/libbpf.0.1.0/opam
+++ b/packages/libbpf/libbpf.0.1.0/opam
@@ -12,8 +12,6 @@ depends: [
   "ocaml" {>= "4.08"}
   "dune" {>= "3.13"}
   "ctypes" {>= "0.22.0"}
-  "ppx_deriving"
-  "ppx_expect"
   "conf-libbpf"
   "conf-clang"
   "conf-bpftool"


### PR DESCRIPTION
It would seem the library never required these dependencies and given ppx_expect pulls in at least 11 direct, extra dependencies; it seems worth it to remove these. I'll follow up afterwards upstream. Hopefully CI will double-check I didn't miss anything here.