### PR TITLE
Constraint errpy.0.0.10 on OCaml < 5.2

### DIFF
--- a/packages/errpy/errpy.0.0.10/opam
+++ b/packages/errpy/errpy.0.0.10/opam
@@ -9,7 +9,7 @@ license: "MIT"
 homepage: "https://github.com/facebook/errpy"
 bug-reports: "https://github.com/facebook/errpy/issues"
 depends: [
-  "ocaml" {>= "4.05"}
+  "ocaml" {>= "4.05" & < "5.2" }
   "dune" {>= "3.4"}
   "ppx_deriving"
   "conf-rust-2021" {build}


### PR DESCRIPTION
The compilation error is

> `#ocamlpool.c: In function 'ocamlpool_reserve_block':`
> `#ocamlpool.c:383:14: error: too many arguments to function caml_shared_try_alloc'`
> `  383 |   value* p = caml_shared_try_alloc(`
> `      |              ^~~~~~~~~~~~~~~~~~~~~`

Investigation leads to [1] where we can see that authors prepared at least for OCaml 5.1. In the unreleased version [2] we see preparation for 5.2. So, the upper bound to 5.2 seems to be reasonable.

Also, the original repo has been archived on Jan 21, 2025. Unlikely we will get updated release soon.

[1] https://github.com/facebook/errpy/blob/0.0.10/vendor/ocaml/interop/ocamlrep_ocamlpool/ocamlpool.c#L387
[2] https://github.com/facebook/errpy/blob/main/vendor/ocaml/interop/ocamlrep_ocamlpool/ocamlpool.c#L392