### PR TITLE
[new release] modelkit (4 packages) (0.4.1)

### DIFF
--- a/packages/modelkit-nx/modelkit-nx.0.4.1/opam
+++ b/packages/modelkit-nx/modelkit-nx.0.4.1/opam
@@ -1,0 +1,44 @@
+opam-version: "2.0"
+synopsis: "Checked Nx tensor admission for ModelKit"
+description:
+  "ModelKit Nx converts explicitly typed Nx tensors into immutable ModelKit features, targets, masks, groups, names, and weights with typed validation and allocation reports."
+maintainer: ["Asara developers <devs@asara.io>"]
+authors: ["Asara"]
+license: "Apache-2.0"
+tags: ["data-science" "machine-learning" "adapters" "tensors"]
+homepage: "https://github.com/asara-io/ModelKit"
+bug-reports: "https://github.com/asara-io/ModelKit/issues"
+depends: [
+  "dune" {>= "3.23"}
+  "ocaml" {>= "5.2"}
+  "modelkit" {= version}
+  "nx" {= "1.0.0~alpha3"}
+  "alcotest" {with-test & >= "1.9.0"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/asara-io/ModelKit.git"
+x-maintenance-intent: ["(latest)"]
+available: os != "win32"
+url {
+  src:
+    "https://github.com/asara-io/ModelKit/releases/download/0.4.1/modelkit-0.4.1.tbz"
+  checksum: [
+    "sha256=7a7af032790248b5d1d5392bbf29f8c8163df2e7f50ab5801cdaed5fd2c543e1"
+    "sha512=185bc224afc9b141d54b89a564694438a268429ba9c58dd3a402da31cb29f3e1eefd3643a76766ce9170c5f6c927f307873d51e4e3ce08aece00884cebbe0e2a"
+  ]
+}
+x-commit-hash: "82c17021b8d9527adc6be62ab8e3b94dc1554d84"

--- a/packages/modelkit-parallel/modelkit-parallel.0.4.1/opam
+++ b/packages/modelkit-parallel/modelkit-parallel.0.4.1/opam
@@ -1,0 +1,43 @@
+opam-version: "2.0"
+synopsis: "Bounded parallel execution for ModelKit"
+description:
+  "ModelKit Parallel provides an optional Domainslib execution backend for deterministic bounded cross-validation."
+maintainer: ["Asara developers <devs@asara.io>"]
+authors: ["Asara"]
+license: "Apache-2.0"
+tags: ["data-science" "machine-learning" "parallelism"]
+homepage: "https://github.com/asara-io/ModelKit"
+bug-reports: "https://github.com/asara-io/ModelKit/issues"
+depends: [
+  "dune" {>= "3.23"}
+  "ocaml" {>= "5.2"}
+  "modelkit" {= version}
+  "domainslib" {>= "0.5.2"}
+  "alcotest" {with-test & >= "1.9.0"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/asara-io/ModelKit.git"
+x-maintenance-intent: ["(latest)"]
+url {
+  src:
+    "https://github.com/asara-io/ModelKit/releases/download/0.4.1/modelkit-0.4.1.tbz"
+  checksum: [
+    "sha256=7a7af032790248b5d1d5392bbf29f8c8163df2e7f50ab5801cdaed5fd2c543e1"
+    "sha512=185bc224afc9b141d54b89a564694438a268429ba9c58dd3a402da31cb29f3e1eefd3643a76766ce9170c5f6c927f307873d51e4e3ce08aece00884cebbe0e2a"
+  ]
+}
+x-commit-hash: "82c17021b8d9527adc6be62ab8e3b94dc1554d84"

--- a/packages/modelkit-talon/modelkit-talon.0.4.1/opam
+++ b/packages/modelkit-talon/modelkit-talon.0.4.1/opam
@@ -1,0 +1,45 @@
+opam-version: "2.0"
+synopsis: "Checked Talon dataframe column admission for ModelKit"
+description:
+  "ModelKit Talon converts explicitly selected, typed Talon dataframe columns into immutable ModelKit features, targets, masks, groups, names, and weights with typed validation and allocation reports."
+maintainer: ["Asara developers <devs@asara.io>"]
+authors: ["Asara"]
+license: "Apache-2.0"
+tags: ["data-science" "machine-learning" "adapters" "dataframes"]
+homepage: "https://github.com/asara-io/ModelKit"
+bug-reports: "https://github.com/asara-io/ModelKit/issues"
+depends: [
+  "dune" {>= "3.23"}
+  "ocaml" {>= "5.2"}
+  "modelkit" {= version}
+  "talon" {= "1.0.0~alpha3"}
+  "nx" {= "1.0.0~alpha3"}
+  "alcotest" {with-test & >= "1.9.0"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/asara-io/ModelKit.git"
+x-maintenance-intent: ["(latest)"]
+available: os != "win32"
+url {
+  src:
+    "https://github.com/asara-io/ModelKit/releases/download/0.4.1/modelkit-0.4.1.tbz"
+  checksum: [
+    "sha256=7a7af032790248b5d1d5392bbf29f8c8163df2e7f50ab5801cdaed5fd2c543e1"
+    "sha512=185bc224afc9b141d54b89a564694438a268429ba9c58dd3a402da31cb29f3e1eefd3643a76766ce9170c5f6c927f307873d51e4e3ce08aece00884cebbe0e2a"
+  ]
+}
+x-commit-hash: "82c17021b8d9527adc6be62ab8e3b94dc1554d84"

--- a/packages/modelkit/modelkit.0.4.1/opam
+++ b/packages/modelkit/modelkit.0.4.1/opam
@@ -1,0 +1,43 @@
+opam-version: "2.0"
+synopsis: "Portable classical machine learning workflows for OCaml"
+description:
+  "ModelKit is a native OCaml library for cohesive classical machine learning workflows. It is designed around immutable estimator specifications, leakage-safe pipelines, deterministic evaluation, and portable fitted artifacts."
+maintainer: ["Asara developers <devs@asara.io>"]
+authors: ["Asara"]
+license: "Apache-2.0"
+tags: ["data-science" "machine-learning"]
+homepage: "https://github.com/asara-io/ModelKit"
+bug-reports: "https://github.com/asara-io/ModelKit/issues"
+depends: [
+  "dune" {>= "3.23"}
+  "ocaml" {>= "5.2"}
+  "alcotest" {with-test & >= "1.9.0"}
+  "mdx" {with-test & >= "2.4.0"}
+  "qcheck-core" {with-test & >= "0.90"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/asara-io/ModelKit.git"
+x-maintenance-intent: ["(latest)"]
+url {
+  src:
+    "https://github.com/asara-io/ModelKit/releases/download/0.4.1/modelkit-0.4.1.tbz"
+  checksum: [
+    "sha256=7a7af032790248b5d1d5392bbf29f8c8163df2e7f50ab5801cdaed5fd2c543e1"
+    "sha512=185bc224afc9b141d54b89a564694438a268429ba9c58dd3a402da31cb29f3e1eefd3643a76766ce9170c5f6c927f307873d51e4e3ce08aece00884cebbe0e2a"
+  ]
+}
+x-commit-hash: "82c17021b8d9527adc6be62ab8e3b94dc1554d84"


### PR DESCRIPTION
Portable classical machine learning workflows for OCaml

- Project page: <a href="https://github.com/asara-io/ModelKit">https://github.com/asara-io/ModelKit</a>

##### Reviewer Guidance

This change introduces 2 net new packages for a total of 4 packages; those new packages are:
* `modelkit-nx`
* `modelkit-talon`


##### CHANGES:

- Add checked immutable CSR matrices with canonical structure validation,
  zero-copy indexed row views, explicit materialization, payload-memory
  accounting, and dense/CSR numerical-kernel dispatch through
  `Feature_matrix`.
- Add min-max, max-absolute, and robust scalers, per-sample normalization,
  one-hot and ordinal encoders with explicit unknown-category policies and
  direct CSR one-hot output, reversible label encoding, polynomial features,
  and missing indicators as immutable transforms with feature-name
  propagation.
- Add lasso and elastic-net regression with deterministic weighted coordinate
  descent and warm-started descending regularization paths, binary and
  multiclass ridge classification, multinomial logistic regression with stable
  softmax probabilities and matrix-valued decision scores, and Poisson and
  Tweedie generalized linear models with target-domain validation and damped
  IRLS, each with solver diagnostics and parity fixtures.
- Add SGD regression and binary/multiclass SGD classification with hinge and
  logistic losses under an immutable incremental-training contract: explicit
  initial class registration, ordered streams, optional shuffling, checkpoints,
  and continuation equivalence.
- Finish sample-weight and class-weight propagation with fold-local balanced
  and explicit class weights for classifier terminals, opt-in sample-weight
  routing to transformers, and a weighted standard scaler.
- Add confusion-matrix and multiclass classification metrics with micro,
  macro, and weighted averaging, average precision, one-versus-rest and
  one-versus-one ROC AUC, top-k accuracy, DCG and NDCG ranking metrics, and
  multiclass scorers with multiclass cross-validation and grid search.
- Add the separately installable `modelkit-nx` and `modelkit-talon` adapter
  packages for checked admission of explicitly typed Nx tensors and explicitly
  selected Talon dataframe columns, with shared `Admission` result records,
  conversion and allocation reports, a source-neutral adapter conformance
  suite, and macOS arm64 lockfiles; the adapters build on Linux and macOS
  only at the pinned Raven `1.0.0~alpha3` release.
- Rewrite the reference numerical kernels to read immutable Bigarray storage
  directly with unboxed compensated sums, verified bit for bit against an
  independent Neumaier fold.
- Add deterministic comparative benchmark reports for regularized linear
  models, ridge classification, multinomial logistic regression, generalized
  linear models, SGD, adapter admission, sparse kernel dispatch, and solver
  convergence and scale across tall, square, wide, and rank-deficient shapes;
  every report remains development evidence with no performance claim.
- Defer the optional Lacaml numerical backend to a later release, where
  LAPACK factorizations first have a consumer.
- Artifacts written by this release record producer version 0.4.1; the
  artifact schema is unchanged and 0.3.x artifacts continue to load.
