### PR TITLE
[new release] yamlx (0.4.0)

### DIFF
--- a/packages/yamlx/yamlx.0.4.0/opam
+++ b/packages/yamlx/yamlx.0.4.0/opam
@@ -1,0 +1,49 @@
+opam-version: "2.0"
+synopsis:
+  "Pure-OCaml YAML 1.2/1.1 parser with a lossless, comment-preserving AST"
+description: """
+YAMLx is a pure-OCaml YAML 1.2 library. It passes all 371 tests from the yaml-test-suite and has no C bindings or external runtime dependencies. The parsed node tree preserves scalar styles, flow vs. block collection style, tags, anchors, source positions, and comments. A pretty-printer can round-trip the AST back to YAML. A typed-value resolver applies the YAML 1.2 JSON schema and returns Null / Bool / Int / Float / String / Seq / Map values. Structured errors carry line, column, and byte-offset information.
+
+YAMLx is currently released under the AGPL. A commercial license and a path to a fully permissive ISC license are available — see FUNDING.md."""
+maintainer: ["Martin Jambon <martin@mjambon.com>"]
+authors: ["Martin Jambon <martin@mjambon.com>"]
+license: "AGPL-3.0-only"
+tags: ["yaml" "parser" "serialization"]
+homepage: "https://github.com/mjambon/yamlx"
+doc: "https://mjambon.github.io/yamlx"
+bug-reports: "https://github.com/mjambon/yamlx/issues"
+depends: [
+  "dune" {>= "3.20"}
+  "ocaml" {>= "4.14.0"}
+  "ppx_deriving"
+  "testo" {with-test}
+  "odoc" {with-doc}
+  "afl-persistent" {with-dev-setup}
+  "ocamlformat" {with-dev-setup}
+  "yaml" {with-dev-setup}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/mjambon/yamlx.git"
+x-maintenance-intent: ["(latest)"]
+url {
+  src:
+    "https://github.com/mjambon/yamlx/releases/download/0.4.0/yamlx-0.4.0.tbz"
+  checksum: [
+    "sha256=6949a4c073defa34518bf86d473074f94052112a60138d135a2f9bae9fa2274b"
+    "sha512=b52510a322dd1d92ab79c19c50bc7ad695c1bd4b66015fe7f371e1395cd0edc79a53dbd057145ec62b7fee5362db198ffd1958c0706846982e2668c47a38f9fa"
+  ]
+}
+x-commit-hash: "7c824a8b4a8823c9f598ed0aa72b7ebcd4f94e11"


### PR DESCRIPTION
Pure-OCaml YAML 1.2/1.1 parser with a lossless, comment-preserving AST

- Project page: <a href="https://github.com/mjambon/yamlx">https://github.com/mjambon/yamlx</a>
- Documentation: <a href="https://mjambon.github.io/yamlx">https://mjambon.github.io/yamlx</a>

##### CHANGES:

- **Folded block scalar for prose strings with a trailing newline**
  ([mjambon/yamlx#39](https://github.com/mjambon/yamlx/issues/39)).
  A long prose string ending with `\n` (e.g. from a text field that already
  carried a line terminator) was incorrectly serialized as a `Double_quoted`
  scalar. It is now emitted as a `>` folded block (clip chomp), matching the
  output for the same string without the trailing newline (`>-`).
- **Better float formatting**
  ([mjambon/yamlx#41](https://github.com/mjambon/yamlx/issues/41)).
  For example, `3.14` is now printed as `3.14` instead of `3.1400000000000001`.
