### PR TITLE
[new release] httpcats (0.3.2)

### DIFF
--- a/packages/httpcats/httpcats.0.3.2/opam
+++ b/packages/httpcats/httpcats.0.3.2/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+maintainer: "Robur <team@robur.coop>"
+authors: ["Robur <team@robur.coop>"]
+homepage: "https://github.com/robur-coop/httpcats"
+dev-repo: "git+https://github.com/robur-coop/httpcats.git"
+bug-reports: "https://github.com/robur-coop/httpcats/issues"
+license: "BSD-3-clause"
+
+depends: [
+  "ocaml" {>= "5.0.0"}
+  "dune" {>= "2.8.0"}
+  "logs" {with-test}
+  "miou" {>= "0.10.0"}
+  "fmt" {>= "0.9.0" & with-test}
+  "h2" {>= "0.13.0"}
+  "h1" {>= "1.1.0"}
+  "ca-certs"
+  "bstr"
+  "tls-miou-unix" {>= "1.0.1"}
+  "dns-client-miou-unix" {>= "9.0.0"}
+  "happy-eyeballs-miou-unix"
+  "mirage-crypto-rng" {with-test & >= "1.1.0"}
+  "alcotest" {>= "1.8.0" & with-test}
+  "digestif" {with-test & >= "1.2.0"}
+]
+conflicts: [ "result" {< "1.5"} ]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+synopsis: "A simple HTTP client / server using h1, h2, and miou"
+available: [ arch != "x86_32" ]
+url {
+  src:
+    "https://github.com/robur-coop/httpcats/releases/download/v0.3.2/httpcats-0.3.2.tbz"
+  checksum: [
+    "sha256=9f4227667fbb8da0db7f759a30009d8770cf31f91f7b09a471740055f47cd6b8"
+    "sha512=9119d5664e7c318f92e05980bf9f758421e1d9e7d6ae486e730e7ddb3f3a375bf33c468cca4287f02ebee4dc68f125f18c2aa10a7399f74fa273126571488623"
+  ]
+}
+x-commit-hash: "9322cb4f03aec878fb47ab6d698fd39fcf7d1090"

--- a/packages/mhttp/mhttp.0.0.1/opam
+++ b/packages/mhttp/mhttp.0.0.1/opam
@@ -12,7 +12,7 @@ depends: [
   "mnet" {< "0.0.4"}
   "mnet-tls" {< "0.0.4"}
   "mirage-crypto-rng"
-  "httpcats" {>= "0.2.0" & < "0.3.0"}
+  "httpcats" {>= "0.2.0" & < "0.3.2"}
 ]
 build: [
   ["dune" "subst"] {dev}

--- a/packages/mhttp/mhttp.0.0.2/opam
+++ b/packages/mhttp/mhttp.0.0.2/opam
@@ -12,7 +12,7 @@ depends: [
   "mnet" {< "0.0.4"}
   "mnet-tls" {< "0.0.4"}
   "mirage-crypto-rng"
-  "httpcats" {>= "0.3.0"}
+  "httpcats" {>= "0.3.0" & < "0.3.2"}
 ]
 build: [
   ["dune" "subst"] {dev}


### PR DESCRIPTION
A simple HTTP client / server using h1, h2, and miou

- Project page: <a href="https://github.com/robur-coop/httpcats">https://github.com/robur-coop/httpcats</a>

##### CHANGES:

- Be able to avoid a cost when we are able to pass to the underlying flow a
  bigstring (@dinosaure, robur-coop/httpcats#67)
- Simplify our runtime implementation and avoid task allocations when we yield
  (@dinosaure, robur-coop/httpcats#67)
- Fix a specific issue with HTTP/1.1 and TLS (@dinosaure, robur-coop/httpcats#67)
