### PR TITLE
[new release] cdp and cdp-gen (0.1.0)

### DIFF
--- a/packages/cdp-gen/cdp-gen.0.1.0/opam
+++ b/packages/cdp-gen/cdp-gen.0.1.0/opam
@@ -1,0 +1,45 @@
+opam-version: "2.0"
+synopsis: "Generator producing the cdp library from CDP protocol JSON"
+description:
+  "Command-line generator behind the cdp package: fetches a devtools-protocol snapshot and emits typed OCaml modules with JSON codecs for the selected domains."
+maintainer: [
+  "Vitalii Shapoval <vytalych@gmail.com>" "Ahrefs <github@ahrefs.com>"
+]
+authors: [
+  "Vitalii Shapoval <vytalych@gmail.com>" "Ahrefs <github@ahrefs.com>"
+]
+license: "MIT AND BSD-3-Clause"
+tags: ["org:ahrefs" "chrome" "devtools" "cdp" "codegen"]
+homepage: "https://github.com/ahrefs/ocaml-cdp"
+bug-reports: "https://github.com/ahrefs/ocaml-cdp/issues"
+depends: [
+  "dune" {>= "3.18"}
+  "ocaml" {>= "4.14"}
+  "yojson" {>= "1.6.0"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/ahrefs/ocaml-cdp.git"
+x-maintenance-intent: ["(latest)"]
+url {
+  src:
+    "https://github.com/ahrefs/ocaml-cdp/releases/download/0.1.0/cdp-0.1.0.tbz"
+  checksum: [
+    "sha256=0ce3fc800198774007743cf1415a2c8c069ba65c22e43accfbce35db1be3144c"
+    "sha512=e6196292d6a1bdcee68a15efe6fff2dea5217bfb5c87cfb476707426bdf69a8592f49a0d30c0bbcd9e554d240611514ba5425129d37adc04945caaae3542dd59"
+  ]
+}
+x-commit-hash: "35836fdda9cec745ae2c8700f9a8d1dc3182620e"

--- a/packages/cdp/cdp.0.1.0/opam
+++ b/packages/cdp/cdp.0.1.0/opam
@@ -1,0 +1,49 @@
+opam-version: "2.0"
+synopsis: "Chrome DevTools Protocol types for OCaml"
+description:
+  "Typed commands, events, and JSON codecs for the Chrome DevTools Protocol, generated from the official protocol definitions. Transport-agnostic: pair it with cdp-lwt or bring your own transport."
+maintainer: [
+  "Vitalii Shapoval <vytalych@gmail.com>" "Ahrefs <github@ahrefs.com>"
+]
+authors: [
+  "Vitalii Shapoval <vytalych@gmail.com>" "Ahrefs <github@ahrefs.com>"
+]
+license: "MIT AND BSD-3-Clause"
+tags: ["org:ahrefs" "chrome" "devtools" "cdp" "browser"]
+homepage: "https://github.com/ahrefs/ocaml-cdp"
+bug-reports: "https://github.com/ahrefs/ocaml-cdp/issues"
+depends: [
+  "dune" {>= "3.18"}
+  "ocaml" {>= "4.14"}
+  "yojson" {>= "1.6.0"}
+  "jsonkit" {>= "1.0.0" & < "2.0.0"}
+  "ppx_deriving" {>= "6.0"}
+  "ocamlformat" {= "0.29.0" & with-dev-setup}
+  "ocaml-lsp-server" {with-dev-setup}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/ahrefs/ocaml-cdp.git"
+x-maintenance-intent: ["(latest)"]
+url {
+  src:
+    "https://github.com/ahrefs/ocaml-cdp/releases/download/0.1.0/cdp-0.1.0.tbz"
+  checksum: [
+    "sha256=0ce3fc800198774007743cf1415a2c8c069ba65c22e43accfbce35db1be3144c"
+    "sha512=e6196292d6a1bdcee68a15efe6fff2dea5217bfb5c87cfb476707426bdf69a8592f49a0d30c0bbcd9e554d240611514ba5425129d37adc04945caaae3542dd59"
+  ]
+}
+x-commit-hash: "35836fdda9cec745ae2c8700f9a8d1dc3182620e"


### PR DESCRIPTION
Chrome DevTools Protocol types for OCaml

- Project page: <a href="https://github.com/ahrefs/ocaml-cdp">https://github.com/ahrefs/ocaml-cdp</a>

##### CHANGES:

- Initial release
- `cdp`: typed commands, events, and JSON codecs for 10 Chrome DevTools
  Protocol domains (Browser, DOM, Debugger, Emulation, IO, Network, Page,
  Runtime, Security, Target), generated from protocol r1687809
- `cdp-gen`: the generator behind `cdp` — fetches a devtools-protocol
  snapshot and emits typed OCaml modules for the selected domains
- `cdp-lwt`: Lwt client — launches or attaches to a Chrome and drives it
  over libcurl WebSockets. Not yet published to opam: it needs an ocurl
  release with the libcurl WebSocket API (`pin-depends` covers source builds)
