### PR TITLE
[new release] miou (0.10.0)

### DIFF
--- a/packages/miou/miou.0.10.0/opam
+++ b/packages/miou/miou.0.10.0/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+maintainer:   "Romain Calascibetta <romain.calascibetta@gmail.com>"
+authors:      "Romain Calascibetta <romain.calascibetta@gmail.com>"
+homepage:     "https://github.com/robur-coop/miou"
+bug-reports:  "https://github.com/robur-coop/miou/issues"
+dev-repo:     "git+https://github.com/robur-coop/miou.git"
+doc:          "https://docs.osau.re/local/miou/"
+license:      "MIT"
+synopsis:     "Composable concurrency primitives for OCaml"
+
+build: [ "dune" "build" "-p" name "-j" jobs ]
+run-test: [ "dune" "runtest" "-p" name "-j" jobs ]
+
+depends: [
+  "ocaml"             {>= "5.2.0"}
+  "dune"              {>= "3.13.0"}
+  "dune-configurator"
+  "dscheck"           {with-test & >= "0.4.0"}
+  "digestif"          {with-test}
+  "happy-eyeballs"    {with-test & >= "0.6.0"}
+  "dns-client"        {with-test}
+  "hxd"               {with-test}
+  "mirage-crypto-rng" {with-test}
+  "ipaddr"            {with-test}
+  "logs"              {with-test & >= "0.7.0"}
+  "dns"               {with-test}
+  "dns-client"        {with-test}
+  "mtime"             {with-test & >= "2.0.0"}
+  "ocamlformat"       {with-dev-setup & = "0.27.0"}
+]
+x-maintenance-intent: [ "(latest)" ]
+x-ci-accept-failures: [ "macos-homebrew" ]
+url {
+  src:
+    "https://github.com/robur-coop/miou/releases/download/v0.10.0/miou-0.10.0.tbz"
+  checksum: [
+    "sha256=bf1954c6f66ac9d306b3b4f948b19f59d2c327213af930e19d9fbc73f134fa18"
+    "sha512=cea8136bf9fef32898c962b4136fd784a20fc8a6626cd19bb7d0a37e798aa7a7f06ea9f19b47f6e03bb1afd477cf46e57d4c6a376601eb282c4fb07d490ca727"
+  ]
+}
+x-commit-hash: "0bc78bf154b342ece37f132349160dd5d2456e79"


### PR DESCRIPTION
Composable concurrency primitives for OCaml

- Project page: <a href="https://github.com/robur-coop/miou">https://github.com/robur-coop/miou</a>
- Documentation: <a href="https://docs.osau.re/local/miou/">https://docs.osau.re/local/miou/</a>

##### CHANGES:

- Delete some useless files for another compilation scheme (@dinosaure, robur-coop/miou#131)
- Optimize a bit when we do an interruption and when we add something into our
  dom0 (@dinosaure, robur-coop/miou#129)
- Optimize our `Miou_unix` internal table of file-descriptors (@dinosaure, robur-coop/miou#130)
- Provide `Miou_unix.{read,write}_bigstring` (since OCaml 5.2)
  (@dinosaure, robur-coop/miou#133)
- Add the support of `epoll(7)` on Linux (@dinosaure, robur-coop/miou#134)
- Optimize our run-queue (replace our proved implementation of our priority
  queue by something more straightforward, a simple ring buffer and duplicate it
  by priorities - clean, cancel, others) (@dinosaure, robur-coop/miou#135, related to robur-coop/miou#40)
- Introduce a new environment variable `MIOU_POLL` which gives a budget to let
  Miou to execute tasks before to observe events (@dinosaure, robur-coop/miou#137)
