### PR TITLE
Inquire need OCaml < 5.2

### DIFF
--- a/packages/inquire/inquire.0.3.1/opam
+++ b/packages/inquire/inquire.0.3.1/opam
@@ -9,7 +9,7 @@ homepage: "https://github.com/tmattio/inquire"
 doc: "https://tmattio.github.io/inquire/"
 bug-reports: "https://github.com/tmattio/inquire/issues"
 depends: [
-  "ocaml" {>= "4.08.0"}
+  "ocaml" {>= "4.08.0" & < "5.2" }
   "dune" {>= "2.7"}
   "uutf"
   "odoc" {with-doc}

--- a/packages/inquire/inquire.0.3.1/opam
+++ b/packages/inquire/inquire.0.3.1/opam
@@ -9,7 +9,7 @@ homepage: "https://github.com/tmattio/inquire"
 doc: "https://tmattio.github.io/inquire/"
 bug-reports: "https://github.com/tmattio/inquire/issues"
 depends: [
-  "ocaml" {>= "4.08.0" & < "5.2" }
+  "ocaml" {>= "4.08.0" & < "5.0" }
   "dune" {>= "2.7"}
   "uutf"
   "odoc" {with-doc}


### PR DESCRIPTION
Compilation error:

>  ansi_stubs.c:45:36: error: implicit declaration of function 'failwith'; did you mean 'caml_failwith'? [-Wimplicit-function-declaration]
    45 |   if (ioctl(fd, TIOCGWINSZ, &win)) failwith("Ansi.size");

These function were renamed near OCaml 5.1: https://github.com/ocaml/ocaml/blob/5.1.1/Changes#L1035