### PR TITLE
Mark afl is non-maintaned: repo is archived

### DIFF
--- a/packages/afl/afl.2.57b/opam
+++ b/packages/afl/afl.2.57b/opam
@@ -34,3 +34,6 @@ extra-source "add-uninstall-target.patch" {
     "md5=2c41a9cb71830813fd4e700b5aacc3b5"
   ]
 }
+
+# Repository has been archived on Mar 22, 2024
+x-maintenance-intent: [ "(none)" ]


### PR DESCRIPTION
It is red at [check.ci.ocaml.org](https://check.ci.ocaml.org/?comp=4.11&comp=4.14&comp=5.2&comp=5.4&comp=5.5&available=4.11&available=4.14&available=5.2&available=5.4&available=5.5&show-only=partial&show-only=bad&show-latest-only=true&packages=afl&maintainers=&logsearch=&logsearch_comp=4.11)