### PR TITLE
guile doesn't fit GCC 14. x-ci-accept-failures added

### DIFF
--- a/packages/conf-guile/conf-guile.1/opam
+++ b/packages/conf-guile/conf-guile.1/opam
@@ -16,7 +16,7 @@ depexts: [
   ["guile-3.0-dev"] {os-family = "debian" | os-family = "ubuntu"}
   ["guile3"] {os = "freebsd"}
   ["lang/guile3"] {os = "openbsd"}
-  ["guile30-devel"] {os-distribution = "centos"} # Needs EPEL
+  ["guile30-devel" "epel-release"] {os-distribution = "centos"}
   ["guile30-devel"] {os-distribution = "rhel"}
   ["guile30-devel"] {os-family = "fedora"}
   ["guile-devel"] {os-distribution = "ol"}

--- a/packages/conf-guile/conf-guile.1/opam
+++ b/packages/conf-guile/conf-guile.1/opam
@@ -16,7 +16,7 @@ depexts: [
   ["guile-3.0-dev"] {os-family = "debian" | os-family = "ubuntu"}
   ["guile3"] {os = "freebsd"}
   ["lang/guile3"] {os = "openbsd"}
-  ["guile30-devel"] {os-distribution = "centos"}
+  ["guile30-devel"] {os-distribution = "centos"} # Needs EPEL
   ["guile30-devel"] {os-distribution = "rhel"}
   ["guile30-devel"] {os-family = "fedora"}
   ["guile-devel"] {os-distribution = "ol"}
@@ -31,3 +31,9 @@ synopsis: "Virtual package relying on an GNU Guile system installation"
 description:
   "This package can only install if GNU Guile is installed on the system."
 flags: conf
+
+x-ci-accept-failures: [
+	"centos-9"
+	"centos-10"
+]
+

--- a/packages/guile/guile.1.0/opam
+++ b/packages/guile/guile.1.0/opam
@@ -59,6 +59,7 @@ x-ci-accept-failures: [
 	"ubuntu-25.04"
 	"ubuntu-25.10"
 	"ubuntu-26.04"
+	"centos-10"
 	"freebsd-15.1"
 	"opensuse-16.0"
 	"opensuse-tumbleweed"

--- a/packages/guile/guile.1.0/opam
+++ b/packages/guile/guile.1.0/opam
@@ -44,3 +44,24 @@ url {
     "sha512=74136c9f933aea8d0403d5f5826cf7acb8824c985639d5a79eb2a7247c1bd1362eb61fd946f148e25e7b0283af2e36435c3d3ffe5f7e7913e27b70d941e97c09"
   ]
 }
+
+
+# Most things below because of too new GCC
+x-ci-accept-failures: [
+	"debian-13"
+	"debian-testing"
+	"debian-unstable"
+	"alpine-3.23"
+	"archlinux"
+	"fedora-42"
+	"fedora-43"
+	"fedora-44"
+	"ubuntu-25.04"
+	"ubuntu-25.10"
+	"ubuntu-26.04"
+	"freebsd-15.1"
+	"opensuse-16.0"
+	"opensuse-tumbleweed"
+	"macos-homebrew"
+]
+


### PR DESCRIPTION
Error is:

> bindings_stubs_gen.c:50:19: error: initialization of ‘intptr_t’ {aka ‘long int’} from ‘struct scm_unused_struct *’ makes integer from pointer without a cast [-Wint-conversion]
    50 |      intptr_t v = (SCM_BOOL_T);