### PR TITLE
Add ocaml.5.4.0 upper bound on gettext.0.5.0

### DIFF
--- a/packages/gettext/gettext.0.5.0/opam
+++ b/packages/gettext/gettext.0.5.0/opam
@@ -19,7 +19,7 @@ bug-reports: "https://github.com/gildor478/ocaml-gettext/issues"
 depends: [
   "dune" {>= "3.17"}
   "dune-site"
-  "ocaml" {>= "4.14.0"}
+  "ocaml" {>= "4.14.0" & < "5.4.0"}
   "cppo" {>= "1.8.0" & build}
   "seq" {>= "base" & with-test}
   "ounit2" {>= "2.2.7" & with-test}


### PR DESCRIPTION
Spotted on https://github.com/ocaml/opam-repository/pull/30474
https://opam.ci.ocaml.org/github/ocaml/opam-repository/commit/dca69c4d6fdd1ecc7e44110f8543cd91d34aa3a7/variant/compilers,5.5,camomile.2.1.0,revdeps,gettext-camomile.0.5.0
```
#=== ERROR while compiling gettext.0.5.0 ======================================#
# context              2.6.0~alpha1 | linux/x86_64 | ocaml-base-compiler.5.5.0 | file:///home/opam/opam-repository
# path                 ~/.opam/5.5/.opam-switch/build/gettext.0.5.0
# command              ~/.opam/opam-init/hooks/sandbox.sh build dune build -p gettext -j 71 --promote-install-files=false @install
# exit-code            1
# env-file             ~/.opam/log/gettext-7-54e518.env
# output-file          ~/.opam/log/gettext-7-54e518.out
### output ###
# (cd _build/.sandbox/42e6a20130f037f17acba08586de9b7d/default && /home/opam/.opam/5.5/bin/ocamlyacc src/lib/gettext/base/gettextMo_parser.mly)
# 14 shift/reduce conflicts.
# (cd _build/.sandbox/318704f9e1c4423cde478c27cf4acbb9/default && /home/opam/.opam/5.5/bin/ocamlyacc src/lib/gettext/extension/gettextPo_parser.mly)
# 12 shift/reduce conflicts.
# (cd _build/default && /home/opam/.opam/5.5/bin/ocamlopt.opt -w -40 -g -I src/bin/ocaml-xgettext/.xgettext.eobjs/byte -I src/bin/ocaml-xgettext/.xgettext.eobjs/native -I /home/opam/.opam/5.5/lib/dune-private-libs/dune-section -I /home/opam/.opam/5.5/lib/dune-site -I /home/opam/.opam/5.5/lib/dune-site/private -I /home/opam/.opam/5.5/lib/fileutils -I /home/opam/.opam/5.5/lib/ocaml/compiler-libs -I /home/opam/.opam/5.5/lib/ocaml/unix -H src/lib/gettext/base/.gettextBase.objs/byte -I src/lib/gettext/base/.gettextBase.objs/native -I src/lib/gettext/base/.gettextBase.objs/public_cmi -H src/lib/gettext/extension/.gettextExtension.objs/byte -I src/lib/gettext/extension/.gettextExtension.objs/native -I src/lib/gettext/extension/.gettextExtension.objs/public_cmi -cmi-file src/bin/ocaml-xgettext/.xgettext.eobjs/byte/dune__exe__Xgettext.cmi -no-alias-deps -o src/bin/ocaml-xgettext/.xgettext.eobjs/native/dune__exe__Xgettext.cmx -c -impl src/bin/ocaml-xgettext/xgettext.pp.ml)
# File "src/bin/ocaml-xgettext/xgettext.ml", line 115, characters 8-32:
# Error: The variable f on the left-hand side of this or-pattern has type
#          string
#        but on the right-hand side it has type string Location.loc
```

The problem is that `Longident.t` from the OCaml AST was changed in 5.4.0 to store locations in sub-fields,
making this incompatible with 5.4.0 and 5.5.0: https://github.com/ocaml/ocaml/pull/13302