### PR TITLE
[new release] jose (0.11.0)

### DIFF
--- a/packages/jose/jose.0.11.0/opam
+++ b/packages/jose/jose.0.11.0/opam
@@ -1,0 +1,57 @@
+opam-version: "2.0"
+synopsis: "JOSE implementation for OCaml and ReasonML"
+description:
+  "JavaScript Object Signing and Encryption built ontop of pure OCaml libs"
+maintainer: [
+  "Ulrik Strid <ulrik.strid@outlook.com>"
+  "Antonio Nuno Monteiro <anmonteiro@gmail.com>"
+]
+authors: ["Ulrik Strid"]
+license: "MIT"
+homepage: "https://ulrikstrid.github.io/ocaml-jose"
+doc: "https://ulrikstrid.github.io/ocaml-jose"
+bug-reports: "https://github.com/ulrikstrid/ocaml-jose/issues"
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "base64" {>= "3.3.0"}
+  "dune" {>= "2.8"}
+  "eqaf" {>= "0.7"}
+  "mirage-crypto" {>= "1.0.0"}
+  "x509" {>= "0.13.0"}
+  "astring"
+  "yojson" {>= "1.6.0"}
+  "zarith"
+  "ptime"
+  "mirage-crypto-rng" {with-test & >= "1.0.0"}
+  "digestif"
+  "containers" {with-test}
+  "bisect_ppx" {with-test}
+  "alcotest" {with-test}
+  "junit" {with-test}
+  "junit_alcotest" {with-test}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/ulrikstrid/ocaml-jose.git"
+url {
+  src:
+    "https://github.com/ulrikstrid/ocaml-jose/releases/download/0.11.0/jose-0.11.0.tbz"
+  checksum: [
+    "sha256=7e0d072c86f971a270ee9d642fa4d8ccf2e28e1768aa56eb9b736fa140414174"
+    "sha512=b6e78ff643479070136f65eb69703aae9c24a1ba3aaeedb065ddc0d4b39229ecc62396e9aa4a08e68bbe95cad256fe33a260f9dd515b680083a3a7a2757ba558"
+  ]
+}
+x-commit-hash: "a4a060bf4888d858566b798397815440e0c426c9"


### PR DESCRIPTION
JOSE implementation for OCaml and ReasonML

- Project page: <a href="https://ulrikstrid.github.io/ocaml-jose">https://ulrikstrid.github.io/ocaml-jose</a>
- Documentation: <a href="https://ulrikstrid.github.io/ocaml-jose">https://ulrikstrid.github.io/ocaml-jose</a>

##### CHANGES:

- Add `kid` to output ed25519 json representation as this was missed when implementing it. Reported by @patricoferris, fixed by @ulrikstrid.
- Correct IV length `enc` is A256GCM
- We had some potential for raising in our unpad function
- Constant time string comparison everywhere
- Fix a bug in RSA validation
- EdDSA is deprecated in rfc 9864, we should use Ed25519 as a less ambiguous name
