### PR TITLE
[new release] reanalyze (2.26.0)

### DIFF
--- a/packages/reanalyze/reanalyze.2.26.0/opam
+++ b/packages/reanalyze/reanalyze.2.26.0/opam
@@ -1,0 +1,38 @@
+opam-version: "2.0"
+synopsis: "Dead values/types, exception, and termination analysis for OCaml"
+description: """
+Experimental analyses for OCaml: for globally dead values/types, exception analysis, and termination analysis.
+"""
+maintainer: ["Cristiano Calcagno"]
+authors: ["Cristiano Calcagno"]
+license: "MIT"
+homepage: "https://github.com/rescript-lang/reanalyze"
+bug-reports: "https://github.com/rescript-lang/reanalyze/issues"
+depends: [
+  "dune" {>= "2.0"}
+  "ocaml" {>= "4.08.0" & < "5.6"}
+  "cppo" {build}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/rescript-lang/reanalyze.git"
+url {
+  src:
+    "https://github.com/rescript-lang/reanalyze/archive/refs/tags/v2.26.0.tar.gz"
+  checksum: [
+    "md5=56ddbd3bc03286f985303db7c3041b0f"
+    "sha512=4d72940bc6adf02d15559a7c2d588f51bbcbf1226876b2e98b40b8b9e9b0caa7b4d46bb064501b8847f8b7a998796d56e009493055037800f637d709416376cc"
+  ]
+}


### PR DESCRIPTION
Adds reanalyze 2.26.0.

Changes since 2.25.1:

- Support for OCaml 5.3, 5.4 and 5.5. The previous release was constrained to `ocaml < 5.3`, so reanalyze could not be installed on any recent switch; this release widens the bound to `< 5.6`.
- The repository moved to `rescript-lang/reanalyze`, so `homepage`, `bug-reports` and `dev-repo` are updated. The former `rescript-association` URLs still redirect.
- The package is now described as an OCaml-only analyzer. ReScript-specific development continues in the ReScript monorepo.

Upstream CI builds and tests this release on 4.14, 5.0, 5.1, 5.2, 5.3, 5.4 and 5.5. Note that the `>= 4.08.0` lower bound is inherited from earlier releases and is no longer covered by upstream CI, whose matrix starts at 4.14.

I also verified locally that the release tarball builds standalone with `dune build -p reanalyze @install`.
