### PR TITLE
obuild.0.3.0

### DIFF
--- a/packages/obuild/obuild.0.3.0/opam
+++ b/packages/obuild/obuild.0.3.0/opam
@@ -28,3 +28,5 @@ url {
     "sha256=9e3ea5227fed9df88805ff2b8466768c1bc28a737148316264481b4c9723c9ea"
   ]
 }
+x-maintenance-intent: ["(latest)"]
+

--- a/packages/obuild/obuild.0.3.0/opam
+++ b/packages/obuild/obuild.0.3.0/opam
@@ -1,0 +1,30 @@
+opam-version: "2.0"
+homepage: "https://github.com/ocaml-obuild/obuild"
+bug-reports: "https://github.com/ocaml-obuild/obuild/issues"
+dev-repo: "git+https://github.com/ocaml-obuild/obuild.git"
+authors: ["Vincent Hanquez" "Jerome Maloberti"]
+synopsis: "Simple package build system for OCaml"
+available: [ os != "win32" & os != "cygwin" ]
+license: "BSD-2-Clause"
+description: """
+The goal is to make a very simple build system for users and developers
+of OCaml libraries and programs.
+
+Obuild acts as a building black box: users only declare what they want to
+build and with which sources; the build system will consistently
+build it.
+
+The design is based on Haskell's Cabal and borrows most of the layout
+and way of working, adapting parts where necessary to fully support OCaml."""
+
+maintainer: "jmaloberti@gmail.com"
+build: [
+  ["./bootstrap"]
+]
+depends: ["ocaml" "ocamlfind" {build}]
+url {
+  src: "https://github.com/ocaml-obuild/obuild/archive/v0.3.0.tar.gz"
+  checksum: [
+    "sha256=9e3ea5227fed9df88805ff2b8466768c1bc28a737148316264481b4c9723c9ea"
+  ]
+}


### PR DESCRIPTION
New release of obuild 0.3.0 (I am the maintainer).

Since 0.2.2: fix for compatibility with recent findlib (relative paths), correct pack/aliasing on OCaml > 4.02, cstubs and installation fixes, and general stability/portability improvements. Minor-bumped to 0.3.0 rather than a patch given the volume of changes.

Tag: https://github.com/ocaml-obuild/obuild/releases/tag/v0.3.0
`opam lint`: Passed.