### PR TITLE
ocluster: add more upper bounds to get this compiling

### DIFF
--- a/packages/ocluster/ocluster.0.2.1/opam
+++ b/packages/ocluster/ocluster.0.2.1/opam
@@ -17,7 +17,7 @@ homepage: "https://github.com/ocurrent/ocluster"
 doc: "https://ocurrent.github.io/ocluster/"
 bug-reports: "https://github.com/ocurrent/ocluster/issues"
 depends: [
-  "dune" {>= "3.3"}
+  "dune" {>= "3.3" & < "3.10"}
   "ocluster-api" {= version}
   "ocluster-worker" {= version}
   "ocaml" {>= "4.12.0"}
@@ -35,7 +35,7 @@ depends: [
   "lwt-dllist"
   "mirage-crypto" {>= "0.8.5" & < "1.0.0"}
   "obuilder" {>= "0.5.1" & < "0.6.0"}
-  "ppx_expect" {>= "v0.14.1"}
+  "ppx_expect" {>= "v0.14.1" & < "v0.16"}
   "ppx_sexp_conv"
   "prometheus"
   "prometheus-app" {>= "1.2"}

--- a/packages/ocluster/ocluster.0.3.0/opam
+++ b/packages/ocluster/ocluster.0.3.0/opam
@@ -26,7 +26,7 @@ homepage: "https://github.com/ocurrent/ocluster"
 doc: "https://ocurrent.github.io/ocluster/"
 bug-reports: "https://github.com/ocurrent/ocluster/issues"
 depends: [
-  "dune" {>= "3.7"}
+  "dune" {>= "3.7" & < "3.10"}
   "ocluster-api" {= version}
   "ocluster-worker" {= version}
   "ocaml" {>= "4.14.1"}
@@ -44,7 +44,7 @@ depends: [
   "lwt-dllist"
   "mirage-crypto" {>= "0.8.5" & < "1.0.0"}
   "obuilder" {>= "0.6.0" & < "0.7.0"}
-  "ppx_expect" {>= "v0.14.1"}
+  "ppx_expect" {>= "v0.14.1" & < "v0.16"}
   "ppx_sexp_conv"
   "prometheus"
   "prometheus-app" {>= "1.2"}


### PR DESCRIPTION
these are historical versions, but they keep showing up in revdeps

```
i# File "test/test_scheduling.ml", line 870, characters 4-13:
let pp_forget =
           ^^^^^^^^^
 Error: The type of this expression,
        ('_weak1, _[< `Still_connected | `Unknown_worker ]) result Fmt.t,
        contains type variables that cannot be generalized
```

from release mode only