### PR TITLE
[new release] mhttp (3 packages) (0.0.3)

### DIFF
--- a/packages/mhttp-client/mhttp-client.0.0.3/opam
+++ b/packages/mhttp-client/mhttp-client.0.0.3/opam
@@ -1,0 +1,32 @@
+opam-version: "2.0"
+maintainer: "Robur <team@robur.coop>"
+authors: ["Robur <team@robur.coop>"]
+homepage: "https://github.com/robur-coop/mhttp"
+dev-repo: "git+https://github.com/robur-coop/mhttp.git"
+bug-reports: "https://github.com/robur-coop/mhttp/issues"
+license: "MIT"
+
+depends: [
+  "ocaml" {>= "5.0.0"}
+  "dune" {>= "2.7.0"}
+  "mhttp" {= version}
+  "mnet-happy-eyeballs"
+  "mirage-ptime" {>= "5.2.0"}
+  "ca-certs-nss" {>= "3.118"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+synopsis: "An implementation of HTTP client in OCaml for unikernels"
+url {
+  src:
+    "https://github.com/robur-coop/mhttp/releases/download/v0.0.3/mhttp-0.0.3.tbz"
+  checksum: [
+    "sha256=4df663a0fa7add9fc41eb51ec618fd0ad083b195f2965ca325175789baef5509"
+    "sha512=54cf201e76a554e9ab497a418c14211d9906deabd188edd44a47a11323274544e50d6ecc77661b891689524339343e993d5785647f251a670dfd613238c90d89"
+  ]
+}
+x-commit-hash: "b148f49f80c6dd16231b2385caf46bc53868f0f1"

--- a/packages/mhttp-server/mhttp-server.0.0.3/opam
+++ b/packages/mhttp-server/mhttp-server.0.0.3/opam
@@ -1,0 +1,30 @@
+opam-version: "2.0"
+maintainer: "Robur <team@robur.coop>"
+authors: ["Robur <team@robur.coop>"]
+homepage: "https://github.com/robur-coop/mhttp"
+dev-repo: "git+https://github.com/robur-coop/mhttp.git"
+bug-reports: "https://github.com/robur-coop/mhttp/issues"
+license: "MIT"
+
+depends: [
+  "ocaml" {>= "5.0.0"}
+  "dune" {>= "2.7.0"}
+  "mhttp" {= version}
+  "mnet-tls"
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+synopsis: "An implementation of an HTTP server in OCaml for unikernels"
+url {
+  src:
+    "https://github.com/robur-coop/mhttp/releases/download/v0.0.3/mhttp-0.0.3.tbz"
+  checksum: [
+    "sha256=4df663a0fa7add9fc41eb51ec618fd0ad083b195f2965ca325175789baef5509"
+    "sha512=54cf201e76a554e9ab497a418c14211d9906deabd188edd44a47a11323274544e50d6ecc77661b891689524339343e993d5785647f251a670dfd613238c90d89"
+  ]
+}
+x-commit-hash: "b148f49f80c6dd16231b2385caf46bc53868f0f1"

--- a/packages/mhttp/mhttp.0.0.3/opam
+++ b/packages/mhttp/mhttp.0.0.3/opam
@@ -1,0 +1,33 @@
+opam-version: "2.0"
+maintainer: "Robur <team@robur.coop>"
+authors: ["Robur <team@robur.coop>"]
+homepage: "https://github.com/robur-coop/mhttp"
+dev-repo: "git+https://github.com/robur-coop/mhttp.git"
+bug-reports: "https://github.com/robur-coop/mhttp/issues"
+license: "MIT"
+
+depends: [
+  "ocaml" {>= "5.0.0"}
+  "dune" {>= "2.7.0"}
+  "mnet" {>= "0.0.6"}
+  "mnet-tls"
+  "mkernel" {>= "0.0.4"}
+  "mirage-crypto-rng"
+  "httpcats" {>= "0.3.2"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+synopsis: "An implementation of HTTP in OCaml for unikernels"
+url {
+  src:
+    "https://github.com/robur-coop/mhttp/releases/download/v0.0.3/mhttp-0.0.3.tbz"
+  checksum: [
+    "sha256=4df663a0fa7add9fc41eb51ec618fd0ad083b195f2965ca325175789baef5509"
+    "sha512=54cf201e76a554e9ab497a418c14211d9906deabd188edd44a47a11323274544e50d6ecc77661b891689524339343e993d5785647f251a670dfd613238c90d89"
+  ]
+}
+x-commit-hash: "b148f49f80c6dd16231b2385caf46bc53868f0f1"

--- a/packages/vifu/vifu.0.0.1~beta2/opam
+++ b/packages/vifu/vifu.0.0.1~beta2/opam
@@ -10,6 +10,7 @@ depends: [
   "ocaml" {>= "5.3.0"}
   "dune" {>= "3.0.0"}
   "vif" {= version}
+  "mnet" {< "0.0.5"}
   "mhttp"
   "mhttp-server"
   "mirage-crypto-rng-mkernel"

--- a/packages/vifu/vifu.0.0.1~beta3/opam
+++ b/packages/vifu/vifu.0.0.1~beta3/opam
@@ -10,6 +10,7 @@ depends: [
   "ocaml" {>= "5.3.0"}
   "dune" {>= "3.0.0"}
   "vif" {= version}
+  "mnet" {< "0.0.5"}
   "mhttp" {>= "0.0.2"}
   "mhttp-server"
   "mirage-crypto-rng-mkernel"

--- a/packages/vifu/vifu.0.0.1~beta4/opam
+++ b/packages/vifu/vifu.0.0.1~beta4/opam
@@ -10,6 +10,7 @@ depends: [
   "ocaml" {>= "5.3.0"}
   "dune" {>= "3.0.0"}
   "vif" {= version}
+  "mnet" {< "0.0.5"}
   "mhttp" {>= "0.0.2"}
   "mhttp-server"
   "mirage-crypto-rng-mkernel"


### PR DESCRIPTION
An implementation of HTTP in OCaml for unikernels

- Project page: <a href="https://github.com/robur-coop/mhttp">https://github.com/robur-coop/mhttp</a>

##### CHANGES:

- Upgrade to `httpcats.0.3.2` and `mnet.0.0.6` (@dinosaure, robur-coop/mhttp#6, robur-coop/mhttp#7)
