### PR TITLE
8 packages from ocaml/opam at 2.6.0~beta1

### DIFF
--- a/packages/opam-client/opam-client.2.6.0~beta1/opam
+++ b/packages/opam-client/opam-client.2.6.0~beta1/opam
@@ -1,0 +1,48 @@
+opam-version: "2.0"
+synopsis: "Client library for opam 2.6"
+description:
+  "Actions on the opam root, switches, installations, and front-end."
+maintainer: "opam-devel@lists.ocaml.org"
+authors: [
+  "David Allsopp <david@tarides.com>"
+  "Vincent Bernardoff <vb@luminar.eu.org>"
+  "Raja Boujbel <raja.boujbel@ocamlpro.com>"
+  "Kate Deplaix <kit-ty-kate@exn.st>"
+  "Roberto Di Cosmo <roberto@dicosmo.org>"
+  "Thomas Gazagnaire <thomas@gazagnaire.org>"
+  "Louis Gesbert <louis.gesbert@ocamlpro.com>"
+  "Fabrice Le Fessant <Fabrice.Le_fessant@inria.fr>"
+  "Anil Madhavapeddy <anil@recoil.org>"
+  "Guillem Rieu <guillem.rieu@ocamlpro.com>"
+  "Ralf Treinen <ralf.treinen@pps.jussieu.fr>"
+  "Frederic Tuong <tuong@users.gforge.inria.fr>"
+]
+license: "LGPL-2.1-only WITH OCaml-LGPL-linking-exception"
+homepage: "https://opam.ocaml.org"
+bug-reports: "https://github.com/ocaml/opam/issues"
+depends: [
+  "ocaml" {>= "4.11.0"}
+  "dune" {>= "2.8.0"}
+  "opam-state" {= version}
+  "opam-solver" {= version}
+  "opam-repository" {= version}
+  "base64" {>= "3.1.0"}
+]
+conflicts: [
+  "extlib" {< "1.7.8"}
+  "extlib-compat"
+]
+available: opam-version >= "2.1.0"
+flags: avoid-version
+build: [
+  ["./configure" "--disable-checks" "--prefix" prefix]
+  ["dune" "build" "-p" name "-j" jobs]
+]
+dev-repo: "git+https://github.com/ocaml/opam.git"
+url {
+  src: "https://github.com/ocaml/opam/archive/refs/tags/2.6.0-beta1.tar.gz"
+  checksum: [
+    "md5=44a606f260d65e41a135c2b9f659453d"
+    "sha512=042ed5742eb7fc5fc921f95f9733cf4b0774a167ee96aa9d0ade48b91f0d3187bb561372f4dfea4087f888fa95371f7b60bc1fb85917fed3e152b71897640505"
+  ]
+}

--- a/packages/opam-core/opam-core.2.6.0~beta1/opam
+++ b/packages/opam-core/opam-core.2.6.0~beta1/opam
@@ -1,0 +1,57 @@
+opam-version: "2.0"
+synopsis: "Core library for opam 2.6"
+description:
+  "Small standard library extensions, and generic system interaction modules used by opam."
+maintainer: "opam-devel@lists.ocaml.org"
+authors: [
+  "David Allsopp <david@tarides.com>"
+  "Vincent Bernardoff <vb@luminar.eu.org>"
+  "Raja Boujbel <raja.boujbel@ocamlpro.com>"
+  "Kate Deplaix <kit-ty-kate@exn.st>"
+  "Roberto Di Cosmo <roberto@dicosmo.org>"
+  "Thomas Gazagnaire <thomas@gazagnaire.org>"
+  "Louis Gesbert <louis.gesbert@ocamlpro.com>"
+  "Fabrice Le Fessant <Fabrice.Le_fessant@inria.fr>"
+  "Anil Madhavapeddy <anil@recoil.org>"
+  "Guillem Rieu <guillem.rieu@ocamlpro.com>"
+  "Ralf Treinen <ralf.treinen@pps.jussieu.fr>"
+  "Frederic Tuong <tuong@users.gforge.inria.fr>"
+]
+license: "LGPL-2.1-only WITH OCaml-LGPL-linking-exception"
+homepage: "https://opam.ocaml.org"
+bug-reports: "https://github.com/ocaml/opam/issues"
+depends: [
+  "ocaml" {>= "4.11.0"}
+  "dune" {>= "2.8.0"}
+  "base-unix"
+  "ocamlgraph" {>= "1.8.8"}
+  "re" {>= "1.10.0"}
+  "sha" {>= "1.13"}
+  "jsonm" {>= "1.0.2"}
+  "swhid_core" {>= "0.1"}
+  "patch" {>= "3.0.0"}
+  "uutf" {>= "1.0.3"}
+  (("host-system-mingw" {os = "win32" & os-distribution != "cygwinports"} &
+    "conf-mingw-w64-gcc-i686"
+      {os = "win32" & os-distribution != "cygwinports"} &
+    "conf-mingw-w64-gcc-x86_64"
+      {os = "win32" & os-distribution != "cygwinports"}) |
+   ("host-system-msvc" {os = "win32" & os-distribution != "cygwinports"} &
+    "conf-msvc32" {os = "win32" & os-distribution != "cygwinports"} &
+    "conf-msvc64" {os = "win32" & os-distribution != "cygwinports"}))
+]
+conflicts: ["extlib-compat"]
+available: opam-version >= "2.1.0"
+flags: avoid-version
+build: [
+  ["./configure" "--disable-checks" "--prefix" prefix]
+  ["dune" "build" "-p" name "-j" jobs]
+]
+dev-repo: "git+https://github.com/ocaml/opam.git"
+url {
+  src: "https://github.com/ocaml/opam/archive/refs/tags/2.6.0-beta1.tar.gz"
+  checksum: [
+    "md5=44a606f260d65e41a135c2b9f659453d"
+    "sha512=042ed5742eb7fc5fc921f95f9733cf4b0774a167ee96aa9d0ade48b91f0d3187bb561372f4dfea4087f888fa95371f7b60bc1fb85917fed3e152b71897640505"
+  ]
+}

