### PR TITLE
Package binaryen.0.37.0

### DIFF
--- a/packages/binaryen/binaryen.0.37.0/opam
+++ b/packages/binaryen/binaryen.0.37.0/opam
@@ -1,0 +1,28 @@
+opam-version: "2.0"
+synopsis: "OCaml bindings for Binaryen"
+maintainer: "oscar@grain-lang.org"
+authors: "Oscar Spencer"
+license: " Apache-2.0"
+homepage: "https://github.com/grain-lang/binaryen.ml"
+bug-reports: "https://github.com/grain-lang/binaryen.ml/issues"
+depends: [
+  "ocaml" {>= "4.13.0"}
+  "dune" {>= "3.0.0"}
+  "dune-configurator" {>= "3.0.0"}
+  "js_of_ocaml-compiler" {>= "6.4.0" & < "7.0.0"}
+  "libbinaryen" {>= "127.0.0" & < "128.0.0"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+dev-repo: "git+https://github.com/grain-lang/binaryen.ml.git"
+url {
+  src:
+    "https://github.com/grain-lang/binaryen.ml/releases/download/v0.37.0/binaryen-archive-v0.37.0.tar.gz"
+  checksum: [
+    "md5=a7c6a7f9ecab7d6685a84011b06fb478"
+    "sha512=49a04b94499802b481175cd6cc7333d0427c1c06392856e7f1609323f197afbdda87858470283b474d02e0b49aaa6e6569a4413304ecb524959c24da54c89004"
+  ]
+}
+x-maintenance-intent: ["0.(latest)"]


### PR DESCRIPTION
### `binaryen.0.37.0`
OCaml bindings for Binaryen



---
* Homepage: https://github.com/grain-lang/binaryen.ml
* Source repo: git+https://github.com/grain-lang/binaryen.ml.git
* Bug tracker: https://github.com/grain-lang/binaryen.ml/issues

---
:camel: Pull-request generated by opam-publish v2.7.1