### PR TITLE
[new release] prometheus (5 packages) (2.0)

### DIFF
--- a/packages/current/current.0.5/opam
+++ b/packages/current/current.0.5/opam
@@ -26,7 +26,7 @@ depends: [
   "cmdliner"
   "sqlite3"
   "duration"
-  "prometheus"
+  "prometheus" {< "2.0"}
   "dune" {>= "2.0"}
   "re" {>= "1.9.0"}
   "lwt-dllist"

--- a/packages/current/current.0.6.2/opam
+++ b/packages/current/current.0.6.2/opam
@@ -27,7 +27,7 @@ depends: [
   "cmdliner" {>= "1.1.0"}
   "sqlite3"
   "duration"
-  "prometheus"
+  "prometheus" {< "2.0"}
   "dune" {>= "2.9"}
   "re" {>= "1.9.0"}
   "lwt-dllist"

--- a/packages/current/current.0.7.1/opam
+++ b/packages/current/current.0.7.1/opam
@@ -59,7 +59,7 @@ depends: [
   "lwt" {>= "5.7"}
   "lwt-dllist"
   "ppx_deriving"
-  "prometheus"
+  "prometheus" {< "2.0"}
   "re" {>= "1.9.0"}
   "result" {>= "1.5"}
   "sqlite3"

--- a/packages/current/current.0.7.2/opam
+++ b/packages/current/current.0.7.2/opam
@@ -59,7 +59,7 @@ depends: [
   "lwt" {>= "5.7"}
   "lwt-dllist"
   "ppx_deriving"
-  "prometheus"
+  "prometheus" {< "2.0"}
   "re" {>= "1.9.0"}
   "result" {>= "1.5"}
   "sqlite3"

--- a/packages/current/current.0.7.3/opam
+++ b/packages/current/current.0.7.3/opam
@@ -59,7 +59,7 @@ depends: [
   "lwt" {>= "5.7"}
   "lwt-dllist"
   "ppx_deriving"
-  "prometheus"
+  "prometheus" {< "2.0"}
   "re" {>= "1.9.0"}
   "result" {>= "1.5"}
   "sqlite3"

--- a/packages/current/current.0.7.4/opam
+++ b/packages/current/current.0.7.4/opam
@@ -59,7 +59,7 @@ depends: [
   "lwt" {>= "5.7"}
   "lwt-dllist"
   "ppx_deriving"
-  "prometheus"
+  "prometheus" {< "2.0"}
   "re" {>= "1.9.0"}
   "result" {>= "1.5"}
   "sqlite3"

--- a/packages/current/current.0.7.5/opam
+++ b/packages/current/current.0.7.5/opam
@@ -59,7 +59,7 @@ depends: [
   "lwt" {>= "5.7"}
   "lwt-dllist"
   "ppx_deriving"
-  "prometheus"
+  "prometheus" {< "2.0"}
   "re" {>= "1.9.0"}
   "result" {>= "1.5"}
   "sqlite3"

--- a/packages/current_web/current_web.0.5/opam
+++ b/packages/current_web/current_web.0.5/opam
@@ -24,7 +24,7 @@ depends: [
   "bos"
   "lwt"
   "cmdliner"
-  "prometheus" {>= "0.7"}
+  "prometheus" {>= "0.7" & < "2.0"}
   "prometheus-app" {< "1.2"}
   "cohttp" {>= "2.2.0"}
   "cohttp-lwt" {>= "2.2.0"}

--- a/packages/current_web/current_web.0.6.2/opam
+++ b/packages/current_web/current_web.0.6.2/opam
@@ -27,8 +27,8 @@ depends: [
   "lwt"
   "multipart_form-lwt" {>= "0.4.0"}
   "cmdliner" {>= "1.1.0"}
-  "prometheus" {>= "0.7"}
-  "prometheus-app" {>= "1.2"}
+  "prometheus" {>= "0.7" & < "2.0"}
+  "prometheus-app" {>= "1.2" & < "2.0"}
   "cohttp-lwt-unix" {>= "4.0.0"}
   "tyxml" {>= "4.4.0" & < "4.6.0"}
   "csv" {>= "2.4"}

--- a/packages/current_web/current_web.0.7.1/opam
+++ b/packages/current_web/current_web.0.7.1/opam
@@ -65,8 +65,8 @@ depends: [
   "ppx_deriving" {>= "5.1"}
   "ppx_deriving_yojson" {>= "3.5.1"}
   "ppx_sexp_conv" {>= "v0.14.1"}
-  "prometheus" {>= "0.7"}
-  "prometheus-app" {>= "1.2"}
+  "prometheus" {>= "0.7" & < "2.0"}
+  "prometheus-app" {>= "1.2" & < "2.0"}
   "re" {>= "1.9.0"}
   "result" {>= "1.5"}
   "routes" {>= "2.0.0"}

--- a/packages/current_web/current_web.0.7.2/opam
+++ b/packages/current_web/current_web.0.7.2/opam
@@ -65,8 +65,8 @@ depends: [
   "ppx_deriving" {>= "5.1"}
   "ppx_deriving_yojson" {>= "3.5.1"}
   "ppx_sexp_conv" {>= "v0.14.1"}
-  "prometheus" {>= "0.7"}
-  "prometheus-app" {>= "1.2"}
+  "prometheus" {>= "0.7" & < "2.0"}
+  "prometheus-app" {>= "1.2" & < "2.0"}
   "re" {>= "1.9.0"}
   "result" {>= "1.5"}
   "routes" {>= "2.0.0"}

--- a/packages/current_web/current_web.0.7.3/opam
+++ b/packages/current_web/current_web.0.7.3/opam
@@ -65,8 +65,8 @@ depends: [
   "ppx_deriving" {>= "5.1"}
   "ppx_deriving_yojson" {>= "3.5.1"}
   "ppx_sexp_conv" {>= "v0.14.1"}
-  "prometheus" {>= "0.7"}
-  "prometheus-app" {>= "1.2"}
+  "prometheus" {>= "0.7" & < "2.0"}
+  "prometheus-app" {>= "1.2" & < "2.0"}
   "re" {>= "1.9.0"}
   "result" {>= "1.5"}
   "routes" {>= "2.0.0"}

--- a/packages/current_web/current_web.0.7.4/opam
+++ b/packages/current_web/current_web.0.7.4/opam
@@ -65,8 +65,8 @@ depends: [
   "ppx_deriving" {>= "5.1"}
   "ppx_deriving_yojson" {>= "3.5.1"}
   "ppx_sexp_conv" {>= "v0.14.1"}
-  "prometheus" {>= "0.7"}
-  "prometheus-app" {>= "1.2"}
+  "prometheus" {>= "0.7" & < "2.0"}
+  "prometheus-app" {>= "1.2" & < "2.0"}
   "re" {>= "1.9.0"}
   "result" {>= "1.5"}
   "routes" {>= "2.0.0"}

--- a/packages/current_web/current_web.0.7.5/opam
+++ b/packages/current_web/current_web.0.7.5/opam
@@ -65,8 +65,8 @@ depends: [
   "ppx_deriving" {>= "5.1"}
   "ppx_deriving_yojson" {>= "3.5.1"}
   "ppx_sexp_conv" {>= "v0.14.1"}
-  "prometheus" {>= "0.7"}
-  "prometheus-app" {>= "1.2"}
+  "prometheus" {>= "0.7" & < "2.0"}
+  "prometheus-app" {>= "1.2" & < "2.0"}
   "re" {>= "1.9.0"}
   "result" {>= "1.5"}
   "routes" {>= "2.0.0"}

--- a/packages/ocluster-worker/ocluster-worker.0.2.1/opam
+++ b/packages/ocluster-worker/ocluster-worker.0.2.1/opam
@@ -19,7 +19,7 @@ depends: [
   "logs"
   "lwt" {>= "5.6.1"}
   "obuilder" {>= "0.5.1" & < "0.6.0"}
-  "prometheus-app" {>= "1.2"}
+  "prometheus-app" {>= "1.2" & < "2.0"}
   "odoc" {with-doc}
 ]
 build: [

--- a/packages/ocluster-worker/ocluster-worker.0.3.0/opam
+++ b/packages/ocluster-worker/ocluster-worker.0.3.0/opam
@@ -28,7 +28,7 @@ depends: [
   "logs"
   "lwt" {>= "5.6.1"}
   "obuilder" {>= "0.6.0" & < "0.7.0"}
-  "prometheus-app" {>= "1.2"}
+  "prometheus-app" {>= "1.2" & < "2.0"}
   "odoc" {with-doc}
 ]
 build: [

--- a/packages/ocluster-worker/ocluster-worker.0.4.0/opam
+++ b/packages/ocluster-worker/ocluster-worker.0.4.0/opam
@@ -28,7 +28,7 @@ depends: [
   "logs"
   "lwt" {>= "5.7.0"}
   "obuilder" {>= "0.7.0"}
-  "prometheus-app" {>= "1.2"}
+  "prometheus-app" {>= "1.2" & < "2.0"}
   "odoc" {with-doc}
 ]
 available: arch != "x86_32"

--- a/packages/prometheus-app/prometheus-app.2.0/opam
+++ b/packages/prometheus-app/prometheus-app.2.0/opam
@@ -1,0 +1,58 @@
+opam-version: "2.0"
+synopsis: "Client library for Prometheus monitoring"
+description: """\
+Applications can enable metric reporting using the `prometheus-app` opam package.
+This depends on cohttp and can serve the metrics collected above over HTTP.
+
+The `prometheus-app.unix` ocamlfind library provides the `Prometheus_unix` module,
+which includes a cmdliner option and pre-configured web-server.
+See the `examples/example.ml` program for an example, which can be run as:
+
+```shell
+$ dune exec -- examples/example.exe --listen-prometheus=9090
+If run with the option --listen-prometheus=9090, this program serves metrics at
+http://localhost:9090/metrics
+Tick!
+Tick!
+...
+```
+
+`--listen-prometheus` takes a bare port number or an address such as
+`tcp:127.0.0.1:9090`, `tcp:[::1]:9090`, `tcp:localhost` or 
+`unix:/run/metrics.sock`. The port defaults to 9090.
+
+Unikernels can use `prometheus-reporter` instead to avoid the `Unix` and cohttp dependencies."""
+maintainer: "talex5@gmail.com"
+authors: ["Thomas Leonard" "David Scott"]
+license: "Apache-2.0"
+homepage: "https://github.com/mirage/prometheus"
+doc: "https://mirage.github.io/prometheus/"
+bug-reports: "https://github.com/mirage/prometheus/issues"
+depends: [
+  "ocaml" {>= "4.11.0"}
+  "dune" {>= "2.3"}
+  "prometheus" {= version}
+  "prometheus-lwt" {= version}
+  "prometheus-reporter" {= version}
+  "fmt" {>= "0.8.7"}
+  "cohttp-lwt" {>= "6.0.0"}
+  "cohttp-lwt-unix" {>= "6.0.0"}
+  "lwt" {>= "2.5.0"}
+  "cmdliner"
+  "uri" {>= "4.4.0"}
+  "alcotest" {with-test}
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/mirage/prometheus.git"
+url {
+  src:
+    "https://github.com/mirage/prometheus/releases/download/v2.0/prometheus-2.0.tbz"
+  checksum: [
+    "sha256=94cb5e95606d5ff17b4d11801ead1ea1981c06b17b084950d7a032933d991a83"
+    "sha512=236cc53cc50e24e18e31bf58dd29e9b98b50da0a92f7077d37ff13088c2b31eee49ed4eced8322f67406b0e4216c4751685002d357d9056335f7fc3e618c7f13"
+  ]
+}
+x-commit-hash: "e860978159cf6741c6d2d5b9c2704d3ddb02b676"

--- a/packages/prometheus-eio/prometheus-eio.2.0/opam
+++ b/packages/prometheus-eio/prometheus-eio.2.0/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+synopsis: "Eio support for Prometheus monitoring"
+description: """\
+Serve Prometheus metrics from an Eio application via a cohttp-eio
+handler for `/metrics`. """
+maintainer: "talex5@gmail.com"
+authors: ["Anil Madhavapeddy" "Mark Elvers" "Thomas Leonard" "David Scott"]
+license: "Apache-2.0"
+homepage: "https://github.com/mirage/prometheus"
+doc: "https://mirage.github.io/prometheus/"
+bug-reports: "https://github.com/mirage/prometheus/issues"
+depends: [
+  "ocaml" {>= "5.0"}
+  "dune" {>= "2.3"}
+  "prometheus" {= version}
+  "prometheus-reporter" {= version}
+  "fmt" {>= "0.8.7"}
+  "eio" {>= "1.0"}
+  "cohttp-eio" {>= "6.0.0"}
+  "http" {>= "6.0.0"}
+  "eio_main" {with-test}
+  "alcotest" {with-test}
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/mirage/prometheus.git"
+url {
+  src:
+    "https://github.com/mirage/prometheus/releases/download/v2.0/prometheus-2.0.tbz"
+  checksum: [
+    "sha256=94cb5e95606d5ff17b4d11801ead1ea1981c06b17b084950d7a032933d991a83"
+    "sha512=236cc53cc50e24e18e31bf58dd29e9b98b50da0a92f7077d37ff13088c2b31eee49ed4eced8322f67406b0e4216c4751685002d357d9056335f7fc3e618c7f13"
+  ]
+}
+x-commit-hash: "e860978159cf6741c6d2d5b9c2704d3ddb02b676"

--- a/packages/prometheus-lwt/prometheus-lwt.2.0/opam
+++ b/packages/prometheus-lwt/prometheus-lwt.2.0/opam
@@ -1,0 +1,33 @@
+opam-version: "2.0"
+synopsis: "Lwt support for Prometheus monitoring"
+description: "Lwt collectors and timing helpers for Prometheus metrics."
+maintainer: "talex5@gmail.com"
+authors: ["Thomas Leonard" "Anil Madhavapeddy" "David Scott"]
+license: "Apache-2.0"
+homepage: "https://github.com/mirage/prometheus"
+doc: "https://mirage.github.io/prometheus/"
+bug-reports: "https://github.com/mirage/prometheus/issues"
+depends: [
+  "ocaml" {>= "4.11.0"}
+  "dune" {>= "2.3"}
+  "prometheus" {= version}
+  "lwt" {>= "2.5.0"}
+  "prometheus-reporter" {= version & with-test}
+  "fmt" {with-test}
+  "alcotest" {with-test}
+  "alcotest-lwt" {with-test}
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/mirage/prometheus.git"
+url {
+  src:
+    "https://github.com/mirage/prometheus/releases/download/v2.0/prometheus-2.0.tbz"
+  checksum: [
+    "sha256=94cb5e95606d5ff17b4d11801ead1ea1981c06b17b084950d7a032933d991a83"
+    "sha512=236cc53cc50e24e18e31bf58dd29e9b98b50da0a92f7077d37ff13088c2b31eee49ed4eced8322f67406b0e4216c4751685002d357d9056335f7fc3e618c7f13"
+  ]
+}
+x-commit-hash: "e860978159cf6741c6d2d5b9c2704d3ddb02b676"

--- a/packages/prometheus-reporter/prometheus-reporter.2.0/opam
+++ b/packages/prometheus-reporter/prometheus-reporter.2.0/opam
@@ -21,7 +21,7 @@ depends: [
   "prometheus" {= version}
   "mirage-mtime" {>= "5.2.0"}
   "fmt" {>= "0.8.7"}
-  "re"
+  "re" {>= "1.8.0"}
   "logs" {>= "0.6.0"}
   "base-unix"
   "alcotest" {with-test}

--- a/packages/prometheus-reporter/prometheus-reporter.2.0/opam
+++ b/packages/prometheus-reporter/prometheus-reporter.2.0/opam
@@ -1,0 +1,42 @@
+opam-version: "2.0"
+synopsis: "Renderer and standard collectors for Prometheus monitoring"
+description: """\
+The `prometheus-reporter` opam package provides the parts of a metrics
+reporter that do not depend on a web server. `Prometheus_reporter` renders
+a registry snapshot in the Prometheus text format and registers collectors
+for the OCaml GC statistics.
+
+The `prometheus-reporter.unix` ocamlfind library provides the
+`Prometheus_reporter_unix` module, which adds a process start-time metric
+and a Logs reporter that counts logged messages."""
+maintainer: "talex5@gmail.com"
+authors: ["Thomas Leonard" "David Scott"]
+license: "Apache-2.0"
+homepage: "https://github.com/mirage/prometheus"
+doc: "https://mirage.github.io/prometheus/"
+bug-reports: "https://github.com/mirage/prometheus/issues"
+depends: [
+  "ocaml" {>= "4.11.0"}
+  "dune" {>= "2.3"}
+  "prometheus" {= version}
+  "mirage-mtime" {>= "5.2.0"}
+  "fmt" {>= "0.8.7"}
+  "re"
+  "logs" {>= "0.6.0"}
+  "base-unix"
+  "alcotest" {with-test}
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/mirage/prometheus.git"
+url {
+  src:
+    "https://github.com/mirage/prometheus/releases/download/v2.0/prometheus-2.0.tbz"
+  checksum: [
+    "sha256=94cb5e95606d5ff17b4d11801ead1ea1981c06b17b084950d7a032933d991a83"
+    "sha512=236cc53cc50e24e18e31bf58dd29e9b98b50da0a92f7077d37ff13088c2b31eee49ed4eced8322f67406b0e4216c4751685002d357d9056335f7fc3e618c7f13"
+  ]
+}
+x-commit-hash: "e860978159cf6741c6d2d5b9c2704d3ddb02b676"

--- a/packages/prometheus/prometheus.2.0/opam
+++ b/packages/prometheus/prometheus.2.0/opam
@@ -1,0 +1,36 @@
+opam-version: "2.0"
+synopsis: "Client library for Prometheus monitoring"
+maintainer: "talex5@gmail.com"
+authors: ["Thomas Leonard" "David Scott"]
+license: "Apache-2.0"
+homepage: "https://github.com/mirage/prometheus"
+doc: "https://mirage.github.io/prometheus/"
+bug-reports: "https://github.com/mirage/prometheus/issues"
+depends: [
+  "ocaml" {>= "4.11.0"}
+  "dune" {>= "2.3"}
+  "re"
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/mirage/prometheus.git"
+description: """
+To run services reliably, it is useful if they can report various metrics
+(for example, heap size, queue lengths, number of warnings logged, etc).
+
+A monitoring service can be configured to collect this data regularly.
+The data can be graphed to help understand the performance of the service over time,
+or to help debug problems quickly.
+It can also be used to send alerts if a service is down or behaving poorly.
+"""
+url {
+  src:
+    "https://github.com/mirage/prometheus/releases/download/v2.0/prometheus-2.0.tbz"
+  checksum: [
+    "sha256=94cb5e95606d5ff17b4d11801ead1ea1981c06b17b084950d7a032933d991a83"
+    "sha512=236cc53cc50e24e18e31bf58dd29e9b98b50da0a92f7077d37ff13088c2b31eee49ed4eced8322f67406b0e4216c4751685002d357d9056335f7fc3e618c7f13"
+  ]
+}
+x-commit-hash: "e860978159cf6741c6d2d5b9c2704d3ddb02b676"


### PR DESCRIPTION
Client library for Prometheus monitoring

- Project page: <a href="https://github.com/mirage/prometheus">https://github.com/mirage/prometheus</a>
- Documentation: <a href="https://mirage.github.io/prometheus/">https://mirage.github.io/prometheus/</a>

##### CHANGES:

- Add a new `prometheus-eio` serving package (@mtelvers @avsm mirage/prometheus#60)

  `Prometheus_eio.callback` is a cohttp-eio handler that serves the
  default registry at `/metrics`. It depends only on `prometheus-reporter`,
  so no Lwt or cohttp-lwt code is linked into an Eio application.

- Add a new `prometheus-reporter` package with the cohttp-free parts of
  `prometheus-app` (@ulrikstrid @avsm mirage/prometheus#39 mirage/prometheus#46)

  `Prometheus_reporter` renders the text format and registers the GC
  collectors. `Prometheus_reporter_unix` adds the process start-time metric
  and the Logs reporter. `prometheus-app` reexports both so existing code
  keeps working. Applications can now serve the rendered metrics with
  any web server of choice.

- Remove Lwt from the `prometheus` core (@mtelvers @avsm mirage/prometheus#60 mirage/prometheus#65)

  The deprecated Lwt functions are removed from the core package, and
  `CollectorRegistry.collect` now returns a snapshot directly.
  Lwt collectors are all in `prometheus-lwt`, whose interface is unchanged
  from the v1.4 release.

  Applications that collected via the core in an Lwt context should use
  `Prometheus_lwt.CollectorRegistry.collect`.

- `prometheus-app`: add `Prometheus_unix.config` to build a configuration
  without cmdliner (@avsm @talex5 requested by @Nymphium mirage/prometheus#44 mirage/prometheus#73)

- `prometheus-app`: allow serving a registry other than the default one.
  (@avsm mirage/prometheus#54)

  `Prometheus_app.Cohttp(S).callback` and `Prometheus_unix.serve` take an
  optional `?registry` argument.

- `prometheus-app`: allow specifying the address as well as the port to bind
  to with `--listen-prometheus`.

  As well as a bare port number, the option now accepts `tcp:HOST[:PORT]`
  (with IPv6 addresses in square brackets, and the port defaulting to 9090)
  and `unix:PATH` for domain sockets, in the same syntax as `capnp-rpc-unix`.
  (@rbjorklin @avsm @talex5 mirage/prometheus#51 mirage/prometheus#72)
