### PR TITLE
[new release] mkernel (0.0.4)

### DIFF
--- a/packages/mkernel/mkernel.0.0.4/opam
+++ b/packages/mkernel/mkernel.0.0.4/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+maintainer:   "romain.calascibetta@gmail.com"
+homepage:     "https://git.robur.coop/robur/mkernel"
+bug-reports:  "https://git.robur.coop/robur/mkernel/issues"
+dev-repo:     "git+https://github.com/robur-coop/mkernel.git"
+doc:          "https://git.robur.coop/robur/mkernel"
+license:      "MIT"
+authors:      [ "Romain Calascibetta <romain.calascibetta@gmail.com>" ]
+build:        [
+  [ "dune" "subst" ] {dev}
+  [ "dune" "build" "-p" name "-j" jobs ]
+  [ "dune" "runtest" "-p" name ] {with-test}
+]
+run-test: [ "dune" "runtest" "-p" name "-j" jobs ]
+synopsis: "An unikernel with Miou in OCaml to provide I/O for Solo5"
+depends: [
+  "ocaml" {>= "5.2.1"}
+  "dune"  {>= "3.23"}
+  "bstr"
+  "miou"  {>= "0.5.2"}
+  "ptime"
+  "solo5"
+  "logs"
+  "jsont"
+  "bytesrw"
+  "ocaml-solo5"
+  "hxd" {with-test}
+  "fmt" {with-test}
+  "cachet" {with-test}
+]
+url {
+  src:
+    "https://github.com/robur-coop/mkernel/releases/download/v0.0.4/mkernel-0.0.4.tbz"
+  checksum: [
+    "sha256=3404c089085a170be5bca63fd4463fd5a2f5420e64802055c24d117bcb9e215d"
+    "sha512=350e2ebf53057d8a45778584959df6fdc6daf7a652fe31cde01810e80dafcbc02093d3b109909c15aa2bc39cbcca7042953bfea48f530db512b316e62e95a8c4"
+  ]
+}
+x-commit-hash: "da6c2ec6e7679d05897f27a3269ccd7ad060e5ab"

--- a/packages/mnet/mnet.0.0.1/opam
+++ b/packages/mnet/mnet.0.0.1/opam
@@ -13,7 +13,7 @@ depends: [
   "bstr" {>= "0.0.4"}
   "bin"
   "slice"
-  "mkernel"
+  "mkernel" {< "0.0.4"}
   "mirage-crypto-rng"
   "duration"
   "fmt"

--- a/packages/mnet/mnet.0.0.2/opam
+++ b/packages/mnet/mnet.0.0.2/opam
@@ -13,7 +13,7 @@ depends: [
   "bstr" {>= "0.0.4"}
   "bin"
   "slice"
-  "mkernel"
+  "mkernel" {< "0.0.4"}
   "mirage-crypto-rng"
   "duration"
   "fmt"

--- a/packages/mnet/mnet.0.0.3/opam
+++ b/packages/mnet/mnet.0.0.3/opam
@@ -13,7 +13,7 @@ depends: [
   "bstr" {>= "0.0.4"}
   "bin"
   "slice"
-  "mkernel"
+  "mkernel" {< "0.0.4"}
   "mirage-crypto-rng"
   "duration"
   "fmt"

--- a/packages/mnet/mnet.0.0.4/opam
+++ b/packages/mnet/mnet.0.0.4/opam
@@ -13,7 +13,7 @@ depends: [
   "bstr" {>= "0.0.4"}
   "bin"
   "slice"
-  "mkernel" {>= "0.0.3"}
+  "mkernel" {>= "0.0.3" & < "0.0.4"}
   "mirage-crypto-rng"
   "duration"
   "fmt"


### PR DESCRIPTION
An unikernel with Miou in OCaml to provide I/O for Solo5

- Project page: <a href="https://git.robur.coop/robur/mkernel">https://git.robur.coop/robur/mkernel</a>
- Documentation: <a href="https://git.robur.coop/robur/mkernel">https://git.robur.coop/robur/mkernel</a>

##### CHANGES:

- Provide malloc statistic (@hannesm, @reynir, [!26][26], [!30][30])
- Introduce `Mkernel.finally` (@reynir, @dinosaure, [!23][23])
- Rename `Block.pagesize` to `Block.sector_size` (@dinosaure, @hannesm, @reynir, [!24][24])
- Add stubs for `mirage-mtime` (@hannesm, @dinosaure, [!25][25])
- Introduce a `Stats` module (@hannesm, @reynir, [!27][27])
- Introduce `Mkernel.now` (@dinosaure, @hannesm, [!28][28])
- Rename log source (@hannesm, @reynir, [!29][29])
- Embed MAC and MTU into the `Net.t` (@hannesm, @dinosaure, [!31][31])
- Remove unikraft from the documentation (@hannesm, @dinosaure, [!32][32])
- Use `memcpy` when we copy bigstring (@hannesm, @dinosaure, [robur-coop/mkernel#34][34], [!36][36])

[34]: https://git.robur.coop/robur/mkernel/issues/34
[23]: https://git.robur.coop/robur/mkernel/pulls/23
[24]: https://git.robur.coop/robur/mkernel/pulls/24
[25]: https://git.robur.coop/robur/mkernel/pulls/25
[26]: https://git.robur.coop/robur/mkernel/pulls/26
[27]: https://git.robur.coop/robur/mkernel/pulls/27
[28]: https://git.robur.coop/robur/mkernel/pulls/28
[29]: https://git.robur.coop/robur/mkernel/pulls/29
[30]: https://git.robur.coop/robur/mkernel/pulls/30
[31]: https://git.robur.coop/robur/mkernel/pulls/31
[32]: https://git.robur.coop/robur/mkernel/pulls/32
[36]: https://git.robur.coop/robur/mkernel/pulls/36
