### PR TITLE
accessor_core 0.17 needs ocaml < 5.5

### DIFF
--- a/packages/accessor_core/accessor_core.v0.17.0/opam
+++ b/packages/accessor_core/accessor_core.v0.17.0/opam
@@ -10,7 +10,7 @@ build: [
   ["dune" "build" "-p" name "-j" jobs]
 ]
 depends: [
-  "ocaml"         {>= "5.1.0"}
+  "ocaml"         {>= "5.1.0" & < "5.5.0" }
   "accessor_base" {>= "v0.17" & < "v0.18~"}
   "core"          {>= "v0.17" & < "v0.18~"}
   "ppx_accessor"  {>= "v0.17" & < "v0.18~"}


### PR DESCRIPTION
See: https://github.com/janestreet/accessor_core/issues/1

Discovered while looking at [check.ci.ocaml](https://check.ci.ocaml.org/?comp=4.11&comp=4.14&comp=5.2&comp=5.4&comp=5.5&available=4.11&available=4.14&available=5.2&available=5.4&available=5.5&show-only=good&show-only=partial&show-only=bad&show-only=not-available&show-only=internal-failure&packages=accessor_core&maintainers=&logsearch=&logsearch_comp=4.11)