### PR TITLE
[new release]: shakuhachi: 0.3.3

### DIFF
--- a/packages/shakuhachi/shakuhachi.0.3.3/opam
+++ b/packages/shakuhachi/shakuhachi.0.3.3/opam
@@ -1,0 +1,54 @@
+opam-version: "2.0"
+synopsis: "A music collection manager"
+description: """
+shakuhachi is mainly a music collection manager but it's also a music tagger.
+ It aims to be a rather simple collection manager extensible by plugins."""
+maintainer: ["EruEri <nayinayu@mailo.com>"]
+authors: ["EruEri <nayinayu@mailo.com>"]
+license: "GPL-3.0-or-later AND MPL-2.0"
+tags: ["music collection" "music tagger"]
+homepage: "https://codeberg.org/EruEri/shakuhachi"
+bug-reports: "https://codeberg.org/EruEri/shakuhachi/issues"
+depends: [
+  "dune" {>= "3.17.2"}
+  "ocaml" {>= "4.14.0"}
+  "xdg"
+  "angstrom" {>= "0.15.0"}
+  "cmdliner" {>= "1.1.0"}
+  "sqlite3" {>= "5.1.0"}
+  "re" {>= "1.10.3"}
+  "otaglibc" {>= "0.1.0"}
+  "uunf" {>= "15.1.0"}
+  "magic-mime" {>= "1.3.0"}
+  "ppx_deriving_yojson" {>= "3.5.3"}
+  "yojson" {>= "2.0.0"}
+  "qcheck" {>= "0.90" & with-test}
+  "qcheck-alcotest" {with-test}
+  "alcotest" {with-test}
+  "fmt" {with-test}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://codeberg.org/EruEri/shakuhachi.git"
+x-maintenance-intent: ["(latest)"]
+
+url {
+  src: "https://codeberg.org/EruEri/shakuhachi/archive/0.3.3.tar.gz"
+  checksum: [
+    "sha256=7d07b9c7edcd5f5cee242facf4260272c56e56eb34b897888299ceece3e61d57"
+    "sha512=305f97d253d39f3b9d260e018d45f2563bea911cb164ad4d40c450e6c21081f1e7cde68203f9be6633b6933e1bad39da8405b99e8ace58adcc07758d37b8f2fd"
+  ]
+}


### PR DESCRIPTION
Dear maintainers,

shakuhachi: A music collection manager

## CHANGES

- fix : modified or replaced musics [skhc-modify], [skhc-replace], [Music.add] were delete from playlists.
- fix : [skhc-tag]: Actually use `-p` option.
- feat : populated *%created_at*, *%modified_at* and *%played_at* for musics, albums and artists (on format)
- feat : Add *%created_at*, *%modified_at** and *%played_at* Float keys
- fix : [skhc-modify]: Artist-mode - handle constraints when participants merge into an already existing
participants for the {album,music} 
- fix : skhc-query : substring nodes matches against all participants (not only the last one).