### PR TITLE
Speed.0.2 seems not compile in OCaml5 according to check.ci.ocaml.org

### DIFF
--- a/packages/speed/speed.0.2.0/opam
+++ b/packages/speed/speed.0.2.0/opam
@@ -13,7 +13,7 @@ tags: ["tdd" "testing" "unit-testing" "bdd"]
 homepage: "https://github.com/stroiman/opam-speed"
 bug-reports: "https://github.com/stroiman/opam-speed/issues"
 depends: [
-  "ocaml" {>= "5"}
+  "ocaml" {>= "5" & < "5.5"}
   "dune" {>= "3.15"}
   "ocolor"
   "ppxlib"


### PR DESCRIPTION
Package (and dev) error is:

File "lib/Speed_dsl_effect.ml", line 57, characters 76-79:
57 |               | Op n -> Some (fun (k : (b, _) continuation) -> loop k () (n ctx))
                                                                                 ^^^
Error: The value ctx has type 'a D.t but an expression was expected of type
         a D.t
       The type constructor a would escape its scope