### PR TITLE
[new release] slipshow (0.13.0): Juraslip Park

### DIFF
--- a/packages/slipshow/slipshow.0.13.0/opam
+++ b/packages/slipshow/slipshow.0.13.0/opam
@@ -1,0 +1,72 @@
+opam-version: "2.0"
+synopsis: "A compiler from Markdown to slipshow"
+description:
+  "Slipshow is an engine to write slips, a concept evolved from slides."
+maintainer: ["Paul-Elliot"]
+authors: ["Paul-Elliot"]
+license: [
+  "GPL-3.0-or-later" "ISC" "BSD-3-Clause" "Apache-2.0" "OFL-1.1" "MIT"
+]
+tags: ["slipshow" "presentation" "slideshow" "beamer"]
+homepage: "https://github.com/panglesd/slipshow"
+doc: "https://slipshow.readthedocs.io"
+bug-reports: "https://github.com/panglesd/slipshow/issues"
+depends: [
+  "ocaml" {>= "4.14"}
+  "dune" {>= "3.6"}
+  "grace" {>= "0.3.0"}
+  "crunch" {with-dev-setup}
+  "lambdasoup" {with-test}
+  "cmdliner" {>= "1.3.0"}
+  "base64" {>= "3.3.0"}
+  "bos"
+  "lwt" {>= "5.9.2"}
+  "inotify" {os = "linux"}
+  "cf-lwt" {>= "0.4"}
+  "astring"
+  "fmt"
+  "logs"
+  "fsevents-lwt"
+  "js_of_ocaml-compiler" {>= "6.0.1"}
+  "js_of_ocaml-lwt"
+  "magic-mime"
+  "dream" {>= "1.0.0~alpha5"}
+  "fpath"
+  "ppx_blob" {>= "0.8.0"}
+  "sexplib"
+  "ppx_sexp_conv"
+  "ppx_deriving_yojson"
+  "ansi" {>= "0.7.0"}
+  "linol" {>= "0.11"}
+  "linol-lwt" {>= "0.11"}
+  "odoc" {with-doc}
+  "ocamlformat" {with-dev-setup & = "0.28.1"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/panglesd/slipshow.git"
+# We avoid 32 bits arcitecture because our usage of ppx_blob generates strings
+# whose size exceed the maximum size in 32 bits OCaml...
+available: arch != "arm32" & arch != "x86_32"
+x-maintenance-intent: [ "(latest)" ]
+url {
+  src:
+    "https://github.com/panglesd/slipshow/releases/download/v0.13.0/slipshow-0.13.0.tbz"
+  checksum: [
+    "sha256=9153350a1c29fa152500b8c620b324636a5aaa5b8547221f1b95186a9b82afb5"
+    "sha512=ea4a2d0635dfa0111777946d91743858df633dffebf414edeff280a1ec9841c215a7c84a5f7896c5e1f00c1c60555a505dcd4f278bc757eea8eed2fd5e808bd7"
+  ]
+}
+x-commit-hash: "b7036c0a6a7c81a628ad7a07f69f69892ce1e282"


### PR DESCRIPTION
See the [release notes](https://github.com/panglesd/slipshow/releases/tag/v0.13.0) for a gif.

CHANGES:

### Added

- "What You See Is What You Want" — positions any "GUI" element absolutely, by dragging it in the preview! Supports moving, redimensioning and scaling elements. (panglesd/slipshow#270)
- "Go to source" by `Ctrl`+clicking (or `Cmd`+clicking on Mac) anywhere in the preview. (panglesd/slipshow#270)
- Added [tachyons](https://tachyons.io/) support (panglesd/slipshow#278)

### Changed

- Improved toolbar and shortcut consistency, notably in recording manager mode, `Shift+R` now closes the recording manager (previously it started a recording). `Shift+S` is used to start a recording. (panglesd/slipshow#270)
- Diagnostics on `slipshow compile` are sorted by location (panglesd/slipshow#277)
- Improve location of "Wrong Type" diagnostic (panglesd/slipshow#277)
- Hint that step counter and toc entries are clickable. (panglesd/slipshow#278)
- Pressing play in drawing editor when the cursor is at the end of the recording now replays from the beginning. (panglesd/slipshow#278)
- Round sub-millisecond time precision in drawing editor. (panglesd/slipshow#278)

### Fixed

- LSP:
  - Respect UTF-16 position encoding when it is the only one supported by the editor. (panglesd/slipshow#270)
  - Fix a bug in detection of element at cursor, and one in locations of "glued" attribute, in effect improving hover and highlight reliability. (panglesd/slipshow#270)
  - Fix `go_next` / `go_previous` doing nothing in "refresh on save" mode. (panglesd/slipshow#270)
  - Fix frontmatter error sometimes not being reported (panglesd/slipshow#277)
- Fix locations reported for frontmatter `attributes:`. (panglesd/slipshow#271)
- Fix drawings being drawn behind positioned elements. (panglesd/slipshow#270)
- Fixed standalonity of html by embedding mono fonts (panglesd/slipshow#272)
- Resolution of css and js files in frontmatter are now relative to the file they are in (and not to the root file). (panglesd/slipshow#271)
- LSP: correctly refresh on changes on files mentioned in frontmatter (such as css and js files). (panglesd/slipshow#271)
- Improve uri vs local path detection. (panglesd/slipshow#271)
- Improve locations of errors in `css:` and `js:` frontmatter fields. (panglesd/slipshow#271)
- Allow spaces and tabs after frontmatter delimiters. (panglesd/slipshow#275)
- Fix drawing replay in editor stuck on a pause. (panglesd/slipshow#278)
- Fix last point of a stroke not being displayed when the recording ends at this time. (panglesd/slipshow#278)
- Group a slide's entrance with its own heading in the table of contents (panglesd/slipshow#273)
- Fixed missing version number in precompiled binary (panglesd/slipshow#281)

### Docs

- Added documentation on the new GUI mode (panglesd/slipshow#270)