### PR TITLE
[new release] mnet (7 packages) (0.0.5)

### DIFF
--- a/packages/mnet-cli/mnet-cli.0.0.5/opam
+++ b/packages/mnet-cli/mnet-cli.0.0.5/opam
@@ -1,0 +1,34 @@
+opam-version: "2.0"
+maintainer: "Robur <team@robur.coop>"
+authors: ["Robur <team@robur.coop>"]
+homepage: "https://github.com/robur-coop/mnet"
+dev-repo: "git+https://github.com/robur-coop/mnet.git"
+bug-reports: "https://github.com/robur-coop/mnet/issues"
+license: "MIT"
+
+depends: [
+  "ocaml" {>= "5.0.0"}
+  "utcp"
+  "dune" {>= "2.7.0"}
+  "mnet" {= version}
+  "re"
+  "logs"
+  "fmt"
+  "cmdliner" {>= "2.0.0"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+synopsis: "A library for defining the options required by a unikernel to configure its TCP/IP stack"
+url {
+  src:
+    "https://github.com/robur-coop/mnet/releases/download/v0.0.5/mnet-0.0.5.tbz"
+  checksum: [
+    "sha256=ebc621ad01b33a7f96fd049e71bbd06ef95c1a6b36d4072fd15fd35c1a93dc17"
+    "sha512=8d47f9434bc6472703f55f819bea21a7deb12095d925f0f8fbb8b96b799473b62a8b302966f579792354aa256b9109dcc16851f5cf951002d35a7d70bca59135"
+  ]
+}
+x-commit-hash: "5a29372f5fabb5210317c8eafaf03243c6ee3bde"

--- a/packages/mnet-dhcp/mnet-dhcp.0.0.5/opam
+++ b/packages/mnet-dhcp/mnet-dhcp.0.0.5/opam
@@ -1,0 +1,48 @@
+opam-version: "2.0"
+maintainer: "Robur <team@robur.coop>"
+authors: ["Robur <team@robur.coop>"]
+homepage: "https://github.com/robur-coop/mnet"
+dev-repo: "git+https://github.com/robur-coop/mnet.git"
+bug-reports: "https://github.com/robur-coop/mnet/issues"
+license: "MIT"
+
+depends: [
+  "ocaml" {>= "5.0.0"}
+  "dune" {>= "2.7.0"}
+  "mnet" {= version}
+  "mkernel"
+  "miou"
+  "utcp"
+  "charrua" {>= "3.2.0"}
+  "charrua-client" {>= "3.2.0"}
+  "cstruct" {>= "6.0.0"}
+  "mirage-crypto-rng"
+  "slice"
+  "bstr" {>= "0.0.4"}
+  "ipaddr"
+  "macaddr"
+  "fmt"
+  "logs"
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+synopsis: "A DHCP client integration for the mnet TCP/IP stack"
+description: """
+mnet-dhcp provides a DHCP-enabled TCP/IP stack on top of mnet, using the charrua
+DHCP implementation. The core mnet library stays free of any DHCP dependency:
+the stack can be configured (and reconfigured) at runtime from DHCP leases, and
+the user is notified of and may confirm or reject configuration changes.
+"""
+url {
+  src:
+    "https://github.com/robur-coop/mnet/releases/download/v0.0.5/mnet-0.0.5.tbz"
+  checksum: [
+    "sha256=ebc621ad01b33a7f96fd049e71bbd06ef95c1a6b36d4072fd15fd35c1a93dc17"
+    "sha512=8d47f9434bc6472703f55f819bea21a7deb12095d925f0f8fbb8b96b799473b62a8b302966f579792354aa256b9109dcc16851f5cf951002d35a7d70bca59135"
+  ]
+}
+x-commit-hash: "5a29372f5fabb5210317c8eafaf03243c6ee3bde"

--- a/packages/mnet-dns/mnet-dns.0.0.5/opam
+++ b/packages/mnet-dns/mnet-dns.0.0.5/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+maintainer: "Robur <team@robur.coop>"
+authors: ["Robur <team@robur.coop>"]
+homepage: "https://github.com/robur-coop/mnet"
+dev-repo: "git+https://github.com/robur-coop/mnet.git"
+bug-reports: "https://github.com/robur-coop/mnet/issues"
+license: "MIT"
+
+depends: [
+  "ocaml" {>= "5.0.0"}
+  "utcp"
+  "dune" {>= "2.7.0"}
+  "mnet" {= version}
+  "mnet-tls" {= version}
+  "mnet-happy-eyeballs" {= version}
+  "dns"
+  "dns-client"
+  "tls"
+  "ca-certs-nss"
+  "cmdliner"
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+synopsis: "An implementation of DNS in OCaml for Miou & Solo5"
+url {
+  src:
+    "https://github.com/robur-coop/mnet/releases/download/v0.0.5/mnet-0.0.5.tbz"
+  checksum: [
+    "sha256=ebc621ad01b33a7f96fd049e71bbd06ef95c1a6b36d4072fd15fd35c1a93dc17"
+    "sha512=8d47f9434bc6472703f55f819bea21a7deb12095d925f0f8fbb8b96b799473b62a8b302966f579792354aa256b9109dcc16851f5cf951002d35a7d70bca59135"
+  ]
+}
+x-commit-hash: "5a29372f5fabb5210317c8eafaf03243c6ee3bde"

--- a/packages/mnet-dns/mnet-dns.0.0.5/opam
+++ b/packages/mnet-dns/mnet-dns.0.0.5/opam
@@ -13,6 +13,7 @@ depends: [
   "mnet" {= version}
   "mnet-tls" {= version}
   "mnet-happy-eyeballs" {= version}
+  "ca-certs-nss" {>= "3.126"}
   "dns"
   "dns-client"
   "tls"

--- a/packages/mnet-happy-eyeballs/mnet-happy-eyeballs.0.0.5/opam
+++ b/packages/mnet-happy-eyeballs/mnet-happy-eyeballs.0.0.5/opam
@@ -1,0 +1,32 @@
+opam-version: "2.0"
+maintainer: "Robur <team@robur.coop>"
+authors: ["Robur <team@robur.coop>"]
+homepage: "https://github.com/robur-coop/mnet"
+dev-repo: "git+https://github.com/robur-coop/mnet.git"
+bug-reports: "https://github.com/robur-coop/mnet/issues"
+license: "MIT"
+
+depends: [
+  "ocaml" {>= "5.0.0"}
+  "dune" {>= "2.7.0"}
+  "mnet" {= version}
+  "happy-eyeballs" {>= "2.0.0"}
+  "cmdliner"
+  "duration"
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+synopsis: "Connecting to a remote host via IP version 4 or 6 using mnet"
+url {
+  src:
+    "https://github.com/robur-coop/mnet/releases/download/v0.0.5/mnet-0.0.5.tbz"
+  checksum: [
+    "sha256=ebc621ad01b33a7f96fd049e71bbd06ef95c1a6b36d4072fd15fd35c1a93dc17"
+    "sha512=8d47f9434bc6472703f55f819bea21a7deb12095d925f0f8fbb8b96b799473b62a8b302966f579792354aa256b9109dcc16851f5cf951002d35a7d70bca59135"
+  ]
+}
+x-commit-hash: "5a29372f5fabb5210317c8eafaf03243c6ee3bde"

--- a/packages/mnet-ssh/mnet-ssh.0.0.5/opam
+++ b/packages/mnet-ssh/mnet-ssh.0.0.5/opam
@@ -11,6 +11,7 @@ depends: [
   "dune" {>= "2.7.0"}
   "mnet" {= version}
   "awa" {>= "0.6.1"}
+  "miou" {>= "0.8.0"}
   "flux"
 ]
 build: [

--- a/packages/mnet-ssh/mnet-ssh.0.0.5/opam
+++ b/packages/mnet-ssh/mnet-ssh.0.0.5/opam
@@ -1,0 +1,31 @@
+opam-version: "2.0"
+maintainer: "Robur <team@robur.coop>"
+authors: ["Robur <team@robur.coop>"]
+homepage: "https://github.com/robur-coop/mnet"
+dev-repo: "git+https://github.com/robur-coop/mnet.git"
+bug-reports: "https://github.com/robur-coop/mnet/issues"
+license: "MIT"
+
+depends: [
+  "ocaml" {>= "5.0.0"}
+  "dune" {>= "2.7.0"}
+  "mnet" {= version}
+  "awa" {>= "0.6.1"}
+  "flux"
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+synopsis: "An implementation of SSH in OCaml for Miou & Solo5"
+url {
+  src:
+    "https://github.com/robur-coop/mnet/releases/download/v0.0.5/mnet-0.0.5.tbz"
+  checksum: [
+    "sha256=ebc621ad01b33a7f96fd049e71bbd06ef95c1a6b36d4072fd15fd35c1a93dc17"
+    "sha512=8d47f9434bc6472703f55f819bea21a7deb12095d925f0f8fbb8b96b799473b62a8b302966f579792354aa256b9109dcc16851f5cf951002d35a7d70bca59135"
+  ]
+}
+x-commit-hash: "5a29372f5fabb5210317c8eafaf03243c6ee3bde"

--- a/packages/mnet-tls/mnet-tls.0.0.5/opam
+++ b/packages/mnet-tls/mnet-tls.0.0.5/opam
@@ -1,0 +1,30 @@
+opam-version: "2.0"
+maintainer: "Robur <team@robur.coop>"
+authors: ["Robur <team@robur.coop>"]
+homepage: "https://github.com/robur-coop/mnet"
+dev-repo: "git+https://github.com/robur-coop/mnet.git"
+bug-reports: "https://github.com/robur-coop/mnet/issues"
+license: "MIT"
+
+depends: [
+  "ocaml" {>= "5.0.0"}
+  "dune" {>= "2.7.0"}
+  "mnet" {= version}
+  "tls" {>= "2.1.1"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+synopsis: "An implementation of TLS in OCaml for Miou & Solo5"
+url {
+  src:
+    "https://github.com/robur-coop/mnet/releases/download/v0.0.5/mnet-0.0.5.tbz"
+  checksum: [
+    "sha256=ebc621ad01b33a7f96fd049e71bbd06ef95c1a6b36d4072fd15fd35c1a93dc17"
+    "sha512=8d47f9434bc6472703f55f819bea21a7deb12095d925f0f8fbb8b96b799473b62a8b302966f579792354aa256b9109dcc16851f5cf951002d35a7d70bca59135"
+  ]
+}
+x-commit-hash: "5a29372f5fabb5210317c8eafaf03243c6ee3bde"

--- a/packages/mnet/mnet.0.0.5/opam
+++ b/packages/mnet/mnet.0.0.5/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+maintainer: "Robur <team@robur.coop>"
+authors: ["Robur <team@robur.coop>"]
+homepage: "https://github.com/robur-coop/mnet"
+dev-repo: "git+https://github.com/robur-coop/mnet.git"
+bug-reports: "https://github.com/robur-coop/mnet/issues"
+license: "MIT"
+
+depends: [
+  "ocaml" {>= "5.0.0"}
+  "utcp" {>= "0.0.7"}
+  "dune" {>= "2.7.0"}
+  "bstr" {>= "0.0.4"}
+  "bin"
+  "slice"
+  "mkernel" {>= "0.0.4"}
+  "mirage-crypto-rng"
+  "duration"
+  "fmt"
+  "ipaddr"
+  "macaddr"
+  "hxd"
+  "logs"
+  "lru"
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+synopsis: "An implementation of TCP (Transmission Control Protocol) in OCaml for Miou & Solo5"
+url {
+  src:
+    "https://github.com/robur-coop/mnet/releases/download/v0.0.5/mnet-0.0.5.tbz"
+  checksum: [
+    "sha256=ebc621ad01b33a7f96fd049e71bbd06ef95c1a6b36d4072fd15fd35c1a93dc17"
+    "sha512=8d47f9434bc6472703f55f819bea21a7deb12095d925f0f8fbb8b96b799473b62a8b302966f579792354aa256b9109dcc16851f5cf951002d35a7d70bca59135"
+  ]
+}
+x-commit-hash: "5a29372f5fabb5210317c8eafaf03243c6ee3bde"

--- a/packages/msendmail/msendmail.0.13.0/opam
+++ b/packages/msendmail/msendmail.0.13.0/opam
@@ -22,7 +22,7 @@ depends: [
   "mnet"
   "mnet-tls"
   "flux" {>= "0.0.1~beta4"}
-  "mnet-happy-eyeballs"
+  "mnet-happy-eyeballs" {< "0.0.5"}
   "ca-certs-nss" {>= "3.108-1"}
 ]
 x-maintenance-intent: [ "(latest)" ]


### PR DESCRIPTION
An implementation of TCP (Transmission Control Protocol) in OCaml for Miou & Solo5

- Project page: <a href="https://github.com/robur-coop/mnet">https://github.com/robur-coop/mnet</a>

##### CHANGES:

- We can close multiple times a TCP connection (@dinosaure, @hannesm,
  [!47][47])
- Use warning names instead of numbers (@hannesm, [!46][46])
- Remove doublon about Ethernet.mac{,addr} (spotted by @hannesm, @dinosaure,
  [!48][48])
- Fix how we select our router on IPv6 (@reynir, [!51][51])
- Upgrade `mnet` with `mkernel.0.0.4` (@hannesm, [!53][53])
- Use `Mkernel.finally` to finalize our daemon (@dinosaure, @reynir, [!54][54])
- Sync OPAM files with dune dependencies (@hannesm, [!55][55])
- Move command-line helpers to their own packages (@hannesm, @dinosaure,
  [!56][56])
- Introduce the new module `Mnet_dhcp.Or_static` which mix DHCP and our TCP/IP
  stack (@reynir, @hannesm, [!52][52])
- Be able to specify its own IPv6 gateway (instead of get them from RA)
  (@reynir, @hannesm, [!50][50])
- Improve the API of `Mnet.TCP` and provide a buffered flow and a direct flow

  **breaking change**
  `TCP.get` is renamed to `TCP.read` and
  `TCP.{really_,}read` to `TCP.{really_,}input`.

  (@dinosaure, @hannesm, [!58][58])
- Improve a bit our `mnet-dns` implementation and our interface (@dinosaure,
  [!59][59])

[46]: https://git.robur.coop/robur/mnet/pulls/46
[47]: https://git.robur.coop/robur/mnet/pulls/47
[48]: https://git.robur.coop/robur/mnet/pulls/48
[50]: https://git.robur.coop/robur/mnet/pulls/50
[51]: https://git.robur.coop/robur/mnet/pulls/51
[52]: https://git.robur.coop/robur/mnet/pulls/52
[53]: https://git.robur.coop/robur/mnet/pulls/53
[54]: https://git.robur.coop/robur/mnet/pulls/54
[55]: https://git.robur.coop/robur/mnet/pulls/55
[56]: https://git.robur.coop/robur/mnet/pulls/56
[58]: https://git.robur.coop/robur/mnet/pulls/58
[59]: https://git.robur.coop/robur/mnet/pulls/59
