### PR TITLE
Package ascon.0.1.0

### DIFF
--- a/packages/ascon/ascon.0.1.0/opam
+++ b/packages/ascon/ascon.0.1.0/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+synopsis: "Pure OCaml implementation of NIST SP 800-232 Ascon"
+description: """
+A portable, dependency-free implementation of the final NIST SP 800-232
+Ascon-AEAD128, Ascon-Hash256, Ascon-XOF128, and Ascon-CXOF128 algorithms.
+The package provides misuse-resistant one-shot AEAD and typed incremental XOF
+interfaces. It has no mandatory C or Unix dependency.
+"""
+maintainer: ["Ville Vesilehto <ville@vesilehto.fi>"]
+authors: ["Ville Vesilehto"]
+license: "ISC"
+homepage: "https://github.com/thevilledev/ocaml-ascon"
+bug-reports: "https://github.com/thevilledev/ocaml-ascon/issues"
+dev-repo: "git+https://github.com/thevilledev/ocaml-ascon.git"
+tags: [
+  "cryptography"
+  "ascon"
+  "aead"
+  "hash"
+  "xof"
+  "nist"
+  "sp-800-232"
+  "mirageos"
+]
+depends: [
+  "ocaml" {>= "4.14"}
+  "dune" {>= "3.10"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs "@install" "@runtest" {with-test} "@doc" {with-doc}]
+]
+url {
+  src:
+    "https://github.com/thevilledev/ocaml-ascon/archive/refs/tags/v0.1.0.tar.gz"
+  checksum: [
+    "md5=4e2904c6a3cbf08eaf2ae59c636043c6"
+    "sha512=2d907cb1fd98d2d02c8852f02cea7a651acb53ee31e255118a0c1369576788b747c0f90ecaf548afc3a0ada25cb98010965a7b48f95ca609be80d39e32375c7e"
+  ]
+}


### PR DESCRIPTION
### `ascon.0.1.0`
Pure OCaml implementation of NIST SP 800-232 Ascon
A portable, dependency-free implementation of the final NIST SP 800-232
Ascon-AEAD128, Ascon-Hash256, Ascon-XOF128, and Ascon-CXOF128 algorithms.
The package provides misuse-resistant one-shot AEAD and typed incremental XOF
interfaces. It has no mandatory C or Unix dependency.



---
* Homepage: https://github.com/thevilledev/ocaml-ascon
* Source repo: git+https://github.com/thevilledev/ocaml-ascon.git
* Bug tracker: https://github.com/thevilledev/ocaml-ascon/issues

---
:camel: Pull-request generated by opam-publish v3.0.1