### PR TITLE
[new package] fxmacrodata (0.1.0)

### DIFF
--- a/packages/fxmacrodata/fxmacrodata.0.1.0/opam
+++ b/packages/fxmacrodata/fxmacrodata.0.1.0/opam
@@ -1,0 +1,46 @@
+opam-version: "2.0"
+synopsis: "OCaml client for the FXMacroData forex and macroeconomic data API"
+description:
+  "Client library for the FXMacroData REST API: official-source forex and macroeconomic data covering central-bank announcements, macroeconomic indicator time series, economic release calendars, CFTC Commitment of Traders positioning, commodities, and FX spot-rate history for 18 catalogue currencies. Provides a small typed wrapper with Lwt-based requests, plus a generic get_json escape hatch for any endpoint of the public API."
+maintainer: ["FXMacroData <quantdevapp@gmail.com>"]
+authors: ["FXMacroData <quantdevapp@gmail.com>"]
+license: "MIT"
+tags: ["forex" "macroeconomics" "finance" "market data" "api-client"]
+homepage: "https://fxmacrodata.com"
+doc: "https://fxmacrodata.com/documentation/reference"
+bug-reports: "https://github.com/fxmacrodata/ocaml-fxmacrodata/issues"
+depends: [
+  "dune" {>= "3.7"}
+  "ocaml" {>= "4.14"}
+  "cohttp-lwt-unix" {>= "5.0"}
+  "cohttp" {>= "5.0"}
+  "cohttp-lwt" {>= "5.0"}
+  "lwt" {>= "5.6"}
+  "uri" {>= "4.0"}
+  "yojson" {>= "2.0"}
+  "alcotest" {>= "1.7" & with-test}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/fxmacrodata/ocaml-fxmacrodata.git"
+url {
+  src:
+    "https://github.com/fxmacrodata/ocaml-fxmacrodata/archive/refs/tags/v0.1.0.tar.gz"
+  checksum: [
+    "sha256=d9e7ddffc396a90ed7888853f501ae86241f794b311b9cce73f7e40897867232"
+    "sha512=239fbf711b71566fb4f75f0d99e072f3ecca5eeea80efecdefffd1722bd033109d401f10689cea4d73302da1585ad7cc9ef326c8b4d297c814640d2d9bbcd8d0"
+  ]
+}


### PR DESCRIPTION
New package: **fxmacrodata 0.1.0** — OCaml client for the [FXMacroData](https://fxmacrodata.com) API (official-source forex and macroeconomic data: central-bank announcements, indicator time series, release calendars, CFTC COT positioning, commodities, and FX spot history across 18 currencies).

- Source: https://github.com/fxmacrodata/ocaml-fxmacrodata (MIT)
- Lwt + cohttp based; OCaml >= 4.14
- Tests run offline via an injected stub HTTP function (`--with-test` needs no network)
- `opam lint` passes locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)