### PR TITLE
Package binaryen.0.36.0

### DIFF
--- a/packages/binaryen/binaryen.0.36.0/opam
+++ b/packages/binaryen/binaryen.0.36.0/opam
@@ -1,0 +1,28 @@
+opam-version: "2.0"
+synopsis: "OCaml bindings for Binaryen"
+maintainer: "oscar@grain-lang.org"
+authors: "Oscar Spencer"
+license: " Apache-2.0"
+homepage: "https://github.com/grain-lang/binaryen.ml"
+bug-reports: "https://github.com/grain-lang/binaryen.ml/issues"
+depends: [
+  "ocaml" {>= "4.13.0"}
+  "dune" {>= "3.0.0"}
+  "dune-configurator" {>= "3.0.0"}
+  "js_of_ocaml-compiler" {>= "6.4.0" & < "7.0.0"}
+  "libbinaryen" {>= "126.0.0" & < "127.0.0"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+dev-repo: "git+https://github.com/grain-lang/binaryen.ml.git"
+url {
+  src:
+    "https://github.com/grain-lang/binaryen.ml/releases/download/v0.36.0/binaryen-archive-v0.36.0.tar.gz"
+  checksum: [
+    "md5=82de6f5c6bb9752bfdd2cb99006a44d3"
+    "sha512=089ff6934241217b65ed1e15c98dda02987d9eacd412716d7acf35a137dcda0fc980bc418368abd1348e260dfd723cf977fcd7c263b86090d27a57d515d9dbe4"
+  ]
+}
+x-maintenance-intent: ["0.(latest)"]


### PR DESCRIPTION
### `binaryen.0.36.0`
OCaml bindings for Binaryen



---
* Homepage: https://github.com/grain-lang/binaryen.ml
* Source repo: git+https://github.com/grain-lang/binaryen.ml.git
* Bug tracker: https://github.com/grain-lang/binaryen.ml/issues

---
:camel: Pull-request generated by opam-publish v2.7.1