### PR TITLE
 Add more x-ci-accept-failures for accplus

### DIFF
--- a/packages/aacplus/aacplus.0.2.2/opam
+++ b/packages/aacplus/aacplus.0.2.2/opam
@@ -14,6 +14,7 @@ remove: ["ocamlfind" "remove" "aacplus"]
 depends: ["ocaml" "ocamlfind" "conf-pkg-config" {build}]
 # Ideally, we want to make conf-* package from this but for unmaintained package it is a waste of time
 depexts: [
+  ["libaacplus"] {os-distribution = "arch"}
   ["libaacplus"] {os-distribution = "gentoo"}
   #["libaacplus"] {os = "freebsd"} # removed from ports https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=262185
 ]
@@ -42,7 +43,7 @@ x-ci-accept-failures: [
 ]
 messages: [
   # https://aur.archlinux.org/packages/libaacplus
-  "On Arch Linux, this package requires 'libaacplus' from the AUR:  yay -S libaacplus" {os-family = "arch"}
+  "On Arch Linux, this package requires 'libaacplus' from the AUR:  yay -S libaacplus" {os-family = "arch" & failure}
 ]
 
 bug-reports: "https://github.com/savonet/ocaml-aacplus/issues"

--- a/packages/aacplus/aacplus.0.2.2/opam
+++ b/packages/aacplus/aacplus.0.2.2/opam
@@ -2,6 +2,7 @@ opam-version: "2.0"
 maintainer: "Romain Beauxis <toots@rastageeks.org>"
 authors: "The Savonet Team <savonet-users@lists.sourceforge.net>"
 homepage: "https://github.com/savonet/ocaml-aacplus"
+license: "LGPL-2.1-only"
 build: [
   ["./configure" "--prefix" prefix]
   [make]
@@ -11,12 +12,39 @@ install: [
 ]
 remove: ["ocamlfind" "remove" "aacplus"]
 depends: ["ocaml" "ocamlfind" "conf-pkg-config" {build}]
+# Ideally, we want to make conf-* package from this but for unmaintained package it is a waste of time
 depexts: [
-  ["libaacplus"] {os-distribution = "arch"}
   ["libaacplus"] {os-distribution = "gentoo"}
-  ["libaacplus"] {os = "freebsd"}
+  #["libaacplus"] {os = "freebsd"} # removed from ports https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=262185
 ]
-x-ci-accept-failures: ["debian-11" "debian-unstable"]
+x-ci-accept-failures: [
+  "freebsd-15.1"
+  "debian-unstable"
+  "debian-testing"
+  "debian-11"
+  "debian-12"
+  "debian-13"
+  "ubuntu-26.04"
+  "ubuntu-24.04"  # Ubuntu and most Linuxes doesn't have this package
+  "ubuntu-25.04"
+  "ubuntu-25.10"
+  "ubuntu-22.04"
+  "fedora-42"
+  "fedora-43"
+  "fedora-44"
+  "opensuse-16.0"
+  "opensuse-tumbleweed"
+  "centos-9"
+  "centos-10"
+  "alpine-3.23"
+  "macos-homebrew"
+  "archlinux"
+]
+messages: [
+  # https://aur.archlinux.org/packages/libaacplus
+  "On Arch Linux, this package requires 'libaacplus' from the AUR:  yay -S libaacplus" {os-family = "arch"}
+]
+
 bug-reports: "https://github.com/savonet/ocaml-aacplus/issues"
 dev-repo: "git+https://github.com/savonet/ocaml-aacplus.git"
 synopsis:


### PR DESCRIPTION
this package seems to have [licensing issues](https://github.com/Distrotech/libaacplus/blob/master/README#L12), so it is not present in
most linux distributions. The only chance seems to be Arch Linux AUR.
I'm not Arch guy, so I can't test it.

It looks like package barely meet point 4 of [1]
> The package version is installable on at least one of the supported platforms.

Also, the package seems to be unmaintanined, so we should not worry too
much.

[1] https://github.com/ocaml/opam-repository/blob/master/governance/policies/archiving.md#criteria-for-inclusion-to-the-primary-repo-the-default-opam-repository

**Ready for review**
