### PR TITLE
[new release] bstr (3 packages) (0.1.0)

### DIFF
--- a/packages/bin/bin.0.1.0/opam
+++ b/packages/bin/bin.0.1.0/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+maintainer:   [ "Romain Calascibetta <romain.calascibetta@gmail.com>" ]
+authors:      [ "Romain Calascibetta <romain.calascibetta@gmail.com>" ]
+homepage:     "https://git.robur.coop/robur/bstr"
+bug-reports:  "https://git.robur.coop/robur/bstr"
+dev-repo:     "git+https://github.com/robur-coop/bstr"
+doc:          "https://robur-coop.github.io/bstr/"
+license:      "MIT"
+synopsis:     "A DSL to describe binary formats"
+
+build: [ "dune" "build" "-p" name "-j" jobs ]
+run-test: [ "dune" "runtest" "-p" name "-j" jobs ]
+
+depends: [
+  "ocaml"         {>= "4.14.0"}
+  "dune"          {>= "3.5.0"}
+  "bstr"          {= version}
+  "crowbar"       {>= "0.2.2" & with-test}
+  "wire"          {= "1.3.0" & with-dev-setup}
+  "repr"          {with-dev-setup}
+  "data-encoding" {with-dev-setup}
+  "angstrom"      {with-dev-setup}
+  "faraday"       {with-dev-setup}
+  "cstruct"       {with-dev-setup}
+  "bechamel"      {with-dev-setup}
+  "bechamel-js"   {with-dev-setup}
+]
+x-maintenance-intent: [ "(latest)" ]
+url {
+  src:
+    "https://github.com/robur-coop/bstr/releases/download/v0.1.0/bstr-0.1.0.tbz"
+  checksum: [
+    "sha256=4a9073caf8c5eb502e002a54910b1477300f1bc27aadfa286370e336ade3ba8e"
+    "sha512=510478a62438caffa6eece71938bc4eb24305ed31743ab1389ec9951e85a22242c1392bf4872051497e7be80613c7a68e9c8cb74e4ed36c106e8fa0f5d24181c"
+  ]
+}
+x-commit-hash: "9172bf084c346111979fe1d33d905789d6821fb5"

--- a/packages/bstr/bstr.0.1.0/opam
+++ b/packages/bstr/bstr.0.1.0/opam
@@ -1,0 +1,27 @@
+opam-version: "2.0"
+maintainer:   [ "Romain Calascibetta <romain.calascibetta@gmail.com>" ]
+authors:      [ "Romain Calascibetta <romain.calascibetta@gmail.com>" ]
+homepage:     "https://git.robur.coop/robur/bstr"
+bug-reports:  "https://git.robur.coop/robur/bstr"
+dev-repo:     "git+https://github.com/robur-coop/bstr"
+doc:          "https://robur-coop.github.io/bstr/"
+license:      "MIT"
+synopsis:     "A simple library for bigstrings"
+
+build: [ "dune" "build" "-p" name "-j" jobs ]
+run-test: [ "dune" "runtest" "-p" name "-j" jobs ]
+
+depends: [
+  "ocaml"       {>= "4.14.0"}
+  "dune"        {>= "3.5.0"}
+]
+x-maintenance-intent: [ "(latest)" ]
+url {
+  src:
+    "https://github.com/robur-coop/bstr/releases/download/v0.1.0/bstr-0.1.0.tbz"
+  checksum: [
+    "sha256=4a9073caf8c5eb502e002a54910b1477300f1bc27aadfa286370e336ade3ba8e"
+    "sha512=510478a62438caffa6eece71938bc4eb24305ed31743ab1389ec9951e85a22242c1392bf4872051497e7be80613c7a68e9c8cb74e4ed36c106e8fa0f5d24181c"
+  ]
+}
+x-commit-hash: "9172bf084c346111979fe1d33d905789d6821fb5"

--- a/packages/slice/slice.0.1.0/opam
+++ b/packages/slice/slice.0.1.0/opam
@@ -1,0 +1,28 @@
+opam-version: "2.0"
+maintainer:   [ "Romain Calascibetta <romain.calascibetta@gmail.com>" ]
+authors:      [ "Romain Calascibetta <romain.calascibetta@gmail.com>" ]
+homepage:     "https://git.robur.coop/robur/bstr"
+bug-reports:  "https://git.robur.coop/robur/bstr"
+dev-repo:     "git+https://github.com/robur-coop/bstr"
+doc:          "https://robur-coop.github.io/bstr/"
+license:      "MIT"
+synopsis:     "A Slice type for bigstrings and bytes"
+
+build: [ "dune" "build" "-p" name "-j" jobs ]
+run-test: [ "dune" "runtest" "-p" name "-j" jobs ]
+
+depends: [
+  "ocaml"       {>= "4.14.0"}
+  "dune"        {>= "3.5.0"}
+  "bstr"        {= version}
+]
+x-maintenance-intent: [ "(latest)" ]
+url {
+  src:
+    "https://github.com/robur-coop/bstr/releases/download/v0.1.0/bstr-0.1.0.tbz"
+  checksum: [
+    "sha256=4a9073caf8c5eb502e002a54910b1477300f1bc27aadfa286370e336ade3ba8e"
+    "sha512=510478a62438caffa6eece71938bc4eb24305ed31743ab1389ec9951e85a22242c1392bf4872051497e7be80613c7a68e9c8cb74e4ed36c106e8fa0f5d24181c"
+  ]
+}
+x-commit-hash: "9172bf084c346111979fe1d33d905789d6821fb5"


### PR DESCRIPTION
A simple library for bigstrings

- Project page: <a href="https://git.robur.coop/robur/bstr">https://git.robur.coop/robur/bstr</a>
- Documentation: <a href="https://robur-coop.github.io/bstr/">https://robur-coop.github.io/bstr/</a>

##### CHANGES:

- Add unsafe access to bigstrings (@dinosaure, [robur-coop/bstr#13][13])
- Use warning names instead of numbers (@hannesm, [robur-coop/bstr#14][14])
- Improve our slice library (@dinosaure, [robur-coop/bstr#18][18])
- Improve our bin library (@dinosaure, [robur-coop/bstr#16][16] & [robur-coop/bstr#17][17])

[13]: https://git.robur.coop/robur/bstr/pulls/13
[14]: https://git.robur.coop/robur/bstr/pulls/14
[18]: https://git.robur.coop/robur/bstr/pulls/18
[16]: https://git.robur.coop/robur/bstr/pulls/16
[17]: https://git.robur.coop/robur/bstr/pulls/17
