### PR TITLE
Add autoconf dependecy to functory

### DIFF
--- a/packages/functory/functory.0.6/opam
+++ b/packages/functory/functory.0.6/opam
@@ -15,6 +15,7 @@ remove: [["ocamlfind" "remove" "functory"]]
 depends: [
   "ocaml" {>= "4.03.0" & < "5.0"}
   "ocamlfind"
+  "conf-autoconf"
 ]
 install: [make "ocamlfind-install"]
 synopsis: "Distributed computing library."

--- a/packages/functory/functory.0.6/opam
+++ b/packages/functory/functory.0.6/opam
@@ -5,6 +5,7 @@ authors: [
   "Kalyan Krishnamani"
 ]
 homepage: "https://github.com/backtracking/functory"
+bug-reports: "https://github.com/backtracking/functory/issues"
 dev-repo: "git+https://github.com/backtracking/functory.git"
 license: "LGPL-2.1-only"
 build: [
@@ -18,7 +19,7 @@ depends: [
   "conf-autoconf"
 ]
 install: [make "ocamlfind-install"]
-synopsis: "Distributed computing library."
+synopsis: "Distributed computing library"
 flags: light-uninstall
 url {
   src:


### PR DESCRIPTION
Error message was:

> Processing  5/6: [functory: make]
> + /home/opam/.opam/opam-init/hooks/sandbox.sh "build" "make" (CWD=/home/opam/.opam/4.11/.opam-switch/build/functory.0.6)
> - autoconf
> - make: autoconf: No such file or directory
> - make: *** [Makefile:308: configure] Error 127