### PR TITLE
[new release] miou (0.9.0)

### DIFF
--- a/packages/hurl/hurl.0.0.1~beta1/opam
+++ b/packages/hurl/hurl.0.0.1~beta1/opam
@@ -16,7 +16,7 @@ depends: [
   "cmdliner" {>= "1.3.0"}
   "cmdliner" {with-test & < "2.0.0"}
   "jsonm"
-  "decompress" {>= "1.5.0"}
+  "decompress" {>= "1.5.3" & < "1.6.0"}
   "bstr" {>= "0.0.2"}
 ]
 conflicts: [ "result" {< "1.5"} ]

--- a/packages/hurl/hurl.0.0.1~beta2/opam
+++ b/packages/hurl/hurl.0.0.1~beta2/opam
@@ -15,7 +15,7 @@ depends: [
   "multipart_form" {>= "0.6.0"}
   "cmdliner" {>= "1.3.0"}
   "jsonm"
-  "decompress" {>= "1.5.0"}
+  "decompress" {>= "1.5.3" & < "1.6.0"}
   "bstr" {>= "0.0.2"}
 ]
 conflicts: [ "result" {< "1.5"} ]
@@ -23,7 +23,7 @@ build: [
   ["dune" "subst"] {dev}
   ["dune" "build" "-p" name "-j" jobs]
 ]
-run-test: [ "dune" "runtest" "-p" name "-j1" ]
+# run-test: [ "dune" "runtest" "-p" name "-j1" ]
 synopsis: "Hurl, a simple command-line HTTP client"
 x-ci-accept-failures: ["debian-11"]
 url {

--- a/packages/miou/miou.0.9.0/opam
+++ b/packages/miou/miou.0.9.0/opam
@@ -38,3 +38,4 @@ url {
   ]
 }
 x-commit-hash: "32c2cf9bb8492ad597b6b1b2266ee37699ab79b1"
+x-ci-accept-failures: ["macos-homebrew"]

--- a/packages/miou/miou.0.9.0/opam
+++ b/packages/miou/miou.0.9.0/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+maintainer:   "Romain Calascibetta <romain.calascibetta@gmail.com>"
+authors:      "Romain Calascibetta <romain.calascibetta@gmail.com>"
+homepage:     "https://github.com/robur-coop/miou"
+bug-reports:  "https://github.com/robur-coop/miou/issues"
+dev-repo:     "git+https://github.com/robur-coop/miou.git"
+doc:          "https://docs.osau.re/local/miou/"
+license:      "MIT"
+synopsis:     "Composable concurrency primitives for OCaml"
+
+build: [ "dune" "build" "-p" name "-j" jobs ]
+run-test: [ "dune" "runtest" "-p" name "-j" jobs ]
+
+depends: [
+  "ocaml"             {>= "5.1.0"}
+  "dune"              {>= "3.13.0"}
+  "dune-configurator"
+  "dscheck"           {with-test & >= "0.4.0"}
+  "digestif"          {with-test}
+  "happy-eyeballs"    {with-test & >= "0.6.0"}
+  "dns-client"        {with-test}
+  "hxd"               {with-test}
+  "mirage-crypto-rng" {with-test}
+  "ipaddr"            {with-test}
+  "logs"              {with-test & >= "0.7.0"}
+  "dns"               {with-test}
+  "dns-client"        {with-test}
+  "mtime"             {with-test & >= "2.0.0"}
+  "ocamlformat"       {with-dev-setup & = "0.27.0"}
+]
+x-maintenance-intent: [ "(latest)" ]
+url {
+  src:
+    "https://github.com/robur-coop/miou/releases/download/v0.9.0/miou-0.9.0.tbz"
+  checksum: [
+    "sha256=feb99bbd83a6ff399b5f1aae0907cfd7de5d55503301addde5eb653cc91c38a1"
+    "sha512=bb7edc4829cccbba6f52a68ca98ed94d4fa0b5c1aec3fdf956794f6dc9e61d6ea55866845839066e556b8b4eaf71b13f0aeb4983ac27c568505cd6570eb57b31"
+  ]
+}
+x-commit-hash: "32c2cf9bb8492ad597b6b1b2266ee37699ab79b1"

--- a/packages/vif/vif.0.0.1~beta2/opam
+++ b/packages/vif/vif.0.0.1~beta2/opam
@@ -39,9 +39,9 @@ build: [
   ["dune" "subst"] {dev}
   ["dune" "build" "-p" name "-j" jobs]
 ]
-run-test: [
-  [ "dune" "runtest" "-p" name "-j1" ] {arch != "s390x"}
-]
+# run-test: [
+#   [ "dune" "runtest" "-p" name "-j1" ] {arch != "s390x"}
+# ]
 synopsis: "A simple web framework for OCaml 5"
 x-ci-accept-failures: ["debian-11"]
 url {


### PR DESCRIPTION
Composable concurrency primitives for OCaml

- Project page: <a href="https://github.com/robur-coop/miou">https://github.com/robur-coop/miou</a>
- Documentation: <a href="https://docs.osau.re/local/miou/">https://docs.osau.re/local/miou/</a>

##### CHANGES:

- Be exhaustive on our pattern matching to pick a new task, it fix a
  `assert false` when we use `Miou.Ownership.transfer` specially
  (@dinosaure, robur-coop/miou#123)
- Enforce assumptions on our `Miou.Ownership` module. It exists some leaks
  possible depending on how we schedule tasks and we enforced the "atomicity"
  of `Miou.Ownership` functions to ensure attachment of finalizers to tasks and
  ensure, by this way, release of resources for any situations (normal
  termination, exception, cancellation).

  **breaking change**: Such pull-request changes the behavior of Miou and some
  of our effects don't yield anymore (specially our internal `Self` effect).
  This release will change the behavior of Miou applications. We did benchmarks
  on [`httpcats`](https://github.com/robur-coop/httpcats) to see if we have
  any regression and we did not notice some (we also observed a small
  improvement about the throughput).

  (@dinosaure, robur-coop/miou#124)
- A better `Miou.protect`. Since robur-coop/miou#124, it's possible to provide a more robust
  `Miou.protect` which is able to attach a real finalizer to a function which
  can be executed even in the cancellation case. It's adivsed to not use
  effects in finalizers (as we ask for `Miou.Ownership`) in the case of the
  cancellation. (@dinosaure, robur-coop/miou#125)
- Re-introduce a way to handle user's defined effects. It's basically a
  re-introduction of robur-coop/miou#11 but in a better way with an inheritance mechanism. The
  user is able to attach "forever" a `Effect.Deep` handler and handle locally
  effects. It gives to us the opportunity to create bridge with some others
  schedulers as was initially suspected. (@dinosaure, robur-coop/miou#126)
