### PR TITLE
conf-autoconf: install also automake on macos

### DIFF
--- a/packages/conf-autoconf/conf-autoconf.1/opam
+++ b/packages/conf-autoconf/conf-autoconf.1/opam
@@ -14,9 +14,9 @@ depexts: [
   ["autoconf"] {os-family = "fedora"}
   ["autoconf"] {os-distribution = "arch"}
   ["dev-build/autoconf"] {os-distribution = "gentoo"}
-  ["autoconf" "automake"] {os-distribution = "nixos"}
+  ["autoconf"] {os-distribution = "nixos"}
   # https://stackoverflow.com/questions/76852766/error-cant-exec-aclocal-with-homebrew-installed-autoreconf-on-mac
-  ["autoconf"] {os = "macos" & os-distribution = "homebrew"}
+  ["autoconf" "automake"] {os = "macos" & os-distribution = "homebrew"}
   ["autoconf"] {os = "macos" & os-distribution = "macports"}
   ["devel/autoconf"] {os = "openbsd"}
   ["autoconf"] {os = "freebsd"}

--- a/packages/conf-autoconf/conf-autoconf.1/opam
+++ b/packages/conf-autoconf/conf-autoconf.1/opam
@@ -1,0 +1,36 @@
+opam-version: "2.0"
+maintainer: "unixjunkie@sdf.org"
+homepage: "http://www.gnu.org/software/autoconf"
+authors: "https://www.gnu.org/software/autoconf/autoconf.html#maintainer"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
+license: "GPL-3.0-only"
+build: [
+  ["sh" "-exc" "autoconf -V"] {os = "win32" & os-distribution != "cygwinports"}
+  ["autoconf" "-V"] {os != "win32" | os-distribution = "cygwinports"}
+]
+depexts: [
+  ["autoconf"] {os-family = "debian" | os-family = "ubuntu"}
+  ["autoconf"] {os-distribution = "centos"}
+  ["autoconf"] {os-family = "fedora"}
+  ["autoconf"] {os-distribution = "arch"}
+  ["dev-build/autoconf"] {os-distribution = "gentoo"}
+  ["autoconf" "automake"] {os-distribution = "nixos"}
+  # https://stackoverflow.com/questions/76852766/error-cant-exec-aclocal-with-homebrew-installed-autoreconf-on-mac
+  ["autoconf"] {os = "macos" & os-distribution = "homebrew"}
+  ["autoconf"] {os = "macos" & os-distribution = "macports"}
+  ["devel/autoconf"] {os = "openbsd"}
+  ["autoconf"] {os = "freebsd"}
+  ["autoconf"] {os = "netbsd"}
+  ["autoconf"] {os-distribution = "alpine"}
+  ["autoconf"] {os-distribution = "ol"}
+  ["autoconf"] {os-distribution = "rhel"}
+  ["system:autoconf"] {os = "win32" & os-distribution = "cygwinports"}
+  ["autoconf"] {os-distribution = "cygwin"}
+  ["autoconf"] {os-family = "suse" | os-family = "opensuse"}
+  ["autoconf"] {os-family = "altlinux"}
+]
+synopsis: "Virtual package relying on autoconf installation"
+description: """
+This package can only install if the autoconf command
+is available on the system."""
+flags: conf


### PR DESCRIPTION
The lack of it can lead to weird error when running autogen or autoreconf. Seen on https://github.com/ocaml/opam-repository/pull/30551