### PR TITLE
[new release] ocaml-ai-sdk (2 packages) (0.6.2)

### DIFF
--- a/packages/ai-sdk-react/ai-sdk-react.0.6.2/opam
+++ b/packages/ai-sdk-react/ai-sdk-react.0.6.2/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+synopsis: "Melange bindings for @ai-sdk/react"
+description: "Type-safe OCaml/Melange bindings for Vercel AI SDK)"
+maintainer: ["José Nogueira <jose.nogueira@ahrefs.com>"]
+authors: ["Ahrefs"]
+license: "MIT"
+homepage: "https://github.com/ahrefs/ocaml-ai-sdk"
+doc: "https://github.com/ahrefs/ocaml-ai-sdk"
+bug-reports: "https://github.com/ahrefs/ocaml-ai-sdk/issues"
+depends: [
+  "dune" {>= "3.21"}
+  "ocaml" {>= "4.14"}
+  "melange" {>= "4.0.0"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/ahrefs/ocaml-ai-sdk.git"
+x-maintenance-intent: ["(latest)"]
+url {
+  src:
+    "https://github.com/ahrefs/ocaml-ai-sdk/releases/download/0.6.2/ocaml-ai-sdk-0.6.2.tbz"
+  checksum: [
+    "sha256=637f60398f673dfb2e661f6ed7da169b823a870d27b48e729d5b9200e46a52b2"
+    "sha512=5aec259473395025edb6689b544e57e821cfbef9352987f95eb2182034979ce898040e06e60a9d89a40a187b77fb5b1b7183c7ec4264da9d9a834864860a5fed"
+  ]
+}
+x-commit-hash: "5ae038ec89bea25eaed7aac5a1d4e6f3f46ad106"

--- a/packages/ocaml-ai-sdk/ocaml-ai-sdk.0.6.2/opam
+++ b/packages/ocaml-ai-sdk/ocaml-ai-sdk.0.6.2/opam
@@ -1,0 +1,54 @@
+opam-version: "2.0"
+synopsis: "OCaml AI SDK - Provider abstraction for AI models"
+description:
+  "Type-safe, provider-agnostic AI model abstraction inspired by Vercel AI SDK"
+maintainer: ["José Nogueira <jose.nogueira@ahrefs.com>"]
+authors: ["Ahrefs"]
+license: "MIT"
+homepage: "https://github.com/ahrefs/ocaml-ai-sdk"
+doc: "https://github.com/ahrefs/ocaml-ai-sdk"
+bug-reports: "https://github.com/ahrefs/ocaml-ai-sdk/issues"
+depends: [
+  "dune" {>= "3.21"}
+  "ocaml" {>= "4.14"}
+  "lwt" {>= "5.9"}
+  "yojson" {>= "2.2"}
+  "jsonschema" {>= "0.1"}
+  "melange-json-native" {>= "2.0"}
+  "cohttp-lwt-unix" {>= "5.3"}
+  "lwt_ssl" {>= "1.2"}
+  "base64" {>= "1.3"}
+  "ppx_deriving" {>= "5.2"}
+  "lwt_ppx" {>= "5.9"}
+  "re2" {>= "0.16"}
+  "uuseg" {>= "17.0"}
+  "trace" {>= "0.12"}
+  "cohttp-lwt" {with-test}
+  "alcotest" {with-test}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/ahrefs/ocaml-ai-sdk.git"
+x-maintenance-intent: ["(latest)"]
+url {
+  src:
+    "https://github.com/ahrefs/ocaml-ai-sdk/releases/download/0.6.2/ocaml-ai-sdk-0.6.2.tbz"
+  checksum: [
+    "sha256=637f60398f673dfb2e661f6ed7da169b823a870d27b48e729d5b9200e46a52b2"
+    "sha512=5aec259473395025edb6689b544e57e821cfbef9352987f95eb2182034979ce898040e06e60a9d89a40a187b77fb5b1b7183c7ec4264da9d9a834864860a5fed"
+  ]
+}
+x-commit-hash: "5ae038ec89bea25eaed7aac5a1d4e6f3f46ad106"


### PR DESCRIPTION
OCaml AI SDK - Provider abstraction for AI models

- Project page: <a href="https://github.com/ahrefs/ocaml-ai-sdk">https://github.com/ahrefs/ocaml-ai-sdk</a>
- Documentation: <a href="https://github.com/ahrefs/ocaml-ai-sdk">https://github.com/ahrefs/ocaml-ai-sdk</a>

##### CHANGES:


