### PR TITLE
Add constraints to two -secondary packages

### DIFF
--- a/packages/dune-secondary/dune-secondary.3.16.0/opam
+++ b/packages/dune-secondary/dune-secondary.3.16.0/opam
@@ -39,6 +39,7 @@ install: [
 ]
 depends: [
   "ocaml-secondary-compiler" {>="4.14.2"}
+  "ocaml" { < "5.4" }
 ]
 url {
   src: "https://github.com/ocaml/dune/releases/download/3.16.0/dune-3.16.0.tbz"

--- a/packages/menhir-secondary/menhir-secondary.20231231/opam
+++ b/packages/menhir-secondary/menhir-secondary.20231231/opam
@@ -22,6 +22,7 @@ install: [
 depends: [
   "dune-secondary"
   "ocaml-secondary-compiler"
+  "ocaml" { < "5.2" }
 ]
 synopsis: "Adds Menhir to ocaml-secondary-compiler"
 url {


### PR DESCRIPTION
Menhir complains about misplaced attribute, but 5.1 is fine.

Dune complains about missing record field, which was introduced in 5.4.

I'm not sure what is a purpose of these packages, and why they call primary compiler at all...

All issues discovered while looking at[ check.ci.ocaml.org](https://check.ci.ocaml.org/?comp=4.11&comp=4.14&comp=5.2&comp=5.4&comp=5.5&available=4.11&available=4.14&available=5.2&available=5.4&available=5.5&show-only=bad&show-latest-only=true&packages=*secondary&maintainers=&logsearch=&logsearch_comp=4.11)