### PR TITLE
cgi: add conf-autoconf dependency

### DIFF
--- a/packages/cgi/cgi.0.10/opam
+++ b/packages/cgi/cgi.0.10/opam
@@ -7,6 +7,8 @@ authors: [
 homepage: "https://www.lri.fr/~filliatr/ftp/ocaml/cgi/"
 bug-reports: "https://github.com/rixed/ocaml-cgi/issues"
 dev-repo: "git+https://github.com/rixed/ocaml-cgi.git"
+license: "LGPL-2.0-only"
+
 build: [
   ["./configure"]
   [make]
@@ -15,6 +17,7 @@ install: [make "install"]
 depends: [
   "ocaml" {> "4.01.0" & < "5.0.0"}
   "ocamlfind" {build}
+  "conf-autoconf"
 ]
 synopsis: "Library for writing CGIs"
 url {


### PR DESCRIPTION
It doesn't compile without it: https://check.ci.ocaml.org/log/1786440186-3e2ef3aff96fed8cfa47af6ea93970d3ff8c1c10/4.14/bad/cgi.0.10