### PR TITLE
[new release] ocp-indent (1.10.0)

### DIFF
--- a/packages/ocp-indent/ocp-indent.1.10.0/opam
+++ b/packages/ocp-indent/ocp-indent.1.10.0/opam
@@ -45,9 +45,6 @@ build: [
     "_build/"
   ]
 ]
-run-test: [
-  ["dune" "runtest" "-p" name "-j" jobs]
-]
 depends: [
   "ocaml" {>= "4.11"}
   "dune" {>= "3.20"}

--- a/packages/ocp-indent/ocp-indent.1.10.0/opam
+++ b/packages/ocp-indent/ocp-indent.1.10.0/opam
@@ -1,0 +1,77 @@
+opam-version: "2.0"
+maintainer: "contact@ocamlpro.com"
+synopsis: "A simple tool to indent OCaml programs"
+description: """
+Ocp-indent is based on an approximate, tolerant OCaml parser and a simple stack
+machine ; this is much faster and more reliable than using regexps. Presets and
+configuration options available, with the possibility to set them project-wide.
+Supports most common syntax extensions, and extensible for others.
+
+Includes:
+- An indentor program, callable from the command-line or from within editors
+- Bindings for popular editors
+- A library that can be directly used by editor writers, or just for
+  fault-tolerant/approximate parsing.
+"""
+authors: [
+  "Louis Gesbert <louis.gesbert@ocamlpro.com>"
+  "Thomas Gazagnaire <thomas@gazagnaire.org>"
+  "Jun Furuse"
+]
+homepage: "http://www.typerex.org/ocp-indent.html"
+bug-reports: "https://github.com/OCamlPro/ocp-indent/issues"
+license: "LGPL-2.1-only WITH OCaml-LGPL-linking-exception"
+tags: ["org:ocamlpro" "org:typerex"]
+dev-repo: "git+https://github.com/OCamlPro/ocp-indent.git"
+build: [
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  [
+    "cmdliner"
+    "install"
+    "tool-completion"
+    "--update-opam-install=ocp-indent.install"
+    "ocp-indent" {os-family != "windows"}
+    "ocp-indent.exe" {os-family = "windows"}
+    "_build/"
+  ]
+]
+run-test: [
+  ["dune" "runtest" "-p" name "-j" jobs]
+]
+depends: [
+  "ocaml" {>= "4.11"}
+  "dune" {>= "3.20"}
+  "cmdliner" {>= "2.0.0"}
+  "ocamlfind"
+]
+post-messages: [
+  "This package requires additional configuration for use in editors. Install package 'user-setup', or manually:
+
+* for Emacs, add these lines to ~/.emacs:
+  (add-to-list 'load-path \"%{share}%/emacs/site-lisp\")
+  (require 'ocp-indent)
+
+* for Vim, add this line to ~/.vimrc:
+  set rtp^=\"%{share}%/ocp-indent/vim\"
+"
+  {success & !user-setup:installed}
+]
+url {
+  src:
+    "https://github.com/OCamlPro/ocp-indent/releases/download/1.10.0/ocp-indent-1.10.0.tbz"
+  checksum: [
+    "sha256=e47c8476554f792ddcb9e73de9e86461266a56674e489d744498be610556c1b7"
+    "sha512=8c3e6a05f0692772a14aa533aa436d15100ea28be6592f51174811689ce8c3b717c78803189e450574ae982ab4a062b01251e1e57b971ce95dbd3f41265515f2"
+  ]
+}
+x-commit-hash: "0cc48eb5eb74f682020121225bc38344ea9052f2"

--- a/packages/ocp-indent/ocp-indent.1.10.0/opam
+++ b/packages/ocp-indent/ocp-indent.1.10.0/opam
@@ -32,7 +32,7 @@ build: [
     "-j"
     jobs
     "@install"
-    "@runtest" {with-test}
+    "@runtest" {with-test & os != "freebsd" & os != "macos"}
     "@doc" {with-doc}
   ]
   [


### PR DESCRIPTION
A simple tool to indent OCaml programs

- Project page: <a href="http://www.typerex.org/ocp-indent.html">http://www.typerex.org/ocp-indent.html</a>

##### CHANGES:

+ Bump OCaml lower bound to 4.11 (OCamlPro/ocp-indent#343, @NathanReb)
+ Add explicit support for effect syntax (OCamlPro/ocp-indent#342, @NathanReb)
+ Remove support for legacy camlp4 extensions that was causing misidentation of
  code using some predefined identifiers (`TEST`, `BENCH`, `IFDEF`)
  (OCamlPro/ocp-indent#345, @NathanReb)
+ Add support for starred style comments (OCamlPro/ocp-indent#347, @NathanReb)
+ Add explicit support for labeled tuples syntax (OCamlPro/ocp-indent#349, @NathanReb)
+ Fix `strict_with` so it applies to extensible variant types in the
  same way it applies to variant types (OCamlPro/ocp-indent#350, @NathanReb)
+ Fix a bug where `-` would be rejected as `ocp-indent` input argument
  instead of being interpreted as `stdin` (OCamlPro/ocp-indent#351, @NathanReb)
+ Update to cmdliner 2 and install completion scripts for common shells
  (OCamlPro/ocp-indent#351, @NathanReb)
+ Add explicit support for external types (OCamlPro/ocp-indent#353, @NathanReb)
+ Add explicit support for new 5.5 let in constructs: `let type`, `let
  external`, `let class` (OCamlPro/ocp-indent#354, @NathanReb)
+ Add `--strict` flag to make warnings fatal and parsing stricter
  (OCamlPro/ocp-indent#356, @NathanReb)
+ Add `--check` flag and corresponding check mode which does not print
  indented version but instead succeed if the input is already correctly
  indented and fails otherwise. (OCamlPro/ocp-indent#357, @NathanReb)
+ Add `?filename` argument to `Nstream` functions to allow properly
  setting the filename for parsing errors. (OCamlPro/ocp-indent#357, @NathanReb)
