### PR TITLE
cb-check.0.1 requires yojson < 3

### DIFF
--- a/packages/cb-check/cb-check.0.1/opam
+++ b/packages/cb-check/cb-check.0.1/opam
@@ -9,7 +9,7 @@ bug-reports: "https://github.com/ocurrent/current-bench/issues"
 depends: [
   "dune" {>= "3.7"}
   "ocaml" {>= "4.13.0"}
-  "yojson"
+  "yojson" {< "3.0.0"}
 ]
 build: [
   ["dune" "subst"] {dev}


### PR DESCRIPTION
Tuples and List has been removed from yojson.
Reported at: https://github.com/ocurrent/current-bench/issues/498 Fixed in upstream: https://github.com/ocurrent/current-bench/pull/499