### PR TITLE
Sundialsml: more x-ci-accept-failures

### DIFF
--- a/packages/conf-sundials/conf-sundials.2/opam
+++ b/packages/conf-sundials/conf-sundials.2/opam
@@ -34,6 +34,7 @@ x-ci-accept-failures: [
   "alpine-3.12" # package not available by default
   "alpine-3.13" # package not available by default
   "alpine-3.14" # package not available by default
+  "alpine-3.23" # package not available by default
   "oraclelinux-7" # requires addition of epel-release repos
   "oraclelinux-8" # requires addition of epel-release repos
 ]

--- a/packages/sundialsml/sundialsml.6.1.1p1/opam
+++ b/packages/sundialsml/sundialsml.6.1.1p1/opam
@@ -84,5 +84,8 @@ x-ci-accept-failures: [
   "ubuntu-25.04"
   "ubuntu-25.10"
   "ubuntu-26.04"
+  "fedora-44"
+  "ubuntu-24.04"
+  "debian-12"
 ]
 

--- a/packages/sundialsml/sundialsml.6.1.1p1/opam
+++ b/packages/sundialsml/sundialsml.6.1.1p1/opam
@@ -91,5 +91,9 @@ x-ci-accept-failures: [
   "fedora-42"
   "centos-9"
   "centos-10"
+  "opensuse-tumbleweed"
+  "archlinux"
+  "opensuse-16.0"
+  "macos-homebrew"
 ]
 

--- a/packages/sundialsml/sundialsml.6.1.1p1/opam
+++ b/packages/sundialsml/sundialsml.6.1.1p1/opam
@@ -95,5 +95,6 @@ x-ci-accept-failures: [
   "archlinux"
   "opensuse-16.0"
   "macos-homebrew"
+  "freebsd-15.1"
 ]
 

--- a/packages/sundialsml/sundialsml.6.1.1p1/opam
+++ b/packages/sundialsml/sundialsml.6.1.1p1/opam
@@ -87,5 +87,9 @@ x-ci-accept-failures: [
   "fedora-44"
   "ubuntu-24.04"
   "debian-12"
+  "fedora-43"
+  "fedora-42"
+  "centos-9"
+  "centos-10"
 ]
 

--- a/packages/sundialsml/sundialsml.6.1.1p1/opam
+++ b/packages/sundialsml/sundialsml.6.1.1p1/opam
@@ -77,3 +77,12 @@ url {
   ]
 }
 
+x-ci-accept-failures: [
+  "debian-13"
+  "debian-testing"
+  "debian-unstable"
+  "ubuntu-25.04"
+  "ubuntu-25.10"
+  "ubuntu-26.04"
+]
+


### PR DESCRIPTION
Compilation error:

> Some errors occurred during configuration:
 	Can't link C code to sundials.  Is sundials installed properly?
 	Saved test code as __configure_test_file__realtype.c
 	Compilation command was:
 	cc  -o __configure_test_file__realtype __configure_test_file__realtype.c

It happend on ubuntu 25.10, debian-13. Ubuntu 24.04 is fine. It looks like right include paths are missing, for example adding this helps: ` $(pkg-config --cflags-only-I ompi) `