### PR TITLE
[new release] realdentalcosts (0.1.0)

### DIFF
--- a/packages/realdentalcosts/realdentalcosts.0.1.0/opam
+++ b/packages/realdentalcosts/realdentalcosts.0.1.0/opam
@@ -1,0 +1,45 @@
+opam-version: "2.0"
+synopsis:
+  "Client helpers for the Real Dental Costs open data API (U.S. dental prices by state, Medicaid paid per CDT code)"
+description: """
+Stdlib-only OCaml helpers for the free, no-key Real Dental Costs open data
+API: U.S. dental procedure cash prices by state and what Medicaid actually
+paid dentists per CDT code (HHS/CMS T-MSIS claims, 2018-2024). This library
+builds request URLs, validates CDT procedure codes, and lists the known
+procedure slugs and API endpoints -- it performs no HTTP itself, so any HTTP
+client can be layered on top. See https://realdentalcosts.com/en/api/ for
+the endpoint reference and https://realdentalcosts.com/en/methodology/ for
+data provenance and limits."""
+maintainer: ["research@realdentalcosts.com"]
+authors: ["Real Dental Costs Data & Research Team <research@realdentalcosts.com>"]
+license: "MIT"
+homepage: "https://realdentalcosts.com/en/api/"
+bug-reports: "https://github.com/shoopeur-eng/realdentalcosts-ocaml/issues"
+depends: [
+  "ocaml" {>= "4.08"}
+  "dune" {>= "3.0"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/shoopeur-eng/realdentalcosts-ocaml.git"
+url {
+  src:
+    "https://github.com/shoopeur-eng/realdentalcosts-ocaml/archive/refs/tags/0.1.0.tar.gz"
+  checksum: [
+    "sha256=398d70399ed3beae312d87185b07403377cf024cef78951c96e885bac51ec8c7"
+    "sha512=7d326b5e6239aa54a9c29ecc8e0790129fcb18a85cf31db89cd593a2af204f24705e07343296be37a9f8a0f8c4d1aa4c14cf88ed48526925ac5841a7b1f6b663"
+  ]
+}


### PR DESCRIPTION
Stdlib-only OCaml URL helpers for the free, no-key Real Dental Costs open data API: U.S. dental procedure cash prices by state and what Medicaid actually paid dentists per CDT code (HHS/CMS T-MSIS claims, 2018-2024).
This library performs no HTTP -- it only builds request URLs, validates CDT codes, and lists known endpoints/procedure slugs, so it has no dependency beyond the OCaml stdlib and dune.
Homepage / API docs: https://realdentalcosts.com/en/api/