### PR TITLE
[new release] oxbow (0.1.1)

### DIFF
--- a/packages/oxbow/oxbow.0.1.1/opam
+++ b/packages/oxbow/oxbow.0.1.1/opam
@@ -50,6 +50,7 @@ build: [
     "@doc" {with-doc}
   ]
 ]
+available: os = "linux" | os-family = "bsd"
 dev-repo: "git+https://github.com/3L0C/oxbow.git"
 url {
   src: "https://github.com/3L0C/oxbow/archive/refs/tags/v0.1.1.tar.gz"

--- a/packages/oxbow/oxbow.0.1.1/opam
+++ b/packages/oxbow/oxbow.0.1.1/opam
@@ -1,0 +1,61 @@
+opam-version: "2.0"
+synopsis: "Dynamic window manager for the river Wayland compositor"
+description: """\
+oxbow is a window manager for River 0.4.6+, written in OCaml.
+It manages windows with built-in dynamic layouts.
+
+The package installs two executables:
+
+- oxbow: the window manager
+- oxctl: a CLI client for commands, queries, and event subscriptions
+
+Configuration is an init script of oxctl commands."""
+maintainer: "3L0C"
+authors: "3L0C"
+license: "GPL-3.0-or-later"
+homepage: "https://github.com/3L0C/oxbow"
+bug-reports: "https://github.com/3L0C/oxbow/issues"
+depends: [
+  "dune" {>= "3.22"}
+  "ocaml" {>= "5.4"}
+  "dune-build-info" {>= "3.22"}
+  "cmdliner" {>= "2.1"}
+  "cstruct" {>= "6.2" & with-test}
+  "eio" {>= "1.3"}
+  "eio_main" {>= "1.2"}
+  "eio_posix" {>= "1.3"}
+  "fmt" {>= "0.11"}
+  "landmarks" {>= "1.7"}
+  "landmarks-ppx" {>= "1.7"}
+  "logs" {>= "0.10"}
+  "ppx_yojson_conv" {>= "0.17"}
+  "ppx_yojson_conv_lib" {>= "0.17"}
+  "re" {>= "1.12"}
+  "wayland" {>= "2.3"}
+  "xkbcommon" {>= "0.1"}
+  "yojson" {>= "3.0"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/3L0C/oxbow.git"
+url {
+  src: "https://github.com/3L0C/oxbow/archive/refs/tags/v0.1.1.tar.gz"
+  checksum: [
+    "md5=a182e6d368a65e6752771e41e651713f"
+    "sha512=020d2c7f9f4e06966ca56695e24eb0b41dd12500aa65d2cd9b56e03068bbb6ea7770de0a33c04f0d054bd474bee8c2b36bb46af86266c9823490e1bd0810c027"
+  ]
+}
+x-maintenance-intent: ["(latest)"]


### PR DESCRIPTION
oxbow is a window manager for the Wayland compositor River (0.4.6+), written in OCaml.

- Project page: https://github.com/3L0C/oxbow
- Documentation: https://oxbow-wm.readthedocs.io

##### FIXED

- Ambiguous arguments for seemingly valid commands like `oxctl bind layout tiling mfact -0.05 to Super+Control+h` failed as `-0.05` was interpreted as an option.
- Missing commands in the `oxctl` man page.