### PR TITLE
Yojson-bench needs OCaml 4.14

### DIFF
--- a/packages/yojson-bench/yojson-bench.2.0.2/opam
+++ b/packages/yojson-bench/yojson-bench.2.0.2/opam
@@ -32,3 +32,11 @@ url {
   ]
 }
 x-commit-hash: "17ca03c5877a4346f0691443f35ed9678f99962f"
+x-maintanence-intent: ["(none)"]
+
+x-ci-accept-failures: [
+	"debian-13"
+	"debian-testing"
+	"debian-unstable"
+]
+

--- a/packages/yojson-bench/yojson-bench.2.0.2/opam
+++ b/packages/yojson-bench/yojson-bench.2.0.2/opam
@@ -32,7 +32,7 @@ url {
   ]
 }
 x-commit-hash: "17ca03c5877a4346f0691443f35ed9678f99962f"
-x-maintanence-intent: ["(none)"]
+x-maintenance-intent: ["(none)"]
 
 x-ci-accept-failures: [
 	"debian-13"


### PR DESCRIPTION
In check.ci.ocaml.org we are getting a compilation error related to its dependency

> /usr/bin/ld: /home/opam/.opam/4.11/lib/core_unix/linux_ext/linux_ext.a(linux_ext.o): in function `camlLinux_ext__sched_setaffinity_this_thread_88225':
> /home/opam/.opam/4.11/.opam-switch/build/core_unix.v0.15.2/_build/default/linux_ext/src/linux_ext.ml:830:(.text+0x5270): undefined reference to `core_unix_gettid'
> /usr/bin/ld: /home/opam/.opam/4.11/lib/core_unix/linux_ext/linux_ext.a(linux_ext.o): in function `camlLinux_ext__1':
> :(.data+0x4300): undefined reference to `core_unix_gettid'

Highly likely it is related to a shortcoming in core_bench.v0.15.x. In OCaml 4.14 CI install core_bench v.0.16.x and everything is OK.

Upstream (nonreleased, it seems) version has constraint OCaml >= 4.14, and not core_bench dependency.

I decided to add constraint >= 4.14 to yojson-bench itself. New release will not suprise users, because it will not support smaller set of compilers, than current one. Digging into core_bench seems too complicated.