### PR TITLE
[new release] highway (2 packages) (0.0.1)

### DIFF
--- a/packages/highway-dream/highway-dream.0.0.1/opam
+++ b/packages/highway-dream/highway-dream.0.0.1/opam
@@ -1,0 +1,54 @@
+opam-version: "2.0"
+synopsis: "Use Highway withing Dream Application"
+description: "Use Highway withing Dream Application"
+maintainer: [
+  "d-plaindoux <d.plaindoux@free.fr>"
+  "xhtmlboi <xhtmlboi@gmail.com>"
+  "xvw <xaviervdw@gmail.com>"
+  "msp <spawnmick@gmail.com>"
+  "grm <grimfw@gmail.com>"
+]
+authors: [
+  "d-plaindoux <d.plaindoux@free.fr>"
+  "xhtmlboi <xhtmlboi@gmail.com>"
+  "xvw <xaviervdw@gmail.com>"
+  "msp <spawnmick@gmail.com>"
+  "grm <grimfw@gmail.com>"
+]
+license: "BSD-3-Clause"
+homepage: "https://github.com/cargocut/highway"
+bug-reports: "https://github.com/cargocut/highway/issues"
+depends: [
+  "dune" {>= "3.21"}
+  "ocaml" {>= "5.0.0"}
+  "highway" {= version}
+  "dream" {>= "1.0.0~alpha8"}
+  "alcotest" {with-test & >= "1.9.1"}
+  "mdx" {with-test & >= "2.6.0"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/cargocut/highway.git"
+x-maintenance-intent: ["(latest)"]
+url {
+  src:
+    "https://github.com/cargocut/highway/releases/download/v0.0.1/highway-0.0.1.tbz"
+  checksum: [
+    "sha256=9354076da1f5b56d6bfca1aacf2b46a7303cd1c3178f26136f52e5e9a931659e"
+    "sha512=c1abdcc5580df3c5a9e65b66a9f1307b806ceb3ecaa5bb138d27d45611eee982ac9fc9e14dfcc24b47afe8740df27ff4c2729061afbee09cb34810c6b71064ad"
+  ]
+}
+x-commit-hash: "bad6117867b0d357e5f82d2a82c0920e44f5b408"

--- a/packages/highway/highway.0.0.1/opam
+++ b/packages/highway/highway.0.0.1/opam
@@ -1,0 +1,58 @@
+opam-version: "2.0"
+synopsis: "A dead-simple agnostic HTTP router"
+description: "A simple framework-agnostic typed HTTP router"
+maintainer: [
+  "d-plaindoux <d.plaindoux@free.fr>"
+  "xhtmlboi <xhtmlboi@gmail.com>"
+  "xvw <xaviervdw@gmail.com>"
+  "msp <spawnmick@gmail.com>"
+  "grm <grimfw@gmail.com>"
+]
+authors: [
+  "d-plaindoux <d.plaindoux@free.fr>"
+  "xhtmlboi <xhtmlboi@gmail.com>"
+  "xvw <xaviervdw@gmail.com>"
+  "msp <spawnmick@gmail.com>"
+  "grm <grimfw@gmail.com>"
+]
+license: "BSD-3-Clause"
+homepage: "https://github.com/cargocut/highway"
+bug-reports: "https://github.com/cargocut/highway/issues"
+depends: [
+  "dune" {>= "3.21"}
+  "ocaml" {>= "5.0.0"}
+  "pidgin" {>= "1.0.0"}
+  "alcotest" {with-test & >= "1.9.1"}
+  "mdx" {with-test & >= "2.6.0"}
+  "utop" {with-dev-setup}
+  "ocamlformat" {with-dev-setup}
+  "ocp-indent" {with-dev-setup}
+  "merlin" {with-dev-setup}
+  "ocaml-lsp-server" {with-dev-setup}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/cargocut/highway.git"
+x-maintenance-intent: ["(latest)"]
+url {
+  src:
+    "https://github.com/cargocut/highway/releases/download/v0.0.1/highway-0.0.1.tbz"
+  checksum: [
+    "sha256=9354076da1f5b56d6bfca1aacf2b46a7303cd1c3178f26136f52e5e9a931659e"
+    "sha512=c1abdcc5580df3c5a9e65b66a9f1307b806ceb3ecaa5bb138d27d45611eee982ac9fc9e14dfcc24b47afe8740df27ff4c2729061afbee09cb34810c6b71064ad"
+  ]
+}
+x-commit-hash: "bad6117867b0d357e5f82d2a82c0920e44f5b408"


### PR DESCRIPTION
A dead-simple agnostic HTTP router

- Project page: <a href="https://github.com/cargocut/highway">https://github.com/cargocut/highway</a>

##### CHANGES:

#### Highway

- First release of `highway`

#### Highway_dream

- First release of `highway-dream` (a very minimalist version)
