### PR TITLE
core_unix 0.17.1: not available on riscv

### DIFF
--- a/packages/core_unix/core_unix.v0.17.1/opam
+++ b/packages/core_unix/core_unix.v0.17.1/opam
@@ -25,7 +25,7 @@ depends: [
   "dune"                     {>= "3.11.0"}
   "spawn"                    {>= "v0.15"}
 ]
-available: arch != "arm32" & arch != "x86_32" & arch != "ppc64" & arch != "s390x" & (os-distribution != "alpine" | os-version < "3.21") & os != "win32"
+available: arch != "arm32" & arch != "x86_32" & arch != "ppc64" & arch != "riscv64" & arch != "s390x" & (os-distribution != "alpine" | os-version < "3.21") & os != "win32"
 synopsis: "Unix-specific portions of Core"
 description: "
 Unix-specific extensions to some of the modules defined in [core] and [core_kernel].


### PR DESCRIPTION
fails with

```
File "time_stamp_counter/src/dune", line 4, characters 9-33:
4 |   (names time_stamp_counter_stubs))
             ^^^^^^^^^^^^^^^^^^^^^^^^
time_stamp_counter_stubs.c: In function 'caml_rdtsc_unboxed':
time_stamp_counter_stubs.c:51:10: error: implicit declaration of function 'rdtsc' [-Wimplicit-function-declaration]
   51 |   return rdtsc();
      |          ^~~~~
```