### PR TITLE
[new release] patricia-tree v0.15.0

### DIFF
--- a/packages/patricia-tree/patricia-tree.0.15.0/opam
+++ b/packages/patricia-tree/patricia-tree.0.15.0/opam
@@ -1,0 +1,48 @@
+opam-version: "2.0"
+synopsis:
+  "Patricia Tree data structure in OCaml for maps and sets. Supports generic key-value pairs"
+maintainer: ["Dorian Lesbre <dorian.lesbre@cea.fr>"]
+authors: [
+  "Matthieu Lemerre <matthieu.lemerre@cea.fr>"
+  "Dorian Lesbre <dorian.lesbre@cea.fr>"
+]
+license: "LGPL-2.1-only"
+homepage: "https://codex.top/api/patricia-tree/"
+doc: "https://codex.top/api/patricia-tree/"
+bug-reports:
+  "https://github.com/codex-semantics-library/patricia-tree/issues"
+depends: [
+  "ocaml" {>= "4.14"}
+  "dune" {>= "3.0"}
+  "qcheck" {>= "0.90" & with-test}
+  "ppx_inline_test" {>= "v0.16.0" & with-test}
+  "mdx" {>= "2.4.1" & with-test}
+  "odoc" {>= "2.4.0" & with-doc}
+  "sherlodoc" {with-doc}
+  "bechamel" {with-dev-setup}
+  "csv" {with-dev-setup}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/codex-semantics-library/patricia-tree.git"
+url {
+  src:
+    "https://github.com/codex-semantics-library/patricia-tree/releases/download/v0.15.0/patricia-tree-0.15.0.tbz"
+  checksum: [
+    "sha256=e0fe66ab7da5b2ad240b64430d605f4064bc704bf487acc6314fd868e98ec279"
+    "sha512=72d267a727bdda2b3254a8459f6ab3b78ac539456dca8d026520a3a1537369d553d4008c17956d465ea40aa0fdca5a4df1d658fd28af68f73754904a0350d421"
+  ]
+}
+x-commit-hash: "f69530c5ddf5598e0776723efae8f053622f4fb6"


### PR DESCRIPTION
Patricia Tree data structure in OCaml for maps and sets. Supports generic key-value pairs
- Project page: https://codex.top/api/patricia-tree/
- Documentation: https://codex.top/api/patricia-tree/

## Changes


* fix difference calling its argument on equal values by @dlesbre in https://github.com/codex-semantics-library/patricia-tree/pull/38
* Add `for_all2`, `fold2`, `exists2` and `iter2` by @dlesbre in https://github.com/codex-semantics-library/patricia-tree/pull/36
* Fix reflexive_compare not being a true comparison function by @dlesbre in https://github.com/codex-semantics-library/patricia-tree/pull/40