### PR TITLE
[new release] mariadb (2.1.0)

### DIFF
--- a/packages/mariadb/mariadb.2.1.0/opam
+++ b/packages/mariadb/mariadb.2.1.0/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+maintainer: "Petter A. Urkedal <paurkedal@gmail.com>"
+x-maintenance-intent: ["(latest)"]
+authors: "Andre Nathan <andrenth@gmail.com>"
+homepage: "https://github.com/ocaml-community/ocaml-mariadb"
+bug-reports: "https://github.com/ocaml-community/ocaml-mariadb/issues"
+license: "MIT"
+dev-repo: "git+https://github.com/ocaml-community/ocaml-mariadb.git"
+synopsis: "OCaml bindings for MariaDB"
+description: "OCaml-MariaDB provides Ctypes-based bindings for MariaDB, including its nonblocking API."
+
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+depends: [
+  "ocaml" {>= "4.11.0"}
+  "ctypes" {>= "0.13.0"}
+  "conf-mariadb"
+  "conf-gcc"
+  "conf-pkg-config"
+  "dune" {>= "3.15.0"}
+  "dune-configurator"
+  "async" {with-test}
+  "lwt" {with-test}
+]
+conflicts: [ "ocaml-option-bytecode-only" ]
+url {
+  src:
+    "https://github.com/ocaml-community/ocaml-mariadb/releases/download/v2.1.0/mariadb-v2.1.0.tbz"
+  checksum: [
+    "sha256=cdeec5e3486f76da9d9ca24fb18b3962a1ef1289ca8ed1692cf2e55c59e9d530"
+    "sha512=2a52a467a8b4dea1b39a620432eeda06e5c72456cf6d8d354809d788f2fd85c5994a8e9d2e19e588d0601ab5d77391ad80435e7dee488b71137402b8414a9142"
+  ]
+}
+x-commit-hash: "23deca62b2d498a66294c6ba627fb595d1bec5b4"


### PR DESCRIPTION
OCaml bindings for MariaDB

- Project page: <a href="https://github.com/ocaml-community/ocaml-mariadb">https://github.com/ocaml-community/ocaml-mariadb</a>

##### CHANGES:

  - Added support for text protocol (non-prepared) execution of statements
    (ocaml-community/ocaml-mariadb#72 by jongleb).  This is limited to statements which do not return any
    result, which should cover primary use cases like changing settings or
    deploying schema definitions.
  - Optimised encoding of string and blob parameters (ocaml-community/ocaml-mariadb#73 by jongleb).
  - Added support for SQLSTATE to the extend implemented in C library (ocaml-community/ocaml-mariadb#42
    by Petter A. Urkedal).
