### PR TITLE
2 packages from rocq-prover/vsrocq at 2.5.0

### DIFF
--- a/packages/vscoq-language-server/vscoq-language-server.2.5.0/opam
+++ b/packages/vscoq-language-server/vscoq-language-server.2.5.0/opam
@@ -1,0 +1,21 @@
+opam-version: "2.0"
+maintainer: "Enrico Tassi <enrico.tassi@inria.fr>"
+authors: [ "Enrico Tassi" "Maxime Dénès" "Romain Tetley" ]
+license: "MIT"
+homepage: "https://github.com/rocq-prover/vsrocq"
+bug-reports: "https://github.com/rocq-prover/vsrocq/issues"
+dev-repo: "git+https://github.com/rocq-prover/vsrocq"
+depends: [
+  "vsrocq-language-server" {= version}
+]
+synopsis: "Compatibility meta package for the VsRocq language server after the Rocq renaming"
+available: arch != "arm32" & arch != "x86_32"
+x-maintenance-intent: ["(latest)"]
+url {
+  src:
+    "https://github.com/rocq-prover/vsrocq/releases/download/v2.5.0/vsrocq-language-server-2.5.0.tar.gz"
+  checksum: [
+    "md5=15c22fee2131c4b3dae4258e8a4484f6"
+    "sha512=b5ab3eea5bb6af643d635781e741a7a7b217fcc33e84c2c9e3448962118a63e174569ef6069c50af2ab57508d5cef476a8cfade14957a9654b1fea16c29a08b9"
+  ]
+}

--- a/packages/vsrocq-language-server/vsrocq-language-server.2.5.0/opam
+++ b/packages/vsrocq-language-server/vsrocq-language-server.2.5.0/opam
@@ -1,0 +1,53 @@
+opam-version: "2.0"
+maintainer: "Enrico Tassi <enrico.tassi@inria.fr>"
+authors: [ "Enrico Tassi" "Maxime Dénès" "Romain Tetley" ]
+license: "MIT"
+homepage: "https://github.com/rocq-prover/vsrocq"
+bug-reports: "https://github.com/rocq-prover/vsrocq/issues"
+dev-repo: "git+https://github.com/rocq-prover/vsrocq"
+
+build: [
+  [make "dune-files"]
+  [ "dune" "build" "-p" name "-j" jobs ]
+]
+depends: [
+  "ocaml" { >= "4.14" }
+  "dune" { >= "3.5" }
+  (("coq-core" { ((>= "8.18" < "8.21")) }
+    "coq-stdlib" { ((>= "8.18" < "8.21")) })
+  | "rocq-core" { ((>= "9.0+rc1" < "9.4~") | (= "dev")) } )
+  "yojson"
+  "jsonrpc" { >= "1.15"}
+  "ocamlfind"
+  "ppx_inline_test" { with-test }
+  "ppx_assert" { with-test }
+  "ppx_blob" { with-test }
+  "ppx_sexp_conv"
+  "ppx_deriving"
+  "sexplib"
+  "bechamel" { with-test }
+  "ppx_yojson_conv"
+  "ppx_import"
+  "ppx_optcomp"
+  "memprof-limits"
+  "result" { >= "1.5" }
+  "lsp" { >= "1.15"}
+  "sel" {>= "0.6.0"}
+]
+conflicts: [
+    "vscoq-language-server" {< "2.2.7~"}
+]
+synopsis: "VSRocq language server"
+available: arch != "arm32" & arch != "x86_32"
+description: """
+LSP based language server for Rocq and its VSRocq user interface
+"""
+x-maintenance-intent: ["(latest)"]
+url {
+  src:
+    "https://github.com/rocq-prover/vsrocq/releases/download/v2.5.0/vsrocq-language-server-2.5.0.tar.gz"
+  checksum: [
+    "md5=15c22fee2131c4b3dae4258e8a4484f6"
+    "sha512=b5ab3eea5bb6af643d635781e741a7a7b217fcc33e84c2c9e3448962118a63e174569ef6069c50af2ab57508d5cef476a8cfade14957a9654b1fea16c29a08b9"
+  ]
+}


### PR DESCRIPTION
This pull-request concerns:
- `vscoq-language-server.2.5.0`: Compatibility meta package for the VsRocq language server after the Rocq renaming
- `vsrocq-language-server.2.5.0`: VSRocq language server



---
* Homepage: https://github.com/rocq-prover/vsrocq
* Source repo: git+https://github.com/rocq-prover/vsrocq
* Bug tracker: https://github.com/rocq-prover/vsrocq/issues

---
:camel: Pull-request generated by opam-publish v2.5.0