### PR TITLE
Package hpke.0.1.1

### DIFF
--- a/packages/hpke/hpke.0.1.1/opam
+++ b/packages/hpke/hpke.0.1.1/opam
@@ -1,0 +1,43 @@
+opam-version: "2.0"
+synopsis: "Idiomatic RFC 9180 Hybrid Public Key Encryption for OCaml"
+description: """
+An idiomatic, misuse-resistant implementation of RFC 9180 HPKE Base and PSK
+modes. Cryptographic primitives are delegated to Mirage Crypto and Digestif.
+"""
+maintainer: ["Ville Vesilehto <ville@vesilehto.fi>"]
+authors: ["Ville Vesilehto <ville@vesilehto.fi>"]
+license: "ISC"
+tags: ["cryptography" "hpke" "rfc9180" "hybrid encryption"]
+homepage: "https://github.com/thevilledev/ocaml-hpke"
+bug-reports: "https://github.com/thevilledev/ocaml-hpke/issues"
+dev-repo: "git+https://github.com/thevilledev/ocaml-hpke.git"
+depends: [
+  "ocaml" {>= "4.14"}
+  "dune" {>= "3.12"}
+  "mirage-crypto" {>= "2.4.0"}
+  "mirage-crypto-ec" {>= "2.4.0"}
+  "mirage-crypto-rng" {>= "2.4.0"}
+  "kdf" {>= "1.1.0"}
+  "digestif" {>= "1.3.1"}
+  "eqaf" {>= "0.10"}
+  "alcotest" {with-test & >= "1.7.0"}
+  "qcheck-alcotest" {with-test & >= "0.25"}
+  "crowbar" {with-test & >= "0.2.1"}
+  "yojson" {with-test & >= "2.0.0"}
+  "odoc" {with-doc}
+  "ocamlformat" {with-dev-setup & = "0.29.0"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+  ["dune" "build" "@doc" "-p" name "-j" jobs] {with-doc}
+]
+url {
+  src:
+    "https://github.com/thevilledev/ocaml-hpke/archive/refs/tags/v0.1.1.tar.gz"
+  checksum: [
+    "md5=4c3cca796939d2b2deb79dd82b8d962e"
+    "sha512=2fe3e8675be657254590aea3b8fe2519c749f9f296c7d3c141118141ddf7b30569a44e1d06b72bce181c47880234a902b03120b4c1ffaad9e3e00706b3375d75"
+  ]
+}


### PR DESCRIPTION
### `hpke.0.1.1`
Idiomatic RFC 9180 Hybrid Public Key Encryption for OCaml
An idiomatic, misuse-resistant implementation of RFC 9180 HPKE Base and PSK
modes. Cryptographic primitives are delegated to Mirage Crypto and Digestif.



---
* Homepage: https://github.com/thevilledev/ocaml-hpke
* Source repo: git+https://github.com/thevilledev/ocaml-hpke.git
* Bug tracker: https://github.com/thevilledev/ocaml-hpke/issues

---
:camel: Pull-request generated by opam-publish v3.0.1