### PR TITLE
Package binaryen.0.38.0

### DIFF
--- a/packages/binaryen/binaryen.0.38.0/opam
+++ b/packages/binaryen/binaryen.0.38.0/opam
@@ -1,0 +1,28 @@
+opam-version: "2.0"
+synopsis: "OCaml bindings for Binaryen"
+maintainer: "oscar@grain-lang.org"
+authors: "Oscar Spencer"
+license: " Apache-2.0"
+homepage: "https://github.com/grain-lang/binaryen.ml"
+bug-reports: "https://github.com/grain-lang/binaryen.ml/issues"
+depends: [
+  "ocaml" {>= "4.14.0"}
+  "dune" {>= "3.0.0"}
+  "dune-configurator" {>= "3.0.0"}
+  "js_of_ocaml-compiler" {>= "6.4.0" & < "7.0.0"}
+  "libbinaryen" {>= "128.0.0" & < "129.0.0"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+dev-repo: "git+https://github.com/grain-lang/binaryen.ml.git"
+url {
+  src:
+    "https://github.com/grain-lang/binaryen.ml/releases/download/v0.38.0/binaryen-archive-v0.38.0.tar.gz"
+  checksum: [
+    "md5=9d3677879e8cc7d7e291fdd368fa215d"
+    "sha512=14f50e017f4993a99e65ffebcba49ebf30d50c7b0167a8d828f728f265b029a5364a06451ba32900a4027ffd1bb16a8d257b1cc3ea338c72797d5457c30b8efb"
+  ]
+}
+x-maintenance-intent: ["0.(latest)"]


### PR DESCRIPTION
### `binaryen.0.38.0`
OCaml bindings for Binaryen



---
* Homepage: https://github.com/grain-lang/binaryen.ml
* Source repo: git+https://github.com/grain-lang/binaryen.ml.git
* Bug tracker: https://github.com/grain-lang/binaryen.ml/issues

---
:camel: Pull-request generated by opam-publish v2.7.1