--- a/packages/opam-devel/opam-devel.2.6.0~beta1/opam
+++ b/packages/opam-devel/opam-devel.2.6.0~beta1/opam
@@ -1,0 +1,51 @@
+opam-version: "2.0"
+synopsis: "Bootstrapped development binary for opam 2.6"
+description:
+  "This package compiles (bootstraps) opam. For consistency and safety of the installation, the binaries are not installed into the PATH, but into lib/opam-devel, from where the user can manually install them system-wide."
+maintainer: "opam-devel@lists.ocaml.org"
+authors: [
+  "David Allsopp <david@tarides.com>"
+  "Vincent Bernardoff <vb@luminar.eu.org>"
+  "Raja Boujbel <raja.boujbel@ocamlpro.com>"
+  "Kate Deplaix <kit-ty-kate@exn.st>"
+  "Roberto Di Cosmo <roberto@dicosmo.org>"
+  "Thomas Gazagnaire <thomas@gazagnaire.org>"
+  "Louis Gesbert <louis.gesbert@ocamlpro.com>"
+  "Fabrice Le Fessant <Fabrice.Le_fessant@inria.fr>"
+  "Anil Madhavapeddy <anil@recoil.org>"
+  "Guillem Rieu <guillem.rieu@ocamlpro.com>"
+  "Ralf Treinen <ralf.treinen@pps.jussieu.fr>"
+  "Frederic Tuong <tuong@users.gforge.inria.fr>"
+]
+license: "LGPL-2.1-only WITH OCaml-LGPL-linking-exception"
+homepage: "https://opam.ocaml.org"
+bug-reports: "https://github.com/ocaml/opam/issues"
+depends: [
+  "ocaml" {>= "4.11.0"}
+  "dune" {>= "2.8.0"}
+  "opam-client" {= version}
+  "conf-openssl" {with-test}
+  "conf-diffutils" {with-test}
+]
+available: opam-version >= "2.1.0"
+flags: avoid-version
+build: [
+  ["./configure" "--disable-checks" "--prefix" prefix]
+  [make "%{name}%.install"]
+]
+post-messages:
+  """\
+The development version of opam has been successfully compiled into %{lib}%/%{name}%. You should not run it from there, please install the binaries to your PATH, e.g. with
+    sudo cp %{lib}%/%{name}%/opam /usr/local/bin
+
+If you just want to give it a try without altering your current installation, you could use instead:
+    alias opam2="OPAMROOT=~/.opam2 %{lib}%/%{name}%/opam\""""
+    {success}
+dev-repo: "git+https://github.com/ocaml/opam.git"
+url {
+  src: "https://github.com/ocaml/opam/archive/refs/tags/2.6.0-beta1.tar.gz"
+  checksum: [
+    "md5=44a606f260d65e41a135c2b9f659453d"
+    "sha512=042ed5742eb7fc5fc921f95f9733cf4b0774a167ee96aa9d0ade48b91f0d3187bb561372f4dfea4087f888fa95371f7b60bc1fb85917fed3e152b71897640505"
+  ]
+}

