### PR TITLE
[new release] mirage-xen (9.0.1)

### DIFF
--- a/packages/mirage-xen/mirage-xen.9.0.1/opam
+++ b/packages/mirage-xen/mirage-xen.9.0.1/opam
@@ -1,0 +1,52 @@
+opam-version: "2.0"
+maintainer:   "anil@recoil.org"
+authors:      "The MirageOS team"
+homepage:     "https://github.com/mirage/mirage-xen"
+bug-reports:  "https://github.com/mirage/mirage-xen/issues/"
+dev-repo:     "git+https://github.com/mirage/mirage-xen.git"
+doc:          "https://mirage.github.io/mirage-xen/"
+license:      "ISC"
+tags:         ["org:mirage"]
+
+build: [
+  [ "dune" "subst" ] {dev}
+  [ "dune" "build" "-p" name "-j" jobs ]
+]
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "2.7.0"}
+  "cstruct" {>= "1.0.1"}
+  "lwt" {>= "2.4.3"}
+  "shared-memory-ring-lwt"
+  "xenstore" {>= "1.2.5"}
+  "lwt-dllist"
+  "io-page" {>= "2.4.0"}
+  "mirage-runtime" {>= "4.6.0"}
+  "logs"
+  "fmt" {>= "0.8.5"}
+  "bheap" {>= "2.0.0"}
+  "duration"
+  "metrics"
+  "metrics-lwt" {>= "0.2.0"}
+  "mirage-sleep" {>= "4.0.0"}
+]
+available: [
+  (arch = "x86_64" ) &
+  (os = "linux" | os = "freebsd" | os = "openbsd")
+]
+synopsis: "Xen core platform libraries for MirageOS"
+description: """
+This package provides the MirageOS `OS` library for
+Xen targets, which handles the main loop and timers.  It also provides
+the low level C startup code and C stubs required by the OCaml code.
+"""
+x-maintenance-intent: [ "(latest)" ]
+url {
+  src:
+    "https://github.com/mirage/mirage-xen/releases/download/v9.0.1/mirage-xen-9.0.1.tbz"
+  checksum: [
+    "sha256=f60d042e0f003c8b9f50821e04f859b36f02eca27f361830a5f7150082f333e3"
+    "sha512=9673f54480bf35ef1b9f11c0f71db6a5a522ce1f6a7acfa862f98253d5574ca8d0d1ea1917286cf7d899a490a8a2d7935e0cb5fda8b6c196f477da610ea7ffe4"
+  ]
+}
+x-commit-hash: "b2590f51d43dff8fc67c4f7355b270071857e619"


### PR DESCRIPTION
Xen core platform libraries for MirageOS

- Project page: <a href="https://github.com/mirage/mirage-xen">https://github.com/mirage/mirage-xen</a>
- Documentation: <a href="https://mirage.github.io/mirage-xen/">https://mirage.github.io/mirage-xen/</a>

##### CHANGES:

* Add Import.copy_from / Import.copy_to, hypervisor-mediated grant copy.
  These copy between one of our own frames and a page another domain has granted
  us. Much faster than the previous approach for e.g. the qubes-mirage-firewall
  (mirage/mirage-xen#56 @palainp)
