### PR TITLE
Package libbinaryen.131.0.0

### DIFF
--- a/packages/libbinaryen/libbinaryen.131.0.0/opam
+++ b/packages/libbinaryen/libbinaryen.131.0.0/opam
@@ -1,0 +1,29 @@
+opam-version: "2.0"
+synopsis: "Libbinaryen packaged for OCaml"
+maintainer: "blaine@grain-lang.org"
+authors: "Blaine Bublitz"
+license: "Apache-2.0"
+homepage: "https://github.com/grain-lang/libbinaryen"
+bug-reports: "https://github.com/grain-lang/libbinaryen/issues"
+depends: [
+  "conf-cmake" {build}
+  "dune" {>= "3.0.0"}
+  "dune-configurator" {>= "3.0.0"}
+  "js_of_ocaml-compiler" {with-test & >= "6.3.0" & < "7.0.0"}
+  "ocaml" {>= "4.14"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+depexts: ["gcc-g++"] {os-distribution = "cygwinports"}
+dev-repo: "git+https://github.com/grain-lang/libbinaryen.git"
+url {
+  src:
+    "https://github.com/grain-lang/libbinaryen/releases/download/v131.0.0/libbinaryen-v131.0.0.tar.gz"
+  checksum: [
+    "md5=97ba41e174df06eb3d2f0aecfb2394ee"
+    "sha512=af08a9bbd0f1efa88b50664114422574973cc87a2a37fd897511b2b787cd54af9c246dcb1d39a2261875dc2f8877546bdd5ea0fa6117cd910da01dd2615b0501"
+  ]
+}
+x-maintenance-intent: ["(latest)"]


### PR DESCRIPTION
### `libbinaryen.131.0.0`
Libbinaryen packaged for OCaml



---
* Homepage: https://github.com/grain-lang/libbinaryen
* Source repo: git+https://github.com/grain-lang/libbinaryen.git
* Bug tracker: https://github.com/grain-lang/libbinaryen/issues

---
:camel: Pull-request generated by opam-publish v2.7.1