### PR TITLE
[new release] vif (2 packages) (0.0.1~beta5)

### DIFF
--- a/packages/vif/vif.0.0.1~beta5/opam
+++ b/packages/vif/vif.0.0.1~beta5/opam
@@ -44,7 +44,7 @@ run-test: [
   [ "dune" "runtest" "-p" name "-j1" ] {arch != "s390x"}
 ]
 synopsis: "A simple web framework for OCaml 5"
-x-ci-accept-failures: ["debian-11"]
+x-ci-accept-failures: ["macos-homebrew"]
 url {
   src:
     "https://github.com/robur-coop/vif/releases/download/v0.0.1_beta5/vif-0.0.1.beta5.tbz"

--- a/packages/vif/vif.0.0.1~beta5/opam
+++ b/packages/vif/vif.0.0.1~beta5/opam
@@ -1,0 +1,56 @@
+opam-version: "2.0"
+maintainer: "Robur <team@robur.coop>"
+authors: ["Robur <team@robur.coop>"]
+homepage: "https://github.com/robur-coop/vif"
+dev-repo: "git+https://github.com/robur-coop/vif.git"
+bug-reports: "https://github.com/robur-coop/vif/issues"
+license: "MIT"
+
+depends: [
+  "ocaml" {>= "5.3.0"}
+  "dune" {>= "3.0.0"}
+  "uri" {>= "4.4.0"}
+  "fmt" {>= "0.11.0"}
+  "bos" {>= "0.2.1"}
+  "logs" {>= "0.9.0"}
+  "fpath" {>= "0.7.3"}
+  "bytesrw"
+  "flux" {>= "0.0.1~beta5"}
+  "fluxt" {>= "0.0.1~beta2"}
+  "jsont" {>= "0.2.0"}
+  "cmdliner" {>= "1.3.0"}
+  "httpcats" {>= "0.3.0"}
+  "tyre" {>= "1.0"}
+  "mirage-crypto-rng" {>= "1.2.0"}
+  "decompress" {>= "1.6.0"}
+  "conan-unix" {>= "0.0.6"}
+  "conan-database"
+  "multipart_form-miou"
+  "hmap"
+  "tyxml" {>= "4.6.0"}
+  "hurl" {>= "0.0.1~beta2" & with-test}
+  "jws" {with-test}
+  "caqti" {with-test & >= "3.0.0"}
+  "caqti-miou" {with-test}
+  "caqti-driver-sqlite3" {with-test}
+  "brr" {with-test}
+]
+conflicts: [ "result" {< "1.5"} ]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+run-test: [
+  [ "dune" "runtest" "-p" name "-j1" ] {arch != "s390x"}
+]
+synopsis: "A simple web framework for OCaml 5"
+x-ci-accept-failures: ["debian-11"]
+url {
+  src:
+    "https://github.com/robur-coop/vif/releases/download/v0.0.1_beta5/vif-0.0.1.beta5.tbz"
+  checksum: [
+    "sha256=f2dafa4f12105d85b4dc2d1e1492f03e809c85d5834dc5694b99226418fe2719"
+    "sha512=1e2087db43e8e13bfc240c1114790ceb702b941d389bbb94a7a18668e65f61d2224f05038cf9101ede890581b0e2227e4d2bd2c620f312fa18c8e37482e273c4"
+  ]
+}
+x-commit-hash: "8736242c6a4d9261b8661e6994a1af0e0877be3f"

--- a/packages/vifu/vifu.0.0.1~beta5/opam
+++ b/packages/vifu/vifu.0.0.1~beta5/opam
@@ -1,0 +1,35 @@
+opam-version: "2.0"
+maintainer: "Robur <team@robur.coop>"
+authors: ["Robur <team@robur.coop>"]
+homepage: "https://github.com/robur-coop/vif"
+dev-repo: "git+https://github.com/robur-coop/vif.git"
+bug-reports: "https://github.com/robur-coop/vif/issues"
+license: "MIT"
+
+depends: [
+  "ocaml" {>= "5.3.0"}
+  "dune" {>= "3.0.0"}
+  "vif" {= version}
+  "mhttp" {>= "0.0.3"}
+  "mhttp-server"
+  "mirage-crypto-rng-mkernel"
+]
+conflicts: [ "result" {< "1.5"} ]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+run-test: [
+  [ "dune" "runtest" "-p" name "-j1" ] {arch != "s390x"}
+]
+synopsis: "A simple web framework for OCaml 5"
+x-ci-accept-failures: ["debian-11"]
+url {
+  src:
+    "https://github.com/robur-coop/vif/releases/download/v0.0.1_beta5/vif-0.0.1.beta5.tbz"
+  checksum: [
+    "sha256=f2dafa4f12105d85b4dc2d1e1492f03e809c85d5834dc5694b99226418fe2719"
+    "sha512=1e2087db43e8e13bfc240c1114790ceb702b941d389bbb94a7a18668e65f61d2224f05038cf9101ede890581b0e2227e4d2bd2c620f312fa18c8e37482e273c4"
+  ]
+}
+x-commit-hash: "8736242c6a4d9261b8661e6994a1af0e0877be3f"


### PR DESCRIPTION
A simple web framework for OCaml 5

- Project page: <a href="https://github.com/robur-coop/vif">https://github.com/robur-coop/vif</a>

##### CHANGES:

- Fix `ETag` (@reynir, [!75][75])
- Fix how we manipulate the target on our handlers (@dinosaure, [!76][76])
- Upgrade to mhttp.0.0.3 (@dinosaure, [!77][77])
- Add `Vif{,u}.Route.query` (@dinosaure, [!65][65])

[65]: https://git.robur.coop/robur/vif/pulls/65
[75]: https://git.robur.coop/robur/vif/pulls/75
[76]: https://git.robur.coop/robur/vif/pulls/76
[77]: https://git.robur.coop/robur/vif/pulls/77
