### PR TITLE
[new release] wire (1.2.0)

### DIFF
--- a/packages/wire/wire.1.2.0/opam
+++ b/packages/wire/wire.1.2.0/opam
@@ -1,0 +1,47 @@
+opam-version: "2.0"
+synopsis: "Binary wire format DSL with EverParse 3D output"
+description:
+  "OCaml DSL for describing binary wire formats with EverParse 3D output. Define your wire format once, then use it for OCaml parsing via bytesrw or emit .3d files for verified C parser generation via EverParse."
+maintainer: ["Thomas Gazagnaire <thomas@gazagnaire.org>"]
+authors: ["Thomas Gazagnaire <thomas@gazagnaire.org>"]
+license: "ISC"
+homepage: "https://github.com/parsimoni-labs/ocaml-wire"
+bug-reports: "https://github.com/parsimoni-labs/ocaml-wire/issues"
+depends: [
+  "dune" {>= "3.21"}
+  "ocaml" {>= "5.3"}
+  "bytesrw" {>= "0.4.0"}
+  "fmt" {>= "0.9"}
+  "optint" {>= "0.3"}
+  "memtrace" {with-test}
+  "alcotest" {with-test}
+  "alcobar" {with-test}
+  "re" {>= "1.11"}
+  "mdx" {with-test}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/parsimoni-labs/ocaml-wire.git"
+x-maintenance-intent: ["(latest)"]
+url {
+  src:
+    "https://github.com/parsimoni-labs/ocaml-wire/releases/download/1.2.0/wire-1.2.0.tbz"
+  checksum: [
+    "sha256=510ae8a38087e02113c83766fc11d223e5de446a536cd8785d672393d3d3b575"
+    "sha512=6cf3feabb1bb0a7bd25219ebbd82a733960f484a3e5ef05b8901dbf3634e9040a92921b0ceb71ec999b52ce148276c57cb1797ea95ca903558df994861bfd357"
+  ]
+}
+x-commit-hash: "0fdcc5f10721f2680d5db2225e65618f6cdf5ac7"


### PR DESCRIPTION
Binary wire format DSL with EverParse 3D output

- Project page: <a href="https://github.com/parsimoni-labs/ocaml-wire">https://github.com/parsimoni-labs/ocaml-wire</a>

##### CHANGES:

### Added

- Support wasm_of_ocaml (31-bit int) and js_of_ocaml (32-bit int). Codecs no
  longer silently truncate values that exceed the target's native integer range
  (parsimoni-labs/ocaml-wire#232, @samoht)

- Add `Wire.Expr.lsr64`, an int64 logical shift right by a constant amount, for
  isolating the high bits of a full-width field inside a constraint. It projects
  to a 3D refinement EverParse verifies (parsimoni-labs/ocaml-wire#232, @samoht)

- Add `Wire.Codec.field_readers` and `Wire.Everparse.Raw.int_slots`.
  `field_readers` is the decoder's own reader for every named int-valued field,
  keyed by name, so a caller holding a type-erased codec can read a field
  without a field handle; `int_slots` is the byte slot of every named whole-byte
  integer field (parsimoni-labs/ocaml-wire#318, @samoht)

- Add `Wire.Everparse.Raw.field_seeds`, exposing constrained whole-byte integer
  values, and seed `Wire_3d.generate_corpus` from them and from accepted inputs,
  so a generated corpus reaches values uniform bytes never would. A one-sided
  corpus, which cannot tell a validator from a constant answer, is now refused
  (parsimoni-labs/ocaml-wire#314, @samoht)

- Add `Wire.equal_error_kind`, structural equality on error kinds ignoring
  location, and `Wire.Everparse.equal_field_action_form` (parsimoni-labs/ocaml-wire#299, parsimoni-labs/ocaml-wire#302, @samoht)

- Document how to make a whole field group conditional with `Field.optional`
  over a sub-codec, keeping the group's byte-length prefix and dependent
  `Field.repeat` local to the group while later fields stay in the parent codec
  (parsimoni-labs/ocaml-wire#236, @samoht)

### Changed

- **Breaking:** A fixed-width integer field decodes to a carrier whose range is
  the field's, so a value it cannot hold is refused where it is built instead of
  being masked into a legal-looking one on the way to the wire: `uint8` to
  `Wire.UInt8.t`, `int8` to `SInt8.t`, `uint16` and `uint16be` to `UInt16.t`,
  `int16` and `int16be` to `SInt16.t`, `uint32` and `uint32be` to `UInt32.t`
  (was `Optint.t`), `int32` and `int32be` to `SInt32.t`, `uint64` and `uint64be`
  to `UInt64.t` (was `int64`). The 8- and 16-bit carriers are a `private int`,
  read with `to_int` and built with the range-checked `v`; the wider ones are
  abstract, read with `to_int32` / `to_int64` and built with `of_int32` /
  `of_int64` or the range-checked `of_int`. `SInt32` and `UInt32` are
  deliberately not interchangeable: they share a representation, so a value read
  with the wrong signedness would be a silent misparse rather than a type error
  (parsimoni-labs/ocaml-wire#321, parsimoni-labs/ocaml-wire#322, parsimoni-labs/ocaml-wire#323, parsimoni-labs/ocaml-wire#330, parsimoni-labs/ocaml-wire#333, parsimoni-labs/ocaml-wire#335, parsimoni-labs/ocaml-wire#336, @samoht)

- **Breaking:** `Wire.uint` decodes to `Optint.Int63.t` rather than a native
  `int`, spelled as that type rather than the `Wire.Private` alias: a 7-byte
  value needs 56 bits, which used to truncate on a narrow-int target. Read it
  with `Optint.Int63.to_int` / `to_int64` (parsimoni-labs/ocaml-wire#232, parsimoni-labs/ocaml-wire#270, @samoht)

- Integer-valued combinators no longer insist on a native `int` base.
  `Wire.enum`, `enum_open`, `variants`, `lookup` and `bit` sit over `uint32`,
  `int32` or `uint64` as readily as over `uint8`, and project to EverParse the
  same way; `Wire.rest_bytes` takes a size parameter of any integer type, and
  `Wire.Field.int64` a field of any type carrying a 64-bit slot (parsimoni-labs/ocaml-wire#321, parsimoni-labs/ocaml-wire#323,
  parsimoni-labs/ocaml-wire#328, @samoht)

- **Breaking:** Require OCaml 5.3, up from 5.2 (parsimoni-labs/ocaml-wire#320, @samoht)

- **Breaking:** `Codec.encode` and `Wire.to_string` raise `Invalid_argument` on
  a value their own decoder rejects, rather than writing bytes that fail to read
  back: an unlisted value in a closed `enum`, a non-zero byte in an `all_zeros`
  padding field, a `byte_array_where` byte that fails its `~per_byte`
  refinement, and a record whose `where` clause or field `~constraint_` does not
  hold. Encoding a well-formed value is unchanged (parsimoni-labs/ocaml-wire#263, @samoht)

- **Breaking:** Encoding an integer a field cannot hold raises
  `Invalid_argument` instead of dropping the bits that do not fit, so `int8`
  refuses `200` rather than writing it back as `-56`, and `bits ~width` and
  `uint ~size` accept exactly their declared width. A masked value is itself
  legal at that width, so nothing downstream could tell it from a value meant
  that way. Applies to `Wire.to_string`, `Codec.encode` and `Codec.set` alike
  (parsimoni-labs/ocaml-wire#275, @samoht)

- **Breaking:** Encoding a `byte_array`, `byte_array_where` or `byte_slice`
  whose length differs from its declared `~size` raises `Invalid_argument`. It
  used to truncate a longer value, zero-pad a shorter one, or, through the
  streaming writer, desynchronise every following field, so the bytes on the
  wire could differ from the value a caller had signed, hashed or
  length-prefixed. For a short value in a fixed-size region use
  `zeroterm_at_most`, which is NUL-terminated and round-trips (parsimoni-labs/ocaml-wire#259, @samoht)

- Require `bytesrw` >= 0.4.0 (parsimoni-labs/ocaml-wire#297, @samoht)

- `Codec.load_word` reads the bitfield base word as an `Optint.t` (was a native
  `int`) and `Codec.extract` takes it, so the word-at-a-time batch API is exact
  for 32-bit bases on every platform; on a 64-bit host the word stays an unboxed
  int (parsimoni-labs/ocaml-wire#232, @samoht)

- Change the exception raised for a description no decoder or encoder can
  handle, such as a casetype value no case projects or an unresolved type
  reference, from `Failure` to the `Invalid_argument` documented in `wire.mli`.
  The buffer is untouched on those paths, so only the exception type changes
  (parsimoni-labs/ocaml-wire#291, @samoht)

- Change the `zeroterm` and `zeroterm_at_most` encode errors to report as
  `Wire.encode` on every path. `Codec.encode` reported the same two faults, a
  NUL in the value and a value too long for its region, under its own name
  (parsimoni-labs/ocaml-wire#269, @samoht)

- Change the generated `.3d` C struct tags to `Wire<Name>` rather than
  `_<Name>`. Public typedef names are unchanged, and standalone entrypoints
  follow as `<Base>CheckWire<Name>` (parsimoni-labs/ocaml-wire#235, @samoht)

### Fixed

- A codec that embeds a sub-codec now projects to a schema EverParse accepts
  whatever that sub-codec holds. The types a sub-codec's own fields name were
  declared after it rather than before, and a refined byte span reached only
  through a sub-codec was never declared at all, so EverParse rejected the
  schema with a "not found" naming a type the codec does use (parsimoni-labs/ocaml-wire#344, @samoht)

- Generating C for a codec with a long name no longer fails with
  `Invalid_argument "List.iter2"`. Past a certain length the generated callback
  declarations wrap onto a second line, which the field-plug generator read as
  no declarations at all; both layouts are read now, and a header that still
  cannot be read is named in the error rather than surfacing as a crash
  somewhere else (parsimoni-labs/ocaml-wire#344, @samoht)

- A value with no fixed wire size read through `Wire.of_reader` no longer costs
  time and memory quadratic in its length. The reader rebuilt the whole
  accumulated buffer and re-parsed it from offset zero after every slice, so a
  64 KiB `zeroterm` arriving one byte at a time took 1.7 s where it now takes a
  millisecond, at the top level and inside a codec alike (parsimoni-labs/ocaml-wire#325, parsimoni-labs/ocaml-wire#331, @samoht)

- `Codec.validate` allocates a constant amount whatever the sender sends, and
  nothing at all for a codec with no parameters. It used to run the field
  readers for their checks and drop what they built, so a refined span, a
  `zeroterm_at_most`, an `all_zeros`, a `repeat`'s elements and a closed
  `enum`'s named cases each cost memory in proportion to lengths and counts the
  sender chooses. Sub-codecs reached through an `array`, a `nested` region or a
  casetype case body are checked in place too, and `Codec.decode` no longer
  keeps a second copy of a span it returns (parsimoni-labs/ocaml-wire#286, parsimoni-labs/ocaml-wire#289, parsimoni-labs/ocaml-wire#290, parsimoni-labs/ocaml-wire#292, parsimoni-labs/ocaml-wire#293, parsimoni-labs/ocaml-wire#294,
  parsimoni-labs/ocaml-wire#295, parsimoni-labs/ocaml-wire#329, @samoht)

- A fixed-offset `Codec.get` or `Codec.set` with no parameters, and
  `Wire.of_string` / `Wire.of_bytes` on a struct type, no longer allocate per
  call: direct scalars represented as immediate OCaml values, bitfields, enums
  and immediate-valued maps measure zero words on a non-Flambda release build,
  and the validator cache lookup no longer builds a closure and an option. Boxed
  results such as `int64`, and allocations performed by a `map` callback itself,
  remain visible to callers. The same accessors are also faster than before
  (parsimoni-labs/ocaml-wire#239, parsimoni-labs/ocaml-wire#269, @samoht)

- A fresh domain's first decode or validate no longer costs about a word per
  compiled validator the program ever built, which reached roughly 1 MB at
  50,000 validators and was charged even to domains that never decode
  (parsimoni-labs/ocaml-wire#320, @samoht)

- `Codec.decode` and `Codec.validate` no longer accept bytes that
  `Wire.of_string` and the EverParse validator built from the same schema
  reject. A sub-codec field's constraints, `where`, closed-enum membership,
  `~per_byte` refinements and actions were skipped, a `byte_array_where`'s
  `~per_byte` ran on the direct parser alone, and a `Field.repeat` whose byte
  budget does not split into whole elements passed (parsimoni-labs/ocaml-wire#268, parsimoni-labs/ocaml-wire#305, parsimoni-labs/ocaml-wire#311, @samoht)

- `Codec.validate` no longer raises `Invalid_argument` where a parse error was
  due. It reaches a field at whatever offset the layout computes and those reads
  were unguarded, so an overlong variable-size field pushing its successors past
  the end of the buffer crashed the documented gate for untrusted input. Same
  for `Wire.of_bytes` and `Wire.of_string` on a struct, an `optional` gated on a
  runtime expression, and a `uint` of runtime width. All now report end of input
  at the field's own offset (parsimoni-labs/ocaml-wire#271, parsimoni-labs/ocaml-wire#276, @samoht)

- `Codec.get` and `Codec.set` no longer read or write past the field they name.
  A bitfield's base word is assembled from byte reads that went unchecked, so a
  truncated frame read at an application-chosen offset answered with the bytes
  that followed it and `set` overwrote them, leaving half a word behind when it
  raised; and a `byte_array`, `byte_array_where` or `byte_slice` whose `~size`
  is known only at decode time wrote the value's own length, running over the
  fields after it with no error. Both spans are now checked first (parsimoni-labs/ocaml-wire#262, parsimoni-labs/ocaml-wire#288,
  @samoht)

- `Codec.set` on a sub-codec, casetype or array field no longer leaves a refused
  value in the buffer. The writer laid the value down and only then checked it,
  against the documented promise to leave the buffer untouched; those writers
  now restore the bytes they replaced. `Codec.encode` is not transactional and
  now says so: after a failed encode the destination holds a partial record
  (parsimoni-labs/ocaml-wire#280, @samoht)

- `Codec.get` and `Codec.set` handle an `optional` or `optional_or` field whose
  gate is fixed at construction, a shape `Codec.decode` reads without trouble
  and `get` used to raise `Failure "build_field_reader: unsupported type"` on. A
  runtime gate stays unsupported and refuses with `Invalid_argument` naming the
  shape (parsimoni-labs/ocaml-wire#280, @samoht)

- `Codec.size_of_value` no longer answers for a write that cannot happen or
  under-reports a field's width: a casetype value no case projects raises
  `Invalid_argument` as encode does, and `Codec.set` refuses before writing,
  while a fixed-size `byte_array`, `byte_array_where` or `byte_slice` reports
  its declared width, so a buffer allocated from the answer exactly fits the
  bytes written (parsimoni-labs/ocaml-wire#238, parsimoni-labs/ocaml-wire#296, @samoht)

- `Unexpected_eof` reports byte counts, not buffer positions, and counts only
  bytes the parse was handed. The `expected` and `got` fields carried absolute
  positions at several sites, so the pair shifted with the offset the frame was
  read at and could come out equal to each other; and a value inside a `nested`
  region or a `repeat` budget was sized from whatever the buffer held past the
  region, so the reported shortfall named bytes the parse never claimed
  (parsimoni-labs/ocaml-wire#285, parsimoni-labs/ocaml-wire#326, parsimoni-labs/ocaml-wire#332, @samoht)

- A parse error names the field's own offset, so a caller locating the field
  from `at` no longer reads or rewrites the wrong bytes. A failing field
  `~constraint_`, an `enum` membership failure and a staged read through a
  bitfield reported the enclosing record's base, and a `lookup` tag out of range
  reported byte 0 whatever offset the frame was read at. A dynamic layout still
  reports the record base (parsimoni-labs/ocaml-wire#306, @samoht)

- A failure under a size or offset expression reports its own error. A
  validation error or an exception from a `map` callback came out as an end of
  input on a buffer that was long enough, and a byte span whose size expression
  went negative escaped as `Invalid_argument "String.sub"`; truncation is now
  raised by the reads themselves, naming the missing span (parsimoni-labs/ocaml-wire#267, @samoht)

- `Field.repeat`, `array`, `array_seq` and `nested` hold to their declared size
  on decode and encode. A repeat consumed or emitted more or less than its byte
  budget, the array encoders accepted a short value and left zero-filled phantom
  elements, and `nested` let its inner value consume less than the region. Use
  `nested_at_most` where trailing region padding is intentional; it remains
  permissive and zero-pads on encode (parsimoni-labs/ocaml-wire#238, @samoht)

- `Codec.v` rejects duplicate field names, and distinct parameter handles with
  the same name. Name-based field access and parameter environments silently
  aliased the first declaration (parsimoni-labs/ocaml-wire#238, @samoht)

- A constant size or length expression such as `Expr.(int 2 + int 2)` behaves
  exactly like the literal `int 4`. It used to slip past every check and fast
  path that looks for a literal size, so such a field encoded without its
  exact-length check, reported its codec as variable-size, and bypassed the
  `uint` 1-7 size guard (parsimoni-labs/ocaml-wire#259, @samoht)

- Operations on the same parametric codec are safe to re-enter and interleave
  across fibers with different `Param.env` values: embedded codecs, casetype
  bodies, fixed-size wrappers and repeated elements no longer read another
  operation's field sizes. An env built for a different codec is rejected first,
  on encode, decode, validation and staged getters alike, including where the
  parameter counts happen to match (parsimoni-labs/ocaml-wire#237, parsimoni-labs/ocaml-wire#239, @samoht)

- A field wider than the target's native `int` no longer decodes or encodes
  wrong under wasm_of_ocaml and js_of_ocaml. A bitfield touching bit 31 of its
  base word dropped that bit, a 4-byte signed field dropped the top bits on the
  way in and sent the frame back out as different bytes with the encode-side
  range check disabled, and a NaN passed a float64 `is_finite` check. The
  emitted 3D refinements are unchanged (parsimoni-labs/ocaml-wire#232, parsimoni-labs/ocaml-wire#321, @samoht)

- A value too wide for the native `int` reports a typed `Value_out_of_range`, or
  a contextual `Invalid_argument` naming the case index or parameter, where
  reading a `uint32`, `uint63` or `uint` field, projecting a casetype and
  `Param.bind` used to leak a bare Optint `Failure`. The validation slots mirror
  only values the int can hold, as `uint64` already did (parsimoni-labs/ocaml-wire#232, parsimoni-labs/ocaml-wire#237, @samoht)

- `uint32` and `uint64` values order as unsigned numbers on every target. Their
  carriers compared the top bit as a sign, so the largest value of each ranked
  below 1 (parsimoni-labs/ocaml-wire#322, parsimoni-labs/ocaml-wire#323, @samoht)

- A shape with no valid encoding or no EverParse projection is refused at
  construction with a clear error, rather than building and misbehaving later: a
  `Field.repeat` element whose greedy tail sits inside a sub-codec and so
  swallows every element after it, a zero-size byte span as an `array` or
  `Field.repeat` element, an `optional` field that can expose a consume-rest
  payload with another field after it, and a `field * constant` byte size whose
  `field <= bound` constraint lets the maximum reach EverParse's `2^32` limit.
  Products without that conclusive shape stay deferred to EverParse, avoiding
  speculative rejections (parsimoni-labs/ocaml-wire#237, parsimoni-labs/ocaml-wire#239, parsimoni-labs/ocaml-wire#256, parsimoni-labs/ocaml-wire#266, parsimoni-labs/ocaml-wire#280, @samoht)

- A `Field.repeat` element that turns out to consume no bytes reports an
  end-of-input error from `Wire.of_string` and `Wire.of_bytes` instead of
  looping forever (parsimoni-labs/ocaml-wire#256, @samoht)

- `Wire.Ascii` diagrams render every expression a size or constraint can
  contain. Bitmasks, shifts, division, casts, conditionals, `sizeof` and
  parameter references used to print as a bare `?`, so a trailing payload sized
  by `Wire.rest_bytes` showed up as `(? - ? bytes)` (parsimoni-labs/ocaml-wire#257, @samoht)

- Generated C no longer enforces the wrong specification when names collide. Two
  codecs whose artifacts differ only in the leading capital or in an uppercase
  run, and two codecs of a family that declare different types under the same
  name, are refused with a clear error instead of the second write winning and
  leaving the shadowed codec's stubs validating against another codec's spec;
  and two domains building descriptions at once can no longer mint the same
  synthesised `byte_array_where` element name, whose 3D typedef was then emitted
  twice. Types declared identically by several codecs still collapse to a single
  declaration (parsimoni-labs/ocaml-wire#255, parsimoni-labs/ocaml-wire#266, parsimoni-labs/ocaml-wire#272, @samoht)

- The generated FFI stubs no longer lose field values. The parse callback
  collected the boxed arguments in a bare `value` array, which is not a GC root,
  so a minor collection triggered by a later box could move or reclaim an
  earlier one and the continuation silently received garbage. `CAMLlocalN` now
  roots them (parsimoni-labs/ocaml-wire#272, @samoht)

- The emitted `EverParseEndianness.h` compiles on a target that is neither
  Linux/glibc nor Apple. The `__BYTE_ORDER__` branch was spliced only when the
  header was absent, which it never is, so the header a cross-compiled
  standalone archive gets stopped at `#error "Unsupported platform"`
  (parsimoni-labs/ocaml-wire#272, @samoht)

- EverParse generation no longer interprets output paths, executable paths and
  schema filenames that contain spaces or shell metacharacters as commands
  (parsimoni-labs/ocaml-wire#239, @samoht)

- A package's committed `.3d` specs, `dune.inc` and EverParse C can no longer go
  stale. `dune runtest` diffs the specs and rules against freshly generated ones
  and rechecks an installed `<Name>.provenance` stamp holding the stdlib
  BLAKE2b-256 digest of the `.3d` the C was built from, no EverParse needed. The
  committed schema is a plain source rather than a promoted build target, so
  drift fails `runtest` with a promotable report and `dune promote` writes the
  new bytes after an intended codec change (parsimoni-labs/ocaml-wire#235, parsimoni-labs/ocaml-wire#317, @samoht)

### Removed

- **Breaking:** Remove `uint63` and `uint63be`. An 8-byte field spans more
  values than their `Optint.Int63.t` carrier holds, and decoding masked the
  difference away instead of failing, on both the OCaml and the generated C
  path. Use `uint64` / `uint64be` instead, whose carrier is exactly the eight
  bytes on the wire, and convert an existing value with `Optint.Int63.to_int64`.
  `Wire.uint ~size` is unaffected: its carrier is exact for the one to seven
  bytes it accepts (parsimoni-labs/ocaml-wire#316, @samoht)

- Delete the dependency on `eio`. Nothing in the library used it, it was only
  ever linked, unused, into `wire.diff` (parsimoni-labs/ocaml-wire#233, @samoht)
