### PR TITLE
[new release] hurl (0.0.1~beta3)

### DIFF
--- a/packages/hurl/hurl.0.0.1~beta3/opam
+++ b/packages/hurl/hurl.0.0.1~beta3/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+maintainer: "Robur <team@robur.coop>"
+authors: ["Robur <team@robur.coop>"]
+homepage: "https://github.com/robur-coop/hurl"
+dev-repo: "git+https://github.com/robur-coop/hurl.git"
+bug-reports: "https://github.com/robur-coop/hurl/issues"
+license: "BSD-3-clause"
+
+depends: [
+  "ocaml" {>= "5.1.0"}
+  "dune" {>= "2.8.0"}
+  "httpcats" {>= "0.3.0"}
+  "mirage-crypto-rng" {>= "1.2.0"}
+  "hxd" {>= "0.3.4"}
+  "multipart_form" {>= "0.6.0"}
+  "cmdliner" {>= "1.3.0"}
+  "jsonm"
+  "decompress" {>= "1.6.0"}
+  "bstr" {>= "0.0.2"}
+]
+conflicts: [ "result" {< "1.5"} ]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+run-test: [ "dune" "runtest" "-p" name "-j1" ]
+synopsis: "Hurl, a simple command-line HTTP client"
+x-ci-accept-failures: ["debian-11"]
+url {
+  src:
+    "https://github.com/robur-coop/hurl/releases/download/v0.0.1_beta3/hurl-0.0.1.beta3.tbz"
+  checksum: [
+    "sha256=824edaacf0e8dd91fd4efb5f151b6af11999f706108c62c1c92856dc5756f194"
+    "sha512=2bb31d861caef4697837e517d34377719be40ea538fcfad72b615dfba70630b6c14c3bd9c3ccc49556af96b29b3be4f7f2f263320cd3f362f5c5514cb2ba5a72"
+  ]
+}
+x-commit-hash: "c5af52789e0ef6c2f3aed757ec4eacb79132a899"


### PR DESCRIPTION
Hurl, a simple command-line HTTP client

- Project page: <a href="https://github.com/robur-coop/hurl">https://github.com/robur-coop/hurl</a>

##### CHANGES:

- Use `Mirage_crypto_rng_unix` instead of `Mirage_crypto_rng_miou_unix` (@hannesm, robur-coop/hurl#9)
- Upgrade our test with `decompress.1.6.0` (@dinosaure, 67a9b3e)
