### PR TITLE
[new release] mirage-net-xen (2.1.8)

### DIFF
--- a/packages/mirage-net-xen/mirage-net-xen.2.1.8/opam
+++ b/packages/mirage-net-xen/mirage-net-xen.2.1.8/opam
@@ -1,0 +1,46 @@
+opam-version: "2.0"
+maintainer:    "anil@recoil.org"
+authors:       ["Anil Madhavapeddy" "Thomas Leonard"]
+license:       "ISC"
+homepage:      "https://github.com/mirage/mirage-net-xen"
+bug-reports:   "https://github.com/mirage/mirage-net-xen/issues"
+dev-repo:      "git+https://github.com/mirage/mirage-net-xen.git"
+doc:           "https://mirage.github.io/mirage-net-xen/"
+build: [
+  [ "dune" "subst"] {dev}
+  [ "dune" "build" "-p" name "-j" jobs ]
+]
+
+depends: [
+  "ocaml" {>= "4.12.0"}
+  "dune"  {>= "1.0"}
+  "cstruct" {>= "6.0.0"}
+  "lwt" {>= "2.4.3"}
+  "mirage-net" {>= "3.0.0"}
+  "io-page" {>= "1.5.0"}
+  "mirage-xen" {>= "9.0.1"}
+  "ipaddr" {>= "3.0.0"}
+  "shared-memory-ring" {>="3.0.0"}
+  "macaddr" {>= "5.2.0"}
+  "lwt-dllist"
+  "logs" {>= "0.5.0"}
+]
+conflicts: [
+    "result" {< "1.5"}
+]
+tags: "org:mirage"
+synopsis: "Network device for reading and writing Ethernet frames via then Xen netfront/netback protocol"
+description: """
+This library allows an OCaml application to read and
+write Ethernet frames via the [Netfront/netback][xen-net] protocol.
+"""
+x-maintenance-intent: [ "(latest)" ]
+url {
+  src:
+    "https://github.com/mirage/mirage-net-xen/releases/download/v2.1.8/mirage-net-xen-2.1.8.tbz"
+  checksum: [
+    "sha256=4d551dcec8c2c3205948cccefde1bf07bcd4b2baba04963484bc4218fca3e3f1"
+    "sha512=e752d82390d3e5312367c9c544982c9b4b344ad6ffed729081911ba0aff7f5c0f1c2dae1400a5d157da0c6028086ae3046d3bbce30b55bc97846d9bb19b1f99a"
+  ]
+}
+x-commit-hash: "050aed3c0be5d84b70e788951986feff50be4602"


### PR DESCRIPTION
Network device for reading and writing Ethernet frames via then Xen netfront/netback protocol

- Project page: <a href="https://github.com/mirage/mirage-net-xen">https://github.com/mirage/mirage-net-xen</a>
- Documentation: <a href="https://mirage.github.io/mirage-net-xen/">https://mirage.github.io/mirage-net-xen/</a>

##### CHANGES:

* Merge backend and frontend (mirage/mirage-net-xen#118 @palainp, reviewed by @hannesm)
* Add Generic Segmentation Offload (mirage/mirage-net-xen#119 @palainp, reviewed by @hannesm)
