### PR TITLE
Add x-ci-accept-failures for taglib

### DIFF
--- a/packages/conf-taglib/conf-taglib.1/opam
+++ b/packages/conf-taglib/conf-taglib.1/opam
@@ -11,8 +11,10 @@ depends: [
 depexts: [
   ["libtag1-dev" "zlib1g-dev"] {os-family = "debian" | os-family = "ubuntu"}
   ["taglib-dev" "zlib-dev"] {os-family = "alpine"}
-  ["libtag-devel"] {os-family = "suse" | os-family = "opensuse" | os-distribution = "cygwin" }
-  ["mingw-w64-x86_64-taglib"] {os = "win32" & os-distribution = "msys2"}
+  ["libtag-devel"] {os-family = "suse" | os-family = "opensuse" }
+  # TODO: introduce conf-* packages for msys2
+  # https://github.com/ocaml/opam-repository/pull/30540#discussion_r3856291865
+  #["mingw-w64-x86_64-taglib"] {os = "win32" & os-distribution = "msys2"}
   ["taglib"] {os-family = "arch" | os = "freebsd" | os-distribution = "nixos"}
   ["taglib"] {os = "macos" & os-distribution = "homebrew"}
   ["taglib"] {os = "macos" & os-distribution = "macports"}

--- a/packages/conf-taglib/conf-taglib.1/opam
+++ b/packages/conf-taglib/conf-taglib.1/opam
@@ -11,7 +11,8 @@ depends: [
 depexts: [
   ["libtag1-dev" "zlib1g-dev"] {os-family = "debian" | os-family = "ubuntu"}
   ["taglib-dev" "zlib-dev"] {os-family = "alpine"}
-  ["libtag-devel"] {os-family = "suse" | os-family = "opensuse"}
+  ["libtag-devel"] {os-family = "suse" | os-family = "opensuse" | os-distribution = "cygwin" }
+  ["mingw-w64-x86_64-taglib"] {os = "win32" & os-distribution = "msys2"}
   ["taglib"] {os-family = "arch" | os = "freebsd" | os-distribution = "nixos"}
   ["taglib"] {os = "macos" & os-distribution = "homebrew"}
   ["taglib"] {os = "macos" & os-distribution = "macports"}

--- a/packages/taglib/taglib.0.3.10/opam
+++ b/packages/taglib/taglib.0.3.10/opam
@@ -37,3 +37,27 @@ url {
     "sha512=70193babf3ddca744de00ad43de12d71bdfbdd2d2081435a546ecccd1ead15c20b2ea91e226a98638935c20d6cd546e4b20111164a28255867192acec1a78ef2"
   ]
 }
+
+post-messages:
+  "In case of errors like `'create' is not a member of 'TagLib::FileRef'` near 'f = FileRef::create(filename);' we need to check installed taglib version. The error happens with taglib 2.2.x
+(ubuntu 26.04 and newer) but with 2.0.x (Ubuntu 24.04) it compiles fine."
+    { failure }
+
+x-ci-accept-failures: [
+	"alpine-3.23"
+	"archlinux"
+	"debian-13"
+	"debian-testing"
+	"debian-unstable"
+	"ubuntu-25.04"
+	"ubuntu-25.10"
+	"ubuntu-26.04"
+	"fedora-44"
+	"opensuse-16.0"
+	"opensuse-tumbleweed"
+	"msys"
+]
+
+# Repository has been archived on  Jan 14, 2025.
+x-maintenance-intent: [ "(none)" ]
+


### PR DESCRIPTION
On [check.ci.ocaml.org](https://check.ci.ocaml.org/?comp=4.11&comp=4.14&comp=5.2&comp=5.4&comp=5.5&available=4.11&available=4.14&available=5.2&available=5.4&available=5.5&show-only=partial&show-only=bad&show-latest-only=true&packages=taglib&maintainers=&logsearch=&logsearch_comp=4.11) the package is red for ALL compilers. There reason is that in modern distribution the depext C library is too new. The repo is archived, so I marked it as not maintained despite the fact that on Ubuntu 24.04 it should compile fine. 