### PR TITLE
[new release] wire (1.3.0)

### DIFF
--- a/packages/wire/wire.1.3.0/opam
+++ b/packages/wire/wire.1.3.0/opam
@@ -1,0 +1,47 @@
+opam-version: "2.0"
+synopsis: "Binary wire format DSL with EverParse 3D output"
+description:
+  "OCaml DSL for describing binary wire formats with EverParse 3D output. Define your wire format once, then use it for OCaml parsing via bytesrw or emit .3d files for verified C parser generation via EverParse."
+maintainer: ["Thomas Gazagnaire <thomas@gazagnaire.org>"]
+authors: ["Thomas Gazagnaire <thomas@gazagnaire.org>"]
+license: "ISC"
+homepage: "https://github.com/parsimoni-labs/ocaml-wire"
+bug-reports: "https://github.com/parsimoni-labs/ocaml-wire/issues"
+depends: [
+  "dune" {>= "3.21"}
+  "ocaml" {>= "5.3"}
+  "bytesrw" {>= "0.4.0"}
+  "fmt" {>= "0.9"}
+  "optint" {>= "0.3"}
+  "memtrace" {with-test}
+  "alcotest" {with-test}
+  "alcobar" {with-test}
+  "re" {>= "1.11"}
+  "mdx" {with-test}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/parsimoni-labs/ocaml-wire.git"
+x-maintenance-intent: ["(latest)"]
+url {
+  src:
+    "https://github.com/parsimoni-labs/ocaml-wire/releases/download/1.3.0/wire-1.3.0.tbz"
+  checksum: [
+    "sha256=8709cb675bb2e4b30554508c4756b20b4ec050b79b262df917ec01228888f361"
+    "sha512=86ca3baa3ad17c164b6c285b91eda969cdd515dcbad5246fd121e1ff4cf0129a010a2c88e18c144e4fb74a3e7e03cad0b9a55aa4c32728242136f37b9ed92a5c"
+  ]
+}
+x-commit-hash: "465791c3fa3097abdb7d38e855cbb9a2fe0ac8e5"


### PR DESCRIPTION
Binary wire format DSL with EverParse 3D output

- Project page: <a href="https://github.com/parsimoni-labs/ocaml-wire">https://github.com/parsimoni-labs/ocaml-wire</a>

##### CHANGES:

### Added

- Add ``~consume:`All`` to the string/bytes and `Codec.decode` entry points for
  callers that require exactly one value. The existing default is explicit as
  ``~consume:`Prefix``; exact rejection reports a structured `Trailing_bytes`
  parse error (parsimoni-labs/ocaml-wire#408, @samoht)

- Add `Wire.Codec.to_bytes` and `Wire.Codec.to_string`: they allocate an
  exact-size buffer, encode the whole record into it and run the same checks as
  `validate`, so a one-call encode cannot return bytes `decode` would reject.
  They replace the easy-to-miss manual `encode` then `validate` sequence
  (parsimoni-labs/ocaml-wire#394, @samoht)

### Changed

- **Breaking:** Replace `Wire.Codec.is_fixed` with `wire_size_opt`, which
  answers the same question and hands back the size in the same call.
  `wire_size` remains for a layout that must be fixed (parsimoni-labs/ocaml-wire#394, @samoht)

- **Breaking:** `Wire.uint` takes its 1-7 byte width as an `int`, so a
  three-byte integer is `uint 3` rather than `uint (int 3)`. Use `Wire.uint_var`
  where the width is a field- or parameter-driven expression (parsimoni-labs/ocaml-wire#382, @samoht)

- **Breaking:** `Wire.sizeof_this` is the enclosing description's fixed prefix:
  one constant, the same wherever it is read. It used to be the bytes consumed
  up to the reading field, so a description reading it after a variable-size
  field now means something different, and agrees with the generated validator
  where the two used to disagree. A constraint reading it no longer sees a
  negative placeholder (parsimoni-labs/ocaml-wire#374, @samoht)

- **Breaking:** `Wire.Codec.wire_size_at`, `get` and `set` raise
  `Invalid_argument` when the codec has input params and no `?env`, as `decode`
  already did, and `set` gains the `?env` that makes a dependent layout
  addressable. Each used to answer from a parameter it had not been given, and
  the answer was a shorter record, the wrong field, or a write over a field the
  caller never named (parsimoni-labs/ocaml-wire#350, parsimoni-labs/ocaml-wire#396, @samoht)

### Documentation

- State in the installed `Wire.Codec` signature that `encode` is
  non-transactional: after an exception, the destination contains a partial
  record and must be discarded. `to_bytes` and `to_string` keep that partial
  buffer private (parsimoni-labs/ocaml-wire#409, @samoht)

- `Wire.Codec.validate` runs field actions but does not write their output
  assignments back to the caller's `Param.env`; use `decode` where you relied on
  them. The documentation claimed otherwise (parsimoni-labs/ocaml-wire#394, @samoht)

- Document that `Field.repeat` has no sizeless form: its budget is the region
  size the description declares, and a caller who does not know that size where
  the codec is built should take it as a `Param.input` rather than baking in a
  literal (parsimoni-labs/ocaml-wire#351, @samoht)

### Fixed

- `Codec.decode` reports `Unexpected_eof` instead of raising
  `Invalid_argument` when a variable-width field moves a following fixed-width
  field past the input (parsimoni-labs/ocaml-wire#402, @samoht)

- Field accessors are bound to the `Field.t` that declared them. `Codec.get`,
  `set`, `bitfield`, `slice_offset` and `slice_length` now reject a different
  same-named field instead of silently using its access plan against the wrong
  layout (parsimoni-labs/ocaml-wire#402, @samoht)

- `Codec.v` rejects a non-final string-tagged `casetype`, a non-scalar
  field refinement and a `zeroterm` field with siblings, instead of letting
  EverParse fail later while compiling or extracting their validators
  (parsimoni-labs/ocaml-wire#399, @samoht)

- A casetype in the generated C dispatches on every tag type it does in OCaml,
  and a case body keeps the refinement its type carries. With a `variants`, a
  `lookup`, a plain `map` or a bare `uint64` tag the union was validated as a
  tag followed by opaque bytes and no case body was checked at all, and a closed
  enum's membership and a `lookup`'s index bound were dropped. Both accepted
  bytes `Codec.decode` rejects, so regenerate the C (parsimoni-labs/ocaml-wire#363, parsimoni-labs/ocaml-wire#364, @samoht)

- A schema that declares two different types under one name is refused instead
  of resolving every reference to whichever came first. Two same-named
  sub-codecs of different widths produced a validator reading a different number
  of bytes than the codec (parsimoni-labs/ocaml-wire#365, @samoht)

- Two `nested` regions whose contents differ in shape no longer share one
  generated type. The second region was silently validated against the first's
  contents; a description that would still land two shapes on one name is
  refused where it is built (@samoht)

- A mutable `byte_slice` returned by `Wire.of_string` owns its backing bytes, so
  it cannot modify the caller's immutable source string. Other decoded values
  remain copy-free, and bytes inputs still alias (parsimoni-labs/ocaml-wire#383, @samoht)

- Expression addition, subtraction and multiplication reject native-integer
  overflow. A dependent byte span could otherwise turn a huge declared size into
  zero or one and pass bounds validation (parsimoni-labs/ocaml-wire#375, @samoht)

- `Wire.Codec.size_of_value` takes `?env` and resolves a field whose byte extent
  is an input parameter, refusing where it has none rather than reporting 0. It
  used to under-report such a field by its whole width, so a caller sizing a
  buffer from the answer got one too short and `encode` ran off the end with a
  raw out-of-bounds instead of a wire error (parsimoni-labs/ocaml-wire#353, @samoht)

- EverParse output names are validated as portable ASCII identifiers before any
  generated file is opened, preventing path escapes and malformed 3D, C or dune
  output (parsimoni-labs/ocaml-wire#385, @samoht)

- A zero divisor supplied to expression division or modulo is reported as
  `Zero_divisor`. It used to escape decoding as the host exception
  `Division_by_zero` rather than a wire parse error (parsimoni-labs/ocaml-wire#376, @samoht)

- `Wire.Everparse.write` no longer refuses a family in which a sub-codec is both
  packed as a codec of its own and reached through another codec's field. The
  two differ only in how the type is used, not in what it is, so they collapse
  into a single declaration that still gets a validator of its own and keeps the
  codec's doc comment (parsimoni-labs/ocaml-wire#346, @samoht)

- `Field.optional` over a sub-codec that takes `Param.input` values, and a
  `nested` region whose contents are sized from a field of the enclosing record,
  project to a schema EverParse accepts. Both described their contents in a
  scope that did not carry those values, so `3d.exe` refused the file with an
  unbound variable (@samoht)

- A casetype tag whose enum sits over a `lookup`, a `where` or a 64-bit base no
  longer fails the 3D projection with an assertion failure. Every integer
  carrier an enum base accepts now yields a case label (parsimoni-labs/ocaml-wire#347, @samoht)

- A codec parameter typed by an enum, and a casetype case label over a bitfield
  base, name a type the generated schema declares rather than one EverParse
  rejects or never sees declared; a `uint_var`-sized parameter names no type at
  all and is refused where it is built (parsimoni-labs/ocaml-wire#366, @samoht)

- `Wire_3d.generate_c` works against EverParse releases after v2026.02.25. The
  whole-buffer check it adds to each generated wrapper named a variable those
  releases renamed, so the emitted C referenced an undeclared identifier and
  failed to compile (parsimoni-labs/ocaml-wire#367, @samoht)

- A record truncated in the middle reports the first field that cannot be read,
  at its own offset. Fields were read in reverse, so the failure was blamed on a
  later field and `at` could point outside the input the caller passed in
  (parsimoni-labs/ocaml-wire#372, @samoht)

- A value too wide for the platform's native integer is reported at the field it
  was read from rather than at byte 0, so seeking to the offset a parse error
  names lands on the field whatever base the frame sits at (parsimoni-labs/ocaml-wire#356, @samoht)

- A parse error from a field whose start ran past the end of the input reports
  the bytes that were missing rather than a negative count. `Wire.of_reader`
  computes how much more to read from that number, so a negative one left it
  asking for a position behind what it had already buffered (parsimoni-labs/ocaml-wire#359, @samoht)

- A parse error from an unmatched casetype tag names the casetype field. It used
  to arrive with an empty field path, leaving a caller no way to tell which
  field the bad tag belonged to (parsimoni-labs/ocaml-wire#348, @samoht)

- `Wire.Codec.min_wire_size` reports the region a `zeroterm_at_most` field
  occupies rather than zero, so a buffer sized from it holds the record. A parse
  error from a `zeroterm` field with no terminator also names the field it came
  from (parsimoni-labs/ocaml-wire#361, @samoht)

- `Field.repeat` says what the byte budget is for when the encoded elements do
  not fill it, instead of refusing without naming the remedy (parsimoni-labs/ocaml-wire#351, @samoht)

- `Wire_3d.generate_corpus` reaches records it used to report as unreachable:
  casetype tags, `lookup` table indices, a constraint written on one field about
  another, a codec-level `where`, a predicate satisfied only at its minimum, a
  string whose terminator has to be written rather than drawn, and a length
  field a byte draw blew up out of range. `Wire.Everparse.Raw.field_seeds`
  supplies those values (parsimoni-labs/ocaml-wire#348, parsimoni-labs/ocaml-wire#349, parsimoni-labs/ocaml-wire#355, parsimoni-labs/ocaml-wire#360, parsimoni-labs/ocaml-wire#362, @samoht)
