### PR TITLE
Add two not-ocamlfind related bounds

### DIFF
--- a/packages/camlp5/camlp5.8.05.01/opam
+++ b/packages/camlp5/camlp5.8.05.01/opam
@@ -29,6 +29,7 @@ doc: "https://camlp5.github.io/doc/html"
 bug-reports: "https://github.com/camlp5/camlp5/issues"
 depends: [
   "ocaml" {>= "4.10" & < "5.6.0" }
+  "ocaml" { with-test & < "5.5.0" }
   "ocamlfind"
   "camlp-streams" { >= "5.0" }
   "conf-perl"


### PR DESCRIPTION
As per discussion in https://github.com/ocaml/opam-repository/pull/30472

camlp5.8.05.01 is failing `with-test` on ocaml.5.5.0:
https://opam.ci.ocaml.org/github/ocaml/opam-repository/commit/b534b3caed86e217f917c6d5eb1a5d08d549dcf9/variant/compilers,5.5,not-ocamlfind.0.15,revdeps,camlp5.8.05.01
```
#=== ERROR while compiling camlp5.8.05.01 =====================================#
# context              2.6.0~alpha1 | linux/x86_64 | ocaml-base-compiler.5.5.0 | file:///home/opam/opam-repository
# path                 ~/.opam/5.5/.opam-switch/build/camlp5.8.05.01
# command              ~/.opam/opam-init/hooks/sandbox.sh build make -C testsuite clean all-tests
# exit-code            2
# env-file             ~/.opam/log/camlp5-7-be7490.env
# output-file          ~/.opam/log/camlp5-7-be7490.out
### output ###
# make: Entering directory '/home/opam/.opam/5.5/.opam-switch/build/camlp5.8.05.01/testsuite'
# rm -f *.cm* *.byte *.log *.cache *.ppo tools/*.byte tools/*.opt link*
[...]
# Error: matrix:498:type-functor-2.
# 
# File "/home/opam/.opam/5.5/.opam-switch/build/camlp5.8.05.01/testsuite/_build/oUnit-matrix-builder#09.log", line 83, characters 1-1:
# Error: matrix:498:type-functor-2 (in the log).
# 
# Called from unknown location
# Called from unknown location
# 
# on input <<type t = (module%ext [@a] M:MT) -> t >>
# expected: <<type t = (module M : MT) -> t>>
# but got: <<type t = (module M : ((MT)[@a ])) -> t>>
# ------------------------------------------------------------------------------
# Ran: 499 tests in: 0.32 seconds.
# FAILED: Cases: 499 Tried: 499 Errors: 0 Failures: 1 Skip:  0 Todo: 0 Timeouts: 0.
# make: *** [Makefile:170: official2official_test] Error 1
# make: Leaving directory '/home/opam/.opam/5.5/.opam-switch/build/camlp5.8.05.01/testsuite'
```
Already fixed in the `camlp5.8.05.02` release:   https://github.com/camlp5/camlp5/commit/0a08a53b1ee0bf8577cb571d601b8db0ceed34f7

pa_ppx.8.05.01 is failing `with-test` on ocaml.5.5.0:
https://opam.ci.ocaml.org/github/ocaml/opam-repository/commit/b534b3caed86e217f917c6d5eb1a5d08d549dcf9/variant/compilers,5.5,not-ocamlfind.0.15,revdeps,pa_ppx.8.05.01
```
#=== ERROR while compiling pa_ppx.8.05.01 =====================================#
# context              2.6.0~alpha1 | linux/x86_64 | ocaml-base-compiler.5.5.0 | file:///home/opam/opam-repository
# path                 ~/.opam/5.5/.opam-switch/build/pa_ppx.8.05.01
# command              ~/.opam/opam-init/hooks/sandbox.sh build make DEBUG=-g test
# exit-code            2
# env-file             ~/.opam/log/pa_ppx-7-3fc88e.env
# output-file          ~/.opam/log/pa_ppx-7-3fc88e.out
### output ###
# WARNING: missing directory generated_src/8.05.02
# WARNING: FALLING BACK to saved info for camlp5 version 8.05.00; please report to maintainer
# set -e; for i in util-lib runtime runtime_fat testutils base pa_unmatched_vala pa_dock pa_fail pa_here pa_here_original pa_undo_deriving pa_assert pa_inline_test pa_expect_test pa_hashrecons pa_deriving pa_deriving.plugins pa_import located_sexp params_runtime; do cd $i; make all; cd ..; done
# make[1]: Entering directory '/home/opam/.opam/5.5/.opam-switch/build/pa_ppx.8.05.01/util-lib'
# make DESTDIR=/home/opam/.opam/5.5/.opam-switch/build/pa_ppx.8.05.01/util-lib/../local-install/ install
# make[2]: Entering directory '/home/opam/.opam/5.5/.opam-switch/build/pa_ppx.8.05.01/util-lib'
[...]
# env TOP=.. ocamlfind camlp5-buildscripts/LAUNCH  -- ocamlfind camlp5-buildscripts/ya-wrap-ocamlfind ocamlfind ocamlc -g  -package fmt,unix,compiler-libs.common,camlp5,camlp5.extfun,camlp5.parser_quotations,oUnit,fmt,str,pcre2,result,rresult,compiler-libs.common,yojson,sexplib,sexplib0 -c test_deriving_ord.ml.ppx.ml
# 'ocamlfind' 'ocamlc' '-g' '-package' 'fmt,unix,compiler-libs.common,camlp5,camlp5.extfun,camlp5.parser_quotations,oUnit,fmt,str,pcre2,result,rresult,compiler-libs.common,yojson,sexplib,sexplib0' '-c' -package ,ppx_deriving.show,ppx_deriving.eq,ppx_deriving.ord,ppx_deriving.enum,ppx_deriving.iter,ppx_deriving.map,ppx_deriving.fold,ppx_deriving.make,ppx_deriving_yojson,ppx_sexp_conv,ppx_here  test_deriving_ord.ml.ppx.ml
# File "test_deriving_ord.ML", lines 134-136, characters 0-22:
# Error: The value lhs0 has type bool/2 but an expression was expected of type
#          Ppx_deriving_runtime.bool = bool/3
#        File "test_deriving_ord.ML", lines 137-138, characters 0-56:
#          Definition of type bool/2
#        File "_none_", line 1:
#          Definition of type bool/3
# make[1]: *** [../config/Makefile.shared:74: test_deriving_ord.ml.ppx.cmo] Error 2
# make[1]: Leaving directory '/home/opam/.opam/5.5/.opam-switch/build/pa_ppx.8.05.01/tests-ounit2'
# make: *** [Makefile:42: all] Error 2
```

This PR therefore adds two `with-test` bounds to prevent these going forward.