### PR TITLE
[new release] locswijch (0.1.0)

### DIFF
--- a/packages/locswijch/locswijch.0.1.0/opam
+++ b/packages/locswijch/locswijch.0.1.0/opam
@@ -1,0 +1,35 @@
+opam-version: "2.0"
+synopsis: "Bidirectional bridge between dune pkg and opam switches"
+description: """
+dune pkg stores built packages in _build/.pkg/, invisible to the standard
+opam switch mechanism that tools like ocamllsp, merlin, and utop rely on.
+locswijch mirrors those built artifacts into a real opam switch using hard
+links, so editor tooling works unchanged, and the switch doubles as a backup
+of dune.lock/ and _build/.pkg/ that survives dune clean. Subcommands: sync
+(project to switch), restore (switch to project), migrate (opam switch to
+dune.lock/), and trip (end-to-end round-trip test).
+"""
+maintainer: "https://github.com/cuihtlauac"
+authors: "Cuihtlauac Alvarado"
+license: "MIT"
+homepage: "https://github.com/cuihtlauac/locswijch"
+bug-reports: "https://github.com/cuihtlauac/locswijch/issues"
+dev-repo: "git+https://github.com/cuihtlauac/locswijch.git"
+x-maintenance-intent: ["(latest)"]
+depends: [
+  "ocaml" {>= "4.14.0"}
+  "dune" {>= "3.0"}
+  "cmdliner" {>= "1.1.0"}
+  "opam-file-format" {>= "2.1.3"}
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+]
+url {
+  src:
+    "https://github.com/cuihtlauac/locswijch/archive/refs/tags/v0.1.0.tar.gz"
+  checksum: [
+    "md5=f3a837b456a1557bcd00a17c3f3c4dae"
+    "sha512=aabd23d0618cbc5a0c5f62792801b0283d7a9607d79eefa525581e1e089b47924708b9ed2e25297180a7743a062d518eb9013ce5d08686ed56f73cdc045e8cfb"
+  ]
+}


### PR DESCRIPTION
First release of locswijch, a CLI tool bridging `dune pkg` builds and opam switches.

`dune pkg` stores built packages in `_build/.pkg/`, invisible to the standard opam switch mechanism that ocamllsp, merlin, and utop rely on. locswijch mirrors those artifacts into a real opam switch using hard links (with a cross-device copy fallback), so editor tooling works unchanged; the switch also serves as a backup of `dune.lock/` and the built artifacts that survives `dune clean`. It provides `sync`, `restore`, `migrate` (opam switch to `dune.lock/`), and `trip` (end-to-end round-trip test) subcommands.

Homepage: https://github.com/cuihtlauac/locswijch
