### PR TITLE
Package libbinaryen.128.0.0

### DIFF
--- a/packages/libbinaryen/libbinaryen.128.0.0/opam
+++ b/packages/libbinaryen/libbinaryen.128.0.0/opam
@@ -1,0 +1,29 @@
+opam-version: "2.0"
+synopsis: "Libbinaryen packaged for OCaml"
+maintainer: "blaine@grain-lang.org"
+authors: "Blaine Bublitz"
+license: "Apache-2.0"
+homepage: "https://github.com/grain-lang/libbinaryen"
+bug-reports: "https://github.com/grain-lang/libbinaryen/issues"
+depends: [
+  "conf-cmake" {build}
+  "dune" {>= "3.0.0"}
+  "dune-configurator" {>= "3.0.0"}
+  "js_of_ocaml-compiler" {with-test & >= "6.3.0" & < "7.0.0"}
+  "ocaml" {>= "4.13"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+depexts: ["gcc-g++"] {os-distribution = "cygwinports"}
+dev-repo: "git+https://github.com/grain-lang/libbinaryen.git"
+url {
+  src:
+    "https://github.com/grain-lang/libbinaryen/releases/download/v128.0.0/libbinaryen-v128.0.0.tar.gz"
+  checksum: [
+    "md5=f8d1d24bbe7d81fcb031278bf0c1f6e3"
+    "sha512=3658ee615e189ef0007f2ec22576464fa32713fdbc8d208c33735ba92387c3699a85931bd3e5fff32475e7e2b6d5452975a3740d06d0ea1be9e8ab85aeb5218b"
+  ]
+}
+x-maintenance-intent: ["(latest)"]


### PR DESCRIPTION
### `libbinaryen.128.0.0`
Libbinaryen packaged for OCaml



---
* Homepage: https://github.com/grain-lang/libbinaryen
* Source repo: git+https://github.com/grain-lang/libbinaryen.git
* Bug tracker: https://github.com/grain-lang/libbinaryen/issues

---
:camel: Pull-request generated by opam-publish v2.7.1