### PR TITLE
[new release] yamlx (0.5.0)

### DIFF
--- a/packages/yamlx/yamlx.0.5.0/opam
+++ b/packages/yamlx/yamlx.0.5.0/opam
@@ -1,0 +1,49 @@
+opam-version: "2.0"
+synopsis:
+  "Pure-OCaml YAML 1.2/1.1 parser with a lossless, comment-preserving AST"
+description: """
+YAMLx is a pure-OCaml YAML 1.2 library. It passes all 371 tests from the yaml-test-suite and has no C bindings or external runtime dependencies. The parsed node tree preserves scalar styles, flow vs. block collection style, tags, anchors, source positions, and comments. A pretty-printer can round-trip the AST back to YAML. A typed-value resolver applies the YAML 1.2 JSON schema and returns Null / Bool / Int / Float / String / Seq / Map values. Structured errors carry line, column, and byte-offset information.
+
+YAMLx is currently released under the AGPL. A commercial license and a path to a fully permissive ISC license are available — see FUNDING.md."""
+maintainer: ["Martin Jambon <martin@mjambon.com>"]
+authors: ["Martin Jambon <martin@mjambon.com>"]
+license: "AGPL-3.0-only"
+tags: ["yaml" "parser" "serialization"]
+homepage: "https://github.com/mjambon/yamlx"
+doc: "https://mjambon.github.io/yamlx"
+bug-reports: "https://github.com/mjambon/yamlx/issues"
+depends: [
+  "dune" {>= "3.20"}
+  "ocaml" {>= "4.14.0"}
+  "ppx_deriving"
+  "testo" {with-test}
+  "odoc" {>= "3.2.1" & with-doc}
+  "afl-persistent" {with-dev-setup}
+  "ocamlformat" {= "0.29.0" & with-dev-setup}
+  "yaml" {with-dev-setup}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/mjambon/yamlx.git"
+x-maintenance-intent: ["(latest)"]
+url {
+  src:
+    "https://github.com/mjambon/yamlx/releases/download/0.5.0/yamlx-0.5.0.tbz"
+  checksum: [
+    "sha256=7a3a45658e06ea6e3f10f02937a183c047c50bda92f1acd678942ca4e0918640"
+    "sha512=2d8317506966f09f75229d03325cdb12be4ecbd19684ade3ac6206ee6d5358d570a18112aef0e109f7449c65a2d4e0273fce73ed52a7ab44871b1bb659b8c199"
+  ]
+}
+x-commit-hash: "aa5760d6893e5d8542c471883303c8b1ca6dff35"


### PR DESCRIPTION
Pure-OCaml YAML 1.2/1.1 parser with a lossless, comment-preserving AST

- Project page: <a href="https://github.com/mjambon/yamlx">https://github.com/mjambon/yamlx</a>
- Documentation: <a href="https://mjambon.github.io/yamlx">https://mjambon.github.io/yamlx</a>

##### CHANGES:

- **Duplicate-key check on export**
  ([mjambon/yamlx#46](https://github.com/mjambon/yamlx/issues/46),
  [mjambon/yamlx#47](https://github.com/mjambon/yamlx/pull/47)).
  `Values.to_nodes`, `Values.to_yaml`, `Values.to_yaml_file`,
  `Value.to_yaml`, and `Value.to_yaml_file` now accept `~strict_keys`
  (default: `true`). Exporting a map with duplicate keys raises
  `Duplicate_key_error`. The default is the opposite of the import-side
  default (`false`) because duplicate keys on export are almost always a bug
  and are not reliably supported across YAML implementations. Pass
  `~strict_keys:false` to allow them through.
  **Breaking change**: existing code that serializes maps with duplicate keys
  will now raise `Duplicate_key_error` unless `~strict_keys:false` is passed.
- **`Value.Build` submodule** — convenience constructors using `zero_loc`
  ([mjambon/yamlx#44](https://github.com/mjambon/yamlx/issues/44),
  [mjambon/yamlx#45](https://github.com/mjambon/yamlx/pull/45)).
  Provides `null`, `bool`, `int`, `int64`, `float`, `string`, `seq`, and
  `map` for building `value` trees programmatically without repeating
  `zero_loc`. `map` takes `(string * value) list`; non-string keys require
  the `Map` constructor directly.