--- a/packages/opam-format/opam-format.2.6.0~beta1/opam
+++ b/packages/opam-format/opam-format.2.6.0~beta1/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+synopsis: "Format library for opam 2.6"
+description: "Definition of opam datastructures and its file interface."
+maintainer: "opam-devel@lists.ocaml.org"
+authors: [
+  "David Allsopp <david@tarides.com>"
+  "Vincent Bernardoff <vb@luminar.eu.org>"
+  "Raja Boujbel <raja.boujbel@ocamlpro.com>"
+  "Kate Deplaix <kit-ty-kate@exn.st>"
+  "Roberto Di Cosmo <roberto@dicosmo.org>"
+  "Thomas Gazagnaire <thomas@gazagnaire.org>"
+  "Louis Gesbert <louis.gesbert@ocamlpro.com>"
+  "Fabrice Le Fessant <Fabrice.Le_fessant@inria.fr>"
+  "Anil Madhavapeddy <anil@recoil.org>"
+  "Guillem Rieu <guillem.rieu@ocamlpro.com>"
+  "Ralf Treinen <ralf.treinen@pps.jussieu.fr>"
+  "Frederic Tuong <tuong@users.gforge.inria.fr>"
+]
+license: "LGPL-2.1-only WITH OCaml-LGPL-linking-exception"
+homepage: "https://opam.ocaml.org"
+bug-reports: "https://github.com/ocaml/opam/issues"
+depends: [
+  "ocaml" {>= "4.11.0"}
+  "dune" {>= "2.8.0"}
+  "opam-core" {= version}
+  "opam-file-format" {>= "2.1.4"}
+]
+available: opam-version >= "2.1.0"
+flags: avoid-version
+build: [
+  ["./configure" "--disable-checks" "--prefix" prefix]
+  ["dune" "build" "-p" name "-j" jobs]
+]
+dev-repo: "git+https://github.com/ocaml/opam.git"
+url {
+  src: "https://github.com/ocaml/opam/archive/refs/tags/2.6.0-beta1.tar.gz"
+  checksum: [
+    "md5=44a606f260d65e41a135c2b9f659453d"
+    "sha512=042ed5742eb7fc5fc921f95f9733cf4b0774a167ee96aa9d0ade48b91f0d3187bb561372f4dfea4087f888fa95371f7b60bc1fb85917fed3e152b71897640505"
+  ]
+}

--- a/packages/opam-installer/opam-installer.2.6.0~beta1/opam
+++ b/packages/opam-installer/opam-installer.2.6.0~beta1/opam
@@ -1,0 +1,43 @@
+opam-version: "2.0"
+synopsis: "Installation of files to a prefix, following opam conventions"
+description: """\
+opam-installer is a small tool that can read *.install files, as defined by opam [1], and execute them to install or remove package files without going through opam.
+
+[1] http://opam.ocaml.org/doc/2.0/Manual.html#lt-pkgname-gt-install"""
+maintainer: "opam-devel@lists.ocaml.org"
+authors: [
+  "David Allsopp <david@tarides.com>"
+  "Vincent Bernardoff <vb@luminar.eu.org>"
+  "Raja Boujbel <raja.boujbel@ocamlpro.com>"
+  "Kate Deplaix <kit-ty-kate@exn.st>"
+  "Roberto Di Cosmo <roberto@dicosmo.org>"
+  "Thomas Gazagnaire <thomas@gazagnaire.org>"
+  "Louis Gesbert <louis.gesbert@ocamlpro.com>"
+  "Fabrice Le Fessant <Fabrice.Le_fessant@inria.fr>"
+  "Anil Madhavapeddy <anil@recoil.org>"
+  "Guillem Rieu <guillem.rieu@ocamlpro.com>"
+  "Ralf Treinen <ralf.treinen@pps.jussieu.fr>"
+  "Frederic Tuong <tuong@users.gforge.inria.fr>"
+]
+license: "LGPL-2.1-only WITH OCaml-LGPL-linking-exception"
+homepage: "https://opam.ocaml.org"
+bug-reports: "https://github.com/ocaml/opam/issues"
+depends: [
+  "ocaml" {>= "4.11.0"}
+  "dune" {>= "2.8.0"}
+  "opam-format" {= version}
+]
+available: opam-version >= "2.1.0"
+flags: avoid-version
+build: [
+  ["./configure" "--disable-checks" "--prefix" prefix]
+  ["dune" "build" "-p" name "-j" jobs]
+]
+dev-repo: "git+https://github.com/ocaml/opam.git"
+url {
+  src: "https://github.com/ocaml/opam/archive/refs/tags/2.6.0-beta1.tar.gz"
+  checksum: [
+    "md5=44a606f260d65e41a135c2b9f659453d"
+    "sha512=042ed5742eb7fc5fc921f95f9733cf4b0774a167ee96aa9d0ade48b91f0d3187bb561372f4dfea4087f888fa95371f7b60bc1fb85917fed3e152b71897640505"
+  ]
+}

