### PR TITLE
[new release] kdf (1.1.1)

### DIFF
--- a/packages/kdf/kdf.1.1.1/opam
+++ b/packages/kdf/kdf.1.1.1/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+maintainer: ["Alfredo Beaumont <alfredo.beaumont@gmail.com>" "Hannes Mehnert <hannes@mehnert.org>"]
+authors: ["Alfredo Beaumont <alfredo.beaumont@gmail.com>" "Sonia Meruelo <smeruelo@gmail.com>" "Hannes Mehnert <hannes@mehnert.org>"]
+license: "BSD-2-Clause"
+homepage: "https://github.com/robur-coop/kdf"
+doc: "https://robur-coop.github.io/kdf/doc"
+bug-reports: "https://github.com/robur-coop/kdf/issues"
+depends: [
+  "ocaml" {>= "4.13.0"}
+  "dune" {>= "1.8.0"}
+  "digestif" {>= "1.2.0"}
+  "mirage-crypto" {>= "1.0.0"}
+  "alcotest" {with-test & >= "0.8.1"}
+  "ohex" {with-test & >= "0.2.0"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/robur-coop/kdf.git"
+synopsis: "Key Derivation Functions: HKDF RFC 5869, PBKDF RFC 2898, SCRYPT RFC 7914"
+description: """
+A pure OCaml implementation of [scrypt](https://tools.ietf.org/html/rfc7914),
+[PBKDF 1 and 2 as defined by PKCS#5](https://tools.ietf.org/html/rfc2898),
+and [HKDF](https://tools.ietf.org/html/rfc5869).
+"""
+x-maintenance-intent: [ "(latest)" ]
+url {
+  src:
+    "https://github.com/robur-coop/kdf/releases/download/v1.1.1/kdf-1.1.1.tbz"
+  checksum: [
+    "sha256=922efdf80d35b8fcb0ec7d0143400f45bb986cb1c715d717d5402f111cf8f8e5"
+    "sha512=8584c24b249d9d264fc58e1cd8299968b6098fe915fe7c8f935937c7e3cb200bde0bd0fdb042fb000337fb0b6298866068933cd20b95e51a021cbf3e9e3c6456"
+  ]
+}
+x-commit-hash: "6200bb4d4a5ad47ffb98a7f1b7ce5a7749cc12fd"


### PR DESCRIPTION
Key Derivation Functions: HKDF RFC 5869, PBKDF RFC 2898, SCRYPT RFC 7914

- Project page: <a href="https://github.com/robur-coop/kdf">https://github.com/robur-coop/kdf</a>
- Documentation: <a href="https://robur-coop.github.io/kdf/doc">https://robur-coop.github.io/kdf/doc</a>

##### CHANGES:

* hkdf: enforce the RFC 5869 length bound in expand (len <= 255 * hash output
  size) - larger requests were accepted, with the one-octet block counter
  wrapping to 0 for block 256, and reject negative len (raising Failure for
  both) (@thevilledev robur-coop/kdf#4)
* hkdf: avoid computing a superfluous block in expand when len is a multiple
  of the hash output size (@thevilledev robur-coop/kdf#4)
