### PR TITLE
Add: jsont.0.4.0, typegist.0.0.0

### DIFF
--- a/packages/jsont/jsont.0.4.0/opam
+++ b/packages/jsont/jsont.0.4.0/opam
@@ -1,0 +1,67 @@
+opam-version: "2.0"
+synopsis: "Declarative JSON data manipulation for OCaml"
+description: """\
+Jsont is an OCaml library for declarative JSON data manipulation. It
+provides:
+
+- Combinators for describing JSON data using the OCaml values of your
+  choice. The descriptions can be used by generic functions to
+  decode, encode, query and update JSON data without having to
+  construct a generic JSON representation.
+- A JSON codec with optional text location tracking and layout
+  preservation. The codec is compatible with effect-based concurrency.
+
+The descriptions are independent from the codec and can be used by
+third-party processors or codecs.
+
+Jsont is distributed under the ISC license. It has no dependencies.
+The codec is optional and depends on the [`bytesrw`] library. The JavaScript
+support is optional and depends on the [`brr`] library. The type gist
+support is optional and depends on the [`typegist`] library.
+
+Homepage: <https://erratique.ch/software/jsont/>
+
+[`bytesrw`]: https://erratique.ch/software/bytesrw
+[`brr`]: https://erratique.ch/software/brr
+[`typegist`]: https://erratique.ch/software/typegist"""
+maintainer: "Daniel Bünzli <daniel.buenzl i@erratique.ch>"
+authors: "The jsont programmers"
+license: "ISC"
+tags: ["json" "codec" "org:erratique"]
+homepage: "https://erratique.ch/software/jsont"
+doc: "https://erratique.ch/software/jsont/doc"
+bug-reports: "https://github.com/dbuenzli/jsont/issues"
+depends: [
+  "ocaml" {>= "4.14.0"}
+  "ocamlfind" {build}
+  "ocamlbuild" {build}
+  "topkg" {build & >= "1.1.0"}
+  "b0" {dev & with-test}
+]
+depopts: ["cmdliner" "brr" "bytesrw" "typegist"]
+conflicts: [
+  "cmdliner" {< "1.3.0"}
+  "brr" {< "0.0.6"}
+]
+build: [
+  "ocaml"
+  "pkg/pkg.ml"
+  "build"
+  "--dev-pkg"
+  "%{dev}%"
+  "--with-cmdliner"
+  "%{cmdliner:installed}%"
+  "--with-bytesrw"
+  "%{bytesrw:installed}%"
+  "--with-brr"
+  "%{brr:installed}%"
+  "--with-typegist"
+  "%{typegist:installed}%"
+]
+dev-repo: "git+https://erratique.ch/repos/jsont.git"
+url {
+  src: "https://erratique.ch/software/jsont/releases/jsont-0.4.0.tbz"
+  checksum:
+    "sha512=5fa106aa3f610888b9c4034fe72aedd2dff37f53850bdcf155e7cd135fb3e46b08d6df3e57cd254a5142989d8bf9c6b15f34166a34841d0f5c7a2587bbbca302"
+}
+x-maintenance-intent: ["(latest)"]

--- a/packages/typegist/typegist.0.0.0/opam
+++ b/packages/typegist/typegist.0.0.0/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+synopsis: "Represent the essence of OCaml types as values"
+description: """\
+Typegist represents the essence of OCaml types as values.
+
+This dynamic type representation can be used to devise generic
+type-indexed functions – value serializers, generators, differs,
+editors, FFI glue, etc. Any accessible type can be described up to the
+limits defined by its public interface.
+
+Typegist does not model OCaml's type language in full detail. It
+focuses on a core structural subset decorated with typed-indexed
+metadata to provide an ergonomic interface for both producers and
+processors of the representation.
+
+Typegist is distributed under the ISC license. It has no dependencies. 
+
+Homepage: <https://erratique.ch/software/typegist>"""
+maintainer: "Daniel Bünzli <daniel.buenzl i@erratique.ch>"
+authors: "The typegist programmers"
+license: "ISC"
+tags: ["typerep" "generic" "org:erratique"]
+homepage: "https://erratique.ch/software/typegist"
+doc: "https://erratique.ch/software/typegist/doc"
+bug-reports: "https://github.com/dbuenzli/typegist/issues"
+depends: [
+  "ocaml" {>= "5.5.0"}
+  "ocamlfind" {build}
+  "ocamlbuild" {build}
+  "topkg" {build & >= "1.1.0"}
+]
+build: ["ocaml" "pkg/pkg.ml" "build" "--dev-pkg" "%{dev}%"]
+dev-repo: "git+https://erratique.ch/repos/typegist.git"
+url {
+  src: "https://erratique.ch/software/typegist/releases/typegist-0.0.0.tbz"
+  checksum:
+    "sha512=6541e4570412fc411f55d1a5cc34817081667f286d425b911795b10637e1e20df41a9e99ba0f7465b00df0588573ae6e7d8c171bbb4521424afc11871a3dedbf"
+}
+x-maintenance-intent: ["(latest)"]


### PR DESCRIPTION
* Add: `jsont.0.4.0` [home](https://erratique.ch/software/jsont), [doc](https://erratique.ch/software/jsont/doc), [issues](https://github.com/dbuenzli/jsont/issues)  
  *Declarative JSON data manipulation for OCaml*
* Add: `typegist.0.0.0` [home](https://erratique.ch/software/typegist), [doc](https://erratique.ch/software/typegist/doc), [issues](https://github.com/dbuenzli/typegist/issues)  
  *Represent the essence of OCaml types as values*


---

#### `jsont` v0.4.0 2026-09-02 Zagreb

- Add `jsont.typegist` library.

---

#### `typegist` v0.0.0 2027-09-02 Zagreb


First release.

Supported by a grant from the OCaml Software Foundation.


---

Use `b0 -- .opam publish jsont.0.4.0 typegist.0.0.0` to update the pull request.