--- a/packages/opam-repository/opam-repository.2.6.0~beta1/opam
+++ b/packages/opam-repository/opam-repository.2.6.0~beta1/opam
@@ -1,0 +1,45 @@
+opam-version: "2.0"
+synopsis: "Repository library for opam 2.6"
+description:
+  "This library includes repository and remote sources handling, including curl/wget, rsync, git, mercurial, darcs backends."
+maintainer: "opam-devel@lists.ocaml.org"
+authors: [
+  "David Allsopp <david@tarides.com>"
+  "Vincent Bernardoff <vb@luminar.eu.org>"
+  "Raja Boujbel <raja.boujbel@ocamlpro.com>"
+  "Kate Deplaix <kit-ty-kate@exn.st>"
+  "Roberto Di Cosmo <roberto@dicosmo.org>"
+  "Thomas Gazagnaire <thomas@gazagnaire.org>"
+  "Louis Gesbert <louis.gesbert@ocamlpro.com>"
+  "Fabrice Le Fessant <Fabrice.Le_fessant@inria.fr>"
+  "Anil Madhavapeddy <anil@recoil.org>"
+  "Guillem Rieu <guillem.rieu@ocamlpro.com>"
+  "Ralf Treinen <ralf.treinen@pps.jussieu.fr>"
+  "Frederic Tuong <tuong@users.gforge.inria.fr>"
+]
+license: "LGPL-2.1-only WITH OCaml-LGPL-linking-exception"
+homepage: "https://opam.ocaml.org"
+bug-reports: "https://github.com/ocaml/opam/issues"
+depends: [
+  "ocaml" {>= "4.11.0"}
+  "dune" {>= "2.8.0"}
+  "opam-format" {= version}
+  "patch" {>= "3.0.0"}
+  "tar" {>= "3.5.0"}
+  "checkseum" {>= "0.5.2"}
+  "decompress" {>= "1.5.1"}
+]
+available: opam-version >= "2.1.0"
+flags: avoid-version
+build: [
+  ["./configure" "--disable-checks" "--prefix" prefix]
+  ["dune" "build" "-p" name "-j" jobs]
+]
+dev-repo: "git+https://github.com/ocaml/opam.git"
+url {
+  src: "https://github.com/ocaml/opam/archive/refs/tags/2.6.0-beta1.tar.gz"
+  checksum: [
+    "md5=44a606f260d65e41a135c2b9f659453d"
+    "sha512=042ed5742eb7fc5fc921f95f9733cf4b0774a167ee96aa9d0ade48b91f0d3187bb561372f4dfea4087f888fa95371f7b60bc1fb85917fed3e152b71897640505"
+  ]
+}

--- a/packages/opam-solver/opam-solver.2.6.0~beta1/opam
+++ b/packages/opam-solver/opam-solver.2.6.0~beta1/opam
@@ -1,0 +1,49 @@
+opam-version: "2.0"
+synopsis: "Solver library for opam 2.6"
+description:
+  "Solver and Cudf interaction. This library is based on the Cudf and Dose libraries, and handles calls to the external solver from opam."
+maintainer: "opam-devel@lists.ocaml.org"
+authors: [
+  "David Allsopp <david@tarides.com>"
+  "Vincent Bernardoff <vb@luminar.eu.org>"
+  "Raja Boujbel <raja.boujbel@ocamlpro.com>"
+  "Kate Deplaix <kit-ty-kate@exn.st>"
+  "Roberto Di Cosmo <roberto@dicosmo.org>"
+  "Thomas Gazagnaire <thomas@gazagnaire.org>"
+  "Louis Gesbert <louis.gesbert@ocamlpro.com>"
+  "Fabrice Le Fessant <Fabrice.Le_fessant@inria.fr>"
+  "Anil Madhavapeddy <anil@recoil.org>"
+  "Guillem Rieu <guillem.rieu@ocamlpro.com>"
+  "Ralf Treinen <ralf.treinen@pps.jussieu.fr>"
+  "Frederic Tuong <tuong@users.gforge.inria.fr>"
+]
+license: "LGPL-2.1-only WITH OCaml-LGPL-linking-exception"
+homepage: "https://opam.ocaml.org"
+bug-reports: "https://github.com/ocaml/opam/issues"
+depends: [
+  "ocaml" {>= "4.11.0"}
+  "dune" {>= "2.8.0"}
+  "opam-format" {= version}
+  "mccs" {>= "1.1+17"}
+  "dose3" {>= "6.1"}
+  "cudf" {>= "0.7"}
+  "opam-0install-cudf" {>= "0.5.0"}
+]
+depopts: ["z3"]
+conflicts: [
+  "z3" {< "4.8.4"}
+]
+available: opam-version >= "2.1.0"
+flags: avoid-version
+build: [
+  ["./configure" "--disable-checks" "--prefix" prefix]
+  ["dune" "build" "-p" name "-j" jobs]
+]
+dev-repo: "git+https://github.com/ocaml/opam.git"
+url {
+  src: "https://github.com/ocaml/opam/archive/refs/tags/2.6.0-beta1.tar.gz"
+  checksum: [
+    "md5=44a606f260d65e41a135c2b9f659453d"
+    "sha512=042ed5742eb7fc5fc921f95f9733cf4b0774a167ee96aa9d0ade48b91f0d3187bb561372f4dfea4087f888fa95371f7b60bc1fb85917fed3e152b71897640505"
+  ]
+}

