### PR TITLE
Add a coq.9.2.0 compatibility package

### DIFF
--- a/packages/coq/coq.9.2.0/opam
+++ b/packages/coq/coq.9.2.0/opam
@@ -8,7 +8,7 @@ doc: "https://rocq-prover.org/docs/"
 bug-reports: "https://github.com/rocq-prover/rocq/issues"
 depends: [
   "coq-core" {= version}
-  "rocq-stdlib" {= "9.1.0"}
+  "rocq-stdlib"
   "coqide-server" {= version}
 ]
 dev-repo: "git+https://github.com/rocq-prover/rocq.git"

--- a/packages/coq/coq.9.2.0/opam
+++ b/packages/coq/coq.9.2.0/opam
@@ -1,0 +1,14 @@
+opam-version: "2.0"
+synopsis: "Compatibility metapackage for Coq after the Rocq renaming"
+maintainer: ["The Rocq development team <rocq+rocq-development@discoursemail.com>"]
+authors: ["The Rocq development team, INRIA, CNRS, and contributors"]
+license: "LGPL-2.1-only"
+homepage: "https://rocq-prover.org/"
+doc: "https://rocq-prover.org/docs/"
+bug-reports: "https://github.com/rocq-prover/rocq/issues"
+depends: [
+  "coq-core" {= version}
+  "rocq-stdlib" {= "9.1.0"}
+  "coqide-server" {= version}
+]
+dev-repo: "git+https://github.com/rocq-prover/rocq.git"


### PR DESCRIPTION
This is meant to ease porting developments still relying on the coq shims.