### PR TITLE
[new release] h1 (2 packages) (1.1.1)

### DIFF
--- a/packages/h1-lwt-unix/h1-lwt-unix.1.1.1/opam
+++ b/packages/h1-lwt-unix/h1-lwt-unix.1.1.1/opam
@@ -1,0 +1,31 @@
+opam-version: "2.0"
+maintainer: "Romain Calascibetta <romain.calascibetta@gmail.com>"
+authors: [
+  "Anton Bachin <antonbachin@yahoo.com>"
+  "Spiros Eliopoulos <spiros@inhabitedtype.com>"
+]
+license: "BSD-3-clause"
+homepage: "https://github.com/robur-coop/ocaml-h1"
+bug-reports: "https://github.com/robur-coop/ocaml-h1/issues"
+dev-repo: "git+https://github.com/robur-coop/ocaml-h1.git"
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "faraday-lwt-unix"
+  "h1" {= version}
+  "dune" {>= "2.0.0"}
+  "lwt" {>= "2.4.7"}
+]
+synopsis: "Lwt support for ocaml-h1"
+url {
+  src:
+    "https://github.com/robur-coop/ocaml-h1/releases/download/v1.1.1/h1-1.1.1.tbz"
+  checksum: [
+    "sha256=2b786c057666959a9e066f0ee7cb849af8e49c95f550845ff9f1b480bcc8e19a"
+    "sha512=5228b2b8fc63427c8f5969bad0a10822793bd02ce674af1c2111eadd819ac35d622f2c09467f7ab6ec1c653ef2978a2bc7fda0714a69eab853e1156497a19d3b"
+  ]
+}
+x-commit-hash: "d5fff216c28fe379c3abaa355b679ffb35d98d07"

--- a/packages/h1/h1.1.1.1/opam
+++ b/packages/h1/h1.1.1.1/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+maintainer: "Romain Calascibetta <romain.calascibetta@gmail.com>"
+authors: [ "Spiros Eliopoulos <spiros@inhabitedtype.com>" ]
+license: "BSD-3-clause"
+homepage: "https://github.com/robur-coop/ocaml-h1"
+bug-reports: "https://github.com/robur-coop/ocaml-h1/issues"
+dev-repo: "git+https://github.com/robur-coop/ocaml-h1.git"
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name] {with-test}
+]
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "2.0.0"}
+  "alcotest" {with-test & >= "1.2.0"}
+  "stdio" {with-test}
+  "base64" {>= "3.5.0"}
+  "bstr"
+  "angstrom" {>= "0.14.0"}
+  "faraday"  {>= "0.6.1"}
+  "httpun-types" {>= "0.1.0"}
+  "lwt" {with-test}
+]
+synopsis:
+  "A high-performance, memory-efficient, and scalable web server for OCaml"
+description: """
+h1 implements the HTTP 1.1 specification with respect to parsing,
+serialization, and connection pipelining as a state machine that is agnostic to
+the underlying IO mechanism, and is therefore portable across many platform.
+It uses the Angstrom and Faraday libraries to implement the parsing and
+serialization layers of the HTTP standard, hence the name."""
+url {
+  src:
+    "https://github.com/robur-coop/ocaml-h1/releases/download/v1.1.1/h1-1.1.1.tbz"
+  checksum: [
+    "sha256=2b786c057666959a9e066f0ee7cb849af8e49c95f550845ff9f1b480bcc8e19a"
+    "sha512=5228b2b8fc63427c8f5969bad0a10822793bd02ce674af1c2111eadd819ac35d622f2c09467f7ab6ec1c653ef2978a2bc7fda0714a69eab853e1156497a19d3b"
+  ]
+}
+x-commit-hash: "d5fff216c28fe379c3abaa355b679ffb35d98d07"


### PR DESCRIPTION
A high-performance, memory-efficient, and scalable web server for OCaml

- Project page: <a href="https://github.com/robur-coop/ocaml-h1">https://github.com/robur-coop/ocaml-h1</a>

##### CHANGES:

- Fix a bug on websocket frames and how we get the length of a frame (@dinosaure, robur-coop/ocaml-h1#19)