--- a/packages/opam-state/opam-state.2.6.0~beta1/opam
+++ b/packages/opam-state/opam-state.2.6.0~beta1/opam
@@ -1,0 +1,43 @@
+opam-version: "2.0"
+synopsis: "State library for opam 2.6"
+description:
+  "Handling of the ~/.opam hierarchy, repository and switch states."
+maintainer: "opam-devel@lists.ocaml.org"
+authors: [
+  "David Allsopp <david@tarides.com>"
+  "Vincent Bernardoff <vb@luminar.eu.org>"
+  "Raja Boujbel <raja.boujbel@ocamlpro.com>"
+  "Kate Deplaix <kit-ty-kate@exn.st>"
+  "Roberto Di Cosmo <roberto@dicosmo.org>"
+  "Thomas Gazagnaire <thomas@gazagnaire.org>"
+  "Louis Gesbert <louis.gesbert@ocamlpro.com>"
+  "Fabrice Le Fessant <Fabrice.Le_fessant@inria.fr>"
+  "Anil Madhavapeddy <anil@recoil.org>"
+  "Guillem Rieu <guillem.rieu@ocamlpro.com>"
+  "Ralf Treinen <ralf.treinen@pps.jussieu.fr>"
+  "Frederic Tuong <tuong@users.gforge.inria.fr>"
+]
+license: "LGPL-2.1-only WITH OCaml-LGPL-linking-exception"
+homepage: "https://opam.ocaml.org"
+bug-reports: "https://github.com/ocaml/opam/issues"
+depends: [
+  "ocaml" {>= "4.11.0"}
+  "dune" {>= "2.8.0"}
+  "opam-repository" {= version}
+  "spdx_licenses" {>= "1.4.0"}
+  "patch" {>= "3.0.0"}
+]
+available: opam-version >= "2.1.0"
+flags: avoid-version
+build: [
+  ["./configure" "--disable-checks" "--prefix" prefix]
+  ["dune" "build" "-p" name "-j" jobs]
+]
+dev-repo: "git+https://github.com/ocaml/opam.git"
+url {
+  src: "https://github.com/ocaml/opam/archive/refs/tags/2.6.0-beta1.tar.gz"
+  checksum: [
+    "md5=44a606f260d65e41a135c2b9f659453d"
+    "sha512=042ed5742eb7fc5fc921f95f9733cf4b0774a167ee96aa9d0ade48b91f0d3187bb561372f4dfea4087f888fa95371f7b60bc1fb85917fed3e152b71897640505"
+  ]
+}


### PR DESCRIPTION
This pull-request concerns:
- `opam-client.2.6.0~beta1`: Client library for opam 2.6
- `opam-core.2.6.0~beta1`: Core library for opam 2.6
- `opam-devel.2.6.0~beta1`: Bootstrapped development binary for opam 2.6
- `opam-format.2.6.0~beta1`: Format library for opam 2.6
- `opam-installer.2.6.0~beta1`: Installation of files to a prefix, following opam conventions
- `opam-repository.2.6.0~beta1`: Repository library for opam 2.6
- `opam-solver.2.6.0~beta1`: Solver library for opam 2.6
- `opam-state.2.6.0~beta1`: State library for opam 2.6



---
* Homepage: https://opam.ocaml.org
* Source repo: git+https://github.com/ocaml/opam.git
* Bug tracker: https://github.com/ocaml/opam/issues

---
:camel: Pull-request generated by opam-publish v3.0.1