### PR TITLE
lambda-runtime: Constraint dependency on logs

### DIFF
--- a/packages/lambda-runtime/lambda-runtime.0.1.0/opam
+++ b/packages/lambda-runtime/lambda-runtime.0.1.0/opam
@@ -16,7 +16,7 @@ depends: [
   "ppx_deriving_yojson"
   "piaf" {< "0.2.0"}
   "uri"
-  "logs"
+  "logs" { != "0.8.0" }
   "lwt"
   "alcotest" {with-test}
 ]


### PR DESCRIPTION
logs.0.8.0 were giving error for OCaml 4.11. Version 0.7.0 is fine. With OCaml 4.14 newer logs are installed and everything is OK

> File "lib/client.ml", line 279, characters 16-70:
 279 |   Logs_lwt.info (fun m -> m "Polling for next event. Path: %s\n" path)
                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error: This expression should not be a function, the expected type is
        ('a, unit Lwt.t) Logs.msgf