### PR TITLE
Package ease-caml.0.1.7

### DIFF
--- a/packages/ease-caml/ease-caml.0.1.7/opam
+++ b/packages/ease-caml/ease-caml.0.1.7/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+synopsis: "A easing/tweening library for OCaml"
+description:
+  "A tween transitions a float from one value to another over time using an easing function. This is useful for creating animations in games. ease-caml provides game framework agnostic methods to easily create tweens and manage them."
+maintainer: "Christopher Sumnicht <csumnicht@berkeley.edu>"
+authors: "Christopher Sumnicht <csumnicht@berkeley.edu>"
+license: "Apache-2.0"
+tags: ["game" "easing" "tween" "animation"]
+homepage: "https://github.com/Modular-Game-Components/ease-caml"
+doc: "https://modular-game-components.github.io/ease-caml/"
+bug-reports: "https://github.com/Modular-Game-Components/ease-caml/issues"
+depends: [
+  "dune" {>= "3.23"}
+  "ocaml" {>= "5.0.0"}
+  "alcotest" {>= "1.9.0" & with-test}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/Modular-Game-Components/ease-caml.git"
+url {
+  src:
+    "https://github.com/Modular-Game-Components/ease-caml/archive/refs/tags/0.1.7.tar.gz"
+  checksum: [
+    "md5=37b9e021586dc7b0615efed0d7996ae2"
+    "sha512=a4223846eb5f875f43b64dcac377c1ec9fdcc165fbd34e027ef3f4ba8a36d04edf9892c5e0ce0f281ef6dbffb53f0a03d69f6d138c1e269e6a12f4630b15f9e6"
+  ]
+}
+x-maintenance-intent: ["(latest)"]


### PR DESCRIPTION
### `ease-caml.0.1.7`
A easing/tweening library for OCaml
A tween transitions a float from one value to another over time using an easing function. This is useful for creating animations in games. ease-caml provides game framework agnostic methods to easily create tweens and manage them.



---
* Homepage: https://github.com/Modular-Game-Components/ease-caml
* Source repo: git+https://github.com/Modular-Game-Components/ease-caml.git
* Bug tracker: https://github.com/Modular-Game-Components/ease-caml/issues

---
:camel: Pull-request generated by opam-publish v3.0.0