### PR TITLE
[new release] eio (5 packages) (1.5)

### DIFF
--- a/packages/eio/eio.1.5/opam
+++ b/packages/eio/eio.1.5/opam
@@ -1,0 +1,57 @@
+opam-version: "2.0"
+synopsis: "Effect-based direct-style IO API for OCaml"
+description: "An effect-based IO API for multicore OCaml with fibers."
+maintainer: ["anil@recoil.org"]
+authors: ["Anil Madhavapeddy" "Thomas Leonard"]
+license: "ISC"
+homepage: "https://github.com/ocaml-multicore/eio"
+doc: "https://ocaml-multicore.github.io/eio/"
+bug-reports: "https://github.com/ocaml-multicore/eio/issues"
+depends: [
+  "dune" {>= "3.9"}
+  "ocaml" {>= "5.2.0"}
+  "bigstringaf" {>= "0.9.0"}
+  "cstruct" {>= "6.0.1"}
+  "lwt-dllist"
+  "optint" {>= "0.1.0"}
+  "psq" {>= "0.2.0"}
+  "fmt" {>= "0.8.9"}
+  "hmap" {>= "0.8.1"}
+  "domain-local-await" {>= "0.1.0"}
+  "crowbar" {>= "0.2" & with-test}
+  "mtime" {>= "2.0.0"}
+  "mdx" {>= "2.4.1" & with-test}
+  "lintcstubs-arity" {with-test}
+  "dscheck" {>= "0.1.0" & with-test}
+  "odoc" {with-doc}
+]
+conflicts: [
+  "seq" {< "0.3"}
+]
+build: [
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/ocaml-multicore/eio.git"
+x-extra-doc-deps: [
+  "eio_main" {= version}
+  "bigstring"
+]
+url {
+  src:
+    "https://github.com/ocaml-multicore/eio/releases/download/v1.5/eio-1.5.tbz"
+  checksum: [
+    "sha256=7d70d1f5fb2b7190bf1ab28fffeb272da51ffe6d6c9c7c94e0485fabdf3b3fda"
+    "sha512=4582ac2fb2f8616b3d8ae9670eb7913a78085899b14044408801b30a34fed6c4d32971ba72eedb0cbc3d82c057610cf81c482090e75e2985330fcde96478ac5e"
+  ]
+}
+x-commit-hash: "d3c8dd98760b28fd292310663a2ff385a0aca7c4"

--- a/packages/eio_linux/eio_linux.1.5/opam
+++ b/packages/eio_linux/eio_linux.1.5/opam
@@ -1,0 +1,48 @@
+opam-version: "2.0"
+synopsis: "Eio implementation for Linux using io-uring"
+description: "An Eio implementation for Linux using io-uring."
+maintainer: ["anil@recoil.org"]
+authors: ["Anil Madhavapeddy" "Thomas Leonard"]
+license: "ISC"
+homepage: "https://github.com/ocaml-multicore/eio"
+doc: "https://ocaml-multicore.github.io/eio/"
+bug-reports: "https://github.com/ocaml-multicore/eio/issues"
+depends: [
+  "dune" {>= "3.9"}
+  "alcotest" {>= "1.7.0" & with-test}
+  "eio" {= version}
+  "mdx" {>= "2.4.1" & with-test}
+  "lintcstubs-arity" {with-test}
+  "logs" {>= "0.7.0" & with-test}
+  "fmt" {>= "0.8.9"}
+  "cmdliner" {>= "1.1.0" & with-test}
+  "uring" {>= "2.15.0"}
+  "odoc" {with-doc}
+]
+build: [
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/ocaml-multicore/eio.git"
+available: [os = "linux"]
+x-extra-doc-deps: [
+  "eio_main" {= version}
+]
+url {
+  src:
+    "https://github.com/ocaml-multicore/eio/releases/download/v1.5/eio-1.5.tbz"
+  checksum: [
+    "sha256=7d70d1f5fb2b7190bf1ab28fffeb272da51ffe6d6c9c7c94e0485fabdf3b3fda"
+    "sha512=4582ac2fb2f8616b3d8ae9670eb7913a78085899b14044408801b30a34fed6c4d32971ba72eedb0cbc3d82c057610cf81c482090e75e2985330fcde96478ac5e"
+  ]
+}
+x-commit-hash: "d3c8dd98760b28fd292310663a2ff385a0aca7c4"

--- a/packages/eio_main/eio_main.1.5/opam
+++ b/packages/eio_main/eio_main.1.5/opam
@@ -1,0 +1,48 @@
+opam-version: "2.0"
+synopsis: "Effect-based direct-style IO mainloop for OCaml"
+description: "Selects an appropriate Eio backend for the current platform."
+maintainer: ["anil@recoil.org"]
+authors: ["Anil Madhavapeddy" "Thomas Leonard"]
+license: "ISC"
+homepage: "https://github.com/ocaml-multicore/eio"
+doc: "https://ocaml-multicore.github.io/eio/"
+bug-reports: "https://github.com/ocaml-multicore/eio/issues"
+depends: [
+  "dune" {>= "3.9"}
+  "mdx" {>= "2.4.1" & with-test}
+  "kcas" {>= "0.3.0" & with-test}
+  "yojson" {>= "2.0.2" & with-test}
+  "eio_linux"
+    {= version & os = "linux" &
+     (os-distribution != "centos" | os-version > "7")}
+  "eio_posix" {= version & os != "win32"}
+  "eio_windows" {= version & os = "win32"}
+  "odoc" {with-doc}
+]
+build: [
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/ocaml-multicore/eio.git"
+x-ci-accept-failures: ["macos-homebrew"]
+x-extra-doc-deps: [
+  "eio_main" {= version}
+]
+url {
+  src:
+    "https://github.com/ocaml-multicore/eio/releases/download/v1.5/eio-1.5.tbz"
+  checksum: [
+    "sha256=7d70d1f5fb2b7190bf1ab28fffeb272da51ffe6d6c9c7c94e0485fabdf3b3fda"
+    "sha512=4582ac2fb2f8616b3d8ae9670eb7913a78085899b14044408801b30a34fed6c4d32971ba72eedb0cbc3d82c057610cf81c482090e75e2985330fcde96478ac5e"
+  ]
+}
+x-commit-hash: "d3c8dd98760b28fd292310663a2ff385a0aca7c4"

--- a/packages/eio_posix/eio_posix.1.5/opam
+++ b/packages/eio_posix/eio_posix.1.5/opam
@@ -1,0 +1,46 @@
+opam-version: "2.0"
+synopsis: "Eio implementation for POSIX systems"
+description: "An Eio implementation for most Unix-like platforms"
+maintainer: ["anil@recoil.org"]
+authors: ["Anil Madhavapeddy" "Thomas Leonard"]
+license: "ISC"
+homepage: "https://github.com/ocaml-multicore/eio"
+doc: "https://ocaml-multicore.github.io/eio/"
+bug-reports: "https://github.com/ocaml-multicore/eio/issues"
+depends: [
+  "dune" {>= "3.9"}
+  "eio" {= version}
+  "iomux" {>= "0.2"}
+  "mdx" {>= "2.4.1" & with-test}
+  "lintcstubs-arity" {with-test}
+  "conf-bash" {with-test}
+  "fmt" {>= "0.8.9"}
+  "odoc" {with-doc}
+]
+build: [
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/ocaml-multicore/eio.git"
+available: [os != "win32"]
+x-extra-doc-deps: [
+  "eio_main" {= version}
+]
+url {
+  src:
+    "https://github.com/ocaml-multicore/eio/releases/download/v1.5/eio-1.5.tbz"
+  checksum: [
+    "sha256=7d70d1f5fb2b7190bf1ab28fffeb272da51ffe6d6c9c7c94e0485fabdf3b3fda"
+    "sha512=4582ac2fb2f8616b3d8ae9670eb7913a78085899b14044408801b30a34fed6c4d32971ba72eedb0cbc3d82c057610cf81c482090e75e2985330fcde96478ac5e"
+  ]
+}
+x-commit-hash: "d3c8dd98760b28fd292310663a2ff385a0aca7c4"

--- a/packages/eio_windows/eio_windows.1.5/opam
+++ b/packages/eio_windows/eio_windows.1.5/opam
@@ -1,0 +1,44 @@
+opam-version: "2.0"
+synopsis: "Eio implementation for Windows"
+description: "An Eio implementation using OCaml's Unix.select"
+maintainer: ["anil@recoil.org"]
+authors: ["Anil Madhavapeddy" "Thomas Leonard"]
+license: "ISC"
+homepage: "https://github.com/ocaml-multicore/eio"
+doc: "https://ocaml-multicore.github.io/eio/"
+bug-reports: "https://github.com/ocaml-multicore/eio/issues"
+depends: [
+  "dune" {>= "3.9"}
+  "eio" {= version}
+  "fmt" {>= "0.8.9"}
+  "kcas" {>= "0.3.0" & with-test}
+  "alcotest" {>= "1.7.0" & with-test}
+  "odoc" {with-doc}
+]
+build: [
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/ocaml-multicore/eio.git"
+available: [os = "win32"]
+x-extra-doc-deps: [
+  "eio_main" {= version}
+]
+url {
+  src:
+    "https://github.com/ocaml-multicore/eio/releases/download/v1.5/eio-1.5.tbz"
+  checksum: [
+    "sha256=7d70d1f5fb2b7190bf1ab28fffeb272da51ffe6d6c9c7c94e0485fabdf3b3fda"
+    "sha512=4582ac2fb2f8616b3d8ae9670eb7913a78085899b14044408801b30a34fed6c4d32971ba72eedb0cbc3d82c057610cf81c482090e75e2985330fcde96478ac5e"
+  ]
+}
+x-commit-hash: "d3c8dd98760b28fd292310663a2ff385a0aca7c4"


### PR DESCRIPTION
Effect-based direct-style IO API for OCaml

- Project page: <a href="https://github.com/ocaml-multicore/eio">https://github.com/ocaml-multicore/eio</a>
- Documentation: <a href="https://ocaml-multicore.github.io/eio/">https://ocaml-multicore.github.io/eio/</a>

##### CHANGES:

New features:

- Windows paths support (@avsm @kentookura @talex5 @dra27 ocaml-multicore/eio#913 ocaml-multicore/eio#916).
  Previously, an `Eio.Path.t` always used POSIX-style paths, using `/` as the separator,
  but this didn't work well on Windows, especially with absolute paths.

- Pre-connect socket options (@avsm @art-w @talex5 ocaml-multicore/eio#875).
  `Eio.Net.connect` now has `?bind_to` and `?options` arguments for pre-connect configuration.
  Allows an outbound socket to be configured before connect or listen.

- Add `Eio.Path.of_dir` (@talex5 ocaml-multicore/eio#919).
  Just a convenience function.

Bug fixes:

- Fix handling of empty paths when using `fs` unconfined (@talex5 ocaml-multicore/eio#907, reported by @samoht, reviewed by @avsm).

  Some path operations could end up using a path of "" which resulted in an error.
  This was breaking `Path.mkdirs` if only the base directory already existed.

Code cleanups and performance:

- eio_posix: fix build on 32-bit platforms (@talex5 ocaml-multicore/eio#917, reported by @glondu).

- unix: optimise the POSIX path split to allocate much less by scanning (@avsm ocaml-multicore/eio#915, reviewed by @talex5).

- eio_linux: use a bigger stack buffer for `getdents` to speed up bigger dirs (@avsm ocaml-multicore/eio#910).

- Add some more tests for POSIX paths (@avsm @talex5 ocaml-multicore/eio#918).

- Add "available" to opam files (@talex5 ocaml-multicore/eio#921).

- Clean up `dir_path` handling (@talex5 @avsm ocaml-multicore/eio#920).
