### PR TITLE
Package floatml.0.2.1

### DIFF
--- a/packages/floatml/floatml.0.1.0/opam
+++ b/packages/floatml/floatml.0.1.0/opam
@@ -14,9 +14,7 @@ depends: [
   "conf-rust-2024" {build}
   "odoc" {with-doc}
 ]
-available:
-  arch != "arm32" & arch != "ppc64" & arch != "s390x" & arch != "x86_32" &
-  os != "win32"
+available: false
 build: [
   ["dune" "subst"] {dev}
   [

--- a/packages/floatml/floatml.0.2.1/opam
+++ b/packages/floatml/floatml.0.2.1/opam
@@ -17,6 +17,12 @@ depends: [
 available:
   arch != "arm32" & arch != "ppc64" & arch != "s390x" & arch != "x86_32" &
   os != "win32"
+x-ci-accept-failures: [
+  "debian-12"
+  "ubuntu-22.04"
+  "ubuntu-24.04"
+  "ubuntu-25.04"
+]
 build: [
   ["dune" "subst"] {dev}
   [

--- a/packages/floatml/floatml.0.2.1/opam
+++ b/packages/floatml/floatml.0.2.1/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+synopsis: "Floats (f16, f32, f64, f128) for OCaml"
+description:
+  "Deterministic, IEEE-754-compliant interface for floating point operators over f16, f32, f64 and f128, backed by Rust's rustc_apfloat. Requires a Rust toolchain (cargo, 1.77 or newer) to build."
+maintainer: "opale.sjostedt@gmail.com"
+authors: "Opale Sjöstedt"
+license: "MIT"
+homepage: "https://github.com/N1ark/floatml"
+bug-reports: "https://github.com/N1ark/floatml/issues"
+depends: [
+  "ocaml" {>= "4.14.0"}
+  "dune" {>= "3.0"}
+  "zarith" {>= "1.13"}
+  "conf-rust-2024" {build}
+  "odoc" {with-doc}
+]
+available:
+  arch != "arm32" & arch != "ppc64" & arch != "s390x" & arch != "x86_32" &
+  os != "win32"
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/N1ark/floatml.git"
+url {
+  src: "https://github.com/N1ark/floatml/archive/refs/tags/v0.2.1.tar.gz"
+  checksum: [
+    "md5=e42bdd511121f3bd65f9fbcdb71be4a8"
+    "sha512=118ef63d0a101465a788b00501d708eacfff402fdce5ca0f57f62d80ee5e585e221cc270760c7702b705a9c10e89f2bbe1b59327dcf67bf4ea25f4d8dd216fd3"
+  ]
+}


### PR DESCRIPTION
### `floatml.0.2.1`
Floats (f16, f32, f64, f128) for OCaml
Deterministic, IEEE-754-compliant interface for floating point operators over f16, f32, f64 and f128, backed by Rust's rustc_apfloat. Requires a Rust toolchain (cargo, 1.77 or newer) to build.



---
* Homepage: https://github.com/N1ark/floatml
* Source repo: git+https://github.com/N1ark/floatml.git
* Bug tracker: https://github.com/N1ark/floatml/issues

---
:camel: Pull-request generated by opam-publish v3.0.1