### PR TITLE
Package tdmrep.1.0

### DIFF
--- a/packages/tdmrep/tdmrep.1.0/opam
+++ b/packages/tdmrep/tdmrep.1.0/opam
@@ -9,7 +9,7 @@ homepage: "https://tangled.org/anil.recoil.org/ocaml-tdmrep"
 bug-reports: "https://tangled.org/anil.recoil.org/ocaml-tdmrep/issues"
 depends: [
   "dune" {>= "3.23"}
-  "ocaml" {>= "4.14"}
+  "ocaml" {>= "5.2"}
   "jsont" {>= "0.2.0"}
   "uri" {>= "4.4.0"}
   "alcotest" {with-test & >= "1.9.0"}

--- a/packages/tdmrep/tdmrep.1.0/opam
+++ b/packages/tdmrep/tdmrep.1.0/opam
@@ -13,6 +13,7 @@ depends: [
   "jsont" {>= "0.2.0"}
   "uri" {>= "4.4.0"}
   "alcotest" {with-test & >= "1.9.0"}
+  "bytesrw" {with-test & >= "0.3.0"}
   "odoc" {with-doc}
 ]
 build: [

--- a/packages/tdmrep/tdmrep.1.0/opam
+++ b/packages/tdmrep/tdmrep.1.0/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+synopsis: "OCaml combinators  for the W3C TDM Reservation Protocol"
+description:
+  "Tdmrep provides Jsont codecs and typed OCaml values for Text Data Mining reservation declarations, well-known rule files, HTTP and document metadata, and TDM policies."
+maintainer: "Anil Madhavapeddy <anil@recoil.org>"
+authors: "Anil Madhavapeddy <anil@recoil.org>"
+license: "ISC"
+homepage: "https://tangled.org/anil.recoil.org/ocaml-tdmrep"
+bug-reports: "https://tangled.org/anil.recoil.org/ocaml-tdmrep/issues"
+depends: [
+  "dune" {>= "3.23"}
+  "ocaml" {>= "4.14"}
+  "jsont" {>= "0.2.0"}
+  "uri" {>= "4.4.0"}
+  "alcotest" {with-test & >= "1.9.0"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://tangled.org/anil.recoil.org/ocaml-tdmrep"
+url {
+  src:
+    "https://tangled.org/anil.recoil.org/ocaml-tdmrep/tags/893c401418dd7547fd02f17f5ebbaad8de552ee1/download/tdmrep-1.0.tbz"
+  checksum: [
+    "md5=3edc29b3956f7a55dba7fe12b897c087"
+    "sha512=33dc369bd70b67168c21c228fdd046a062e22d7a5780610dc8ff849f305d4fcdfba2e2d3d64b23fcdc4be5856ec1e562749f8475c4bb9d1ec38482f4c6382a8f"
+  ]
+}
+x-maintenance-intent: ["(latest)"]

--- a/packages/tdmrep/tdmrep.1.0/opam
+++ b/packages/tdmrep/tdmrep.1.0/opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-synopsis: "OCaml combinators  for the W3C TDM Reservation Protocol"
+synopsis: "OCaml combinators for the W3C TDM Reservation Protocol"
 description:
   "Tdmrep provides Jsont codecs and typed OCaml values for Text Data Mining reservation declarations, well-known rule files, HTTP and document metadata, and TDM policies."
 maintainer: "Anil Madhavapeddy <anil@recoil.org>"


### PR DESCRIPTION
### `tdmrep.1.0`
OCaml combinators  for the W3C TDM Reservation Protocol
Tdmrep provides Jsont codecs and typed OCaml values for Text Data Mining reservation declarations, well-known rule files, HTTP and document metadata, and TDM policies.



---
* Homepage: https://tangled.org/anil.recoil.org/ocaml-tdmrep
* Source repo: git+https://tangled.org/anil.recoil.org/ocaml-tdmrep
* Bug tracker: https://tangled.org/anil.recoil.org/ocaml-tdmrep/issues

---
:camel: Pull-request generated by opam-publish v3.0.1