### PR TITLE
Remove unnecessary dependencies from libbpf

### DIFF
--- a/packages/libbpf/libbpf.0.1.0/opam
+++ b/packages/libbpf/libbpf.0.1.0/opam
@@ -12,8 +12,6 @@ depends: [
   "ocaml" {>= "4.08"}
   "dune" {>= "3.13"}
   "ctypes" {>= "0.22.0"}
-  "ppx_deriving"
-  "ppx_expect"
   "conf-libbpf"
   "conf-clang"
   "conf-bpftool"


### PR DESCRIPTION
Retrying #30490 but from a fresh fork of opam-repository and a proper branch (not using the Github UI).