### PR TITLE
[new release] binsec (0.11.3)

### DIFF
--- a/packages/binsec/binsec.0.11.3/opam
+++ b/packages/binsec/binsec.0.11.3/opam
@@ -1,0 +1,112 @@
+opam-version: "2.0"
+synopsis: "Semantic analysis of binary executables"
+description: """
+
+BINSEC aims at developing an open-source platform filling the gap between formal
+methods over executable code and binary-level security analyses currently used
+in the security industry.
+
+The project targets the following applicative domains:
+
+    vulnerability analyses
+    malware comprehension
+    code protection
+    binary-level verification
+
+BINSEC is developed at CEA List in scientfic collaboration with Verimag and LORIA.
+
+An overview of some BINSEC features can be found in our SSPREW'17 tutorial."""
+maintainer: ["BINSEC <binsec@saxifrage.saclay.cea.fr>"]
+authors: [
+  "Adel Djoudi"
+  "Benoit Boero"
+  "Benjamin Farinier"
+  "Chakib Foulani"
+  "Dorian Lesbre"
+  "Frédéric Recoules"
+  "Guillaume Girol"
+  "Josselin Feist"
+  "Lesly-Ann Daniel"
+  "Mahmudul Faisal Al Ameen"
+  "Manh-Dung Nguyen"
+  "Mathéo Vergnolle"
+  "Matthieu Lemerre"
+  "Nicolas Bellec"
+  "Olivier Nicole"
+  "Richard Bonichon"
+  "Robin David"
+  "Sébastien Bardin"
+  "Soline Ducousso"
+  "Ta Thanh Dinh"
+  "Yaëlle Vinçont"
+  "Yanis Sellami"
+]
+license: "LGPL-2.1-or-later"
+tags: [
+  "binary code analysis"
+  "symbolic execution"
+  "deductive"
+  "program verification"
+  "formal specification"
+  "automated theorem prover"
+  "plugins"
+  "abstract interpretation"
+  "dataflow analysis"
+  "linking"
+  "disassembly"
+]
+homepage: "https://binsec.github.io"
+bug-reports: "mailto:binsec@saxifrage.saclay.cea.fr"
+depends: [
+  "dune" {>= "3.18"}
+  "ocaml" {>= "4.14"}
+  "menhir" {build & >= "20181113"}
+  "ocamlgraph" {>= "1.8.5"}
+  "zarith" {>= "1.13"}
+  "dune-site"
+  "dypgen"
+  "toml" {>= "6"}
+  "mula"
+  "ounit2" {with-test & >= "2"}
+  "qcheck" {with-test & >= "0.90"}
+  "ppx_inline_test" {with-test}
+  "unionFind" {with-test}
+  "ocamlformat" {with-dev-setup & = "0.28.1"}
+  "odoc" {with-doc}
+]
+depopts: ["curses" "llvm" "unisim_archisec" "bitwuzla" "bitwuzla-cxx" "z3"]
+conflicts: [
+  "llvm" {< "6.0.0" | >= "16.0.0"}
+  "bitwuzla" {< "1.0.6"}
+  "bitwuzla-cxx" {< "0.4"}
+  "z3" {< "4.8.13"}
+  "unisim_archisec" {< "0.0.6"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+dev-repo: "git+https://github.com/binsec/binsec.git"
+x-maintenance-intent: ["(latest)"]
+available: [ os-family != "windows" ]
+url {
+  src:
+    "https://github.com/binsec/binsec/releases/download/0.11.3/binsec-0.11.3.tbz"
+  checksum: [
+    "sha256=93f6fe439d486b166062ef6dd92c4ce3aa0947b5e18b1c3aa7de2fc3003aa6d9"
+    "sha512=98feb2b0a3f0a33fe912e9885311dd1c051768c707437f8ef038a8489fec019960142b588c6973eb8f726a14d9b2a1b4c765d915539911cb9f6ed6da9f1e51f2"
+  ]
+}
+x-commit-hash: "9749bd8aed7ee0a27959158b1e53e8789cb0e5ab"


### PR DESCRIPTION
Semantic analysis of binary executables

- Project page: <a href="https://binsec.github.io">https://binsec.github.io</a>

##### CHANGES:

** Misc

- Improve command-line interface error messages and color output support
- Improve `Makefile` build rules and add `switch-dev` target
- Restore `Formula` SMT solver internal backend

** Bugs

- Fix a bug where non-`PT_LOAD` segments were incorrectly loaded from ELF binaries (binsec/binsec#67)
- Fix a parsing error caused by grammar ambiguity
- Fix minor typos and missing documentation (including binsec/binsec#65)
