### PR TITLE
conf-lua: add Ubuntu and other depexts

### DIFF
--- a/packages/conf-lua/conf-lua.1/opam
+++ b/packages/conf-lua/conf-lua.1/opam
@@ -7,10 +7,23 @@ authors: [
 ]
 homepage: "http://www.lua.org/"
 license: "MIT"
-build: [["pkg-config" "lua"]]
+build: [
+  # Ubuntu have separate packages liblua5.2-dev, liblua5.3-dev, liblua5.4-dev and no single .pc file
+  ["pkg-config" "lua5.2"] { os-family = "debian" }
+  ["pkg-config" "lua-5.2"] { os = "freebsd" }
+  ["pkg-config" "lua"] { os-family != "debian" & os != "freebsd" }
+]
 depexts: [
   ["liblua5.2-dev"] {os-family = "debian"}
   ["liblua-devel"] {os-distribution = "mageia"}
+  ["lua-devel"] {os-family = "fedora" |  os-family = "rhel" | os-distribution = "centos" |
+    os-family = "suse" |
+    os-distribution = "opensuse-tumbleweed" |
+    os-distribution = "opensuse"
+  }
+  ["lua"] {os-family = "arch" | os-distribution = "homebrew" }
+  ["lua-dev"] {os-family = "alpine"}
+  ["lua52"] {os = "freebsd"}
 ]
 x-ci-accept-failures: ["debian-unstable"]
 synopsis: "Virtual package relying on a Lua system installation"

--- a/packages/conf-lua/conf-lua.1/opam
+++ b/packages/conf-lua/conf-lua.1/opam
@@ -11,7 +11,7 @@ build: [
   # Ubuntu have separate packages liblua5.2-dev, liblua5.3-dev, liblua5.4-dev and no single .pc file
   ["pkg-config" "lua5.2"] { os-family = "debian" }
   ["pkg-config" "lua-5.2"] { os = "freebsd" }
-  ["pkg-config" "lua"] { os-family != "debian" & os != "freebsd" }
+  ["pkg-config" "lua"] { os-family != "debian" & os-family != "ubuntu" & os != "freebsd" }
 ]
 depexts: [
   ["liblua5.2-dev"] {os-family = "debian"}

--- a/packages/conf-lua/conf-lua.1/opam
+++ b/packages/conf-lua/conf-lua.1/opam
@@ -9,7 +9,7 @@ homepage: "http://www.lua.org/"
 license: "MIT"
 build: [
   # Ubuntu have separate packages liblua5.2-dev, liblua5.3-dev, liblua5.4-dev and no single .pc file
-  ["pkg-config" "lua5.2"] { os-family = "debian" }
+  ["pkg-config" "lua5.2"] { os-family = "debian" | os-family = "ubuntu" }
   ["pkg-config" "lua-5.2"] { os = "freebsd" }
   ["pkg-config" "lua"] { os-family != "debian" & os-family != "ubuntu" & os != "freebsd" }
 ]

--- a/packages/conf-lua/conf-lua.1/opam
+++ b/packages/conf-lua/conf-lua.1/opam
@@ -14,7 +14,7 @@ build: [
   ["pkg-config" "lua"] { os-family != "debian" & os-family != "ubuntu" & os != "freebsd" }
 ]
 depexts: [
-  ["liblua5.2-dev"] {os-family = "debian"}
+  ["liblua5.2-dev"] {os-family = "debian" | os-family = "ubuntu" }
   ["liblua-devel"] {os-distribution = "mageia"}
   ["lua-devel"] {os-family = "fedora" |  os-family = "rhel" | os-distribution = "centos" |
     os-family = "suse" |


### PR DESCRIPTION
Only windows depexts are missing for now. But we should start addressing    this from the package conf-pkgconfig
