### PR TITLE
Package json-pointer.1.0

### DIFF
--- a/packages/json-pointer/json-pointer.1.0/opam
+++ b/packages/json-pointer/json-pointer.1.0/opam
@@ -1,0 +1,42 @@
+opam-version: "2.0"
+synopsis: "RFC 6901 JSON Pointer implementation for jsont"
+description:
+  "This library provides RFC 6901 JSON Pointer parsing, serialization, and evaluation for jsont values and codecs. It also provides the RFC 6902 JSON Patch operations and RFC 8620 JMAP wildcard evaluation."
+maintainer: "Anil Madhavapeddy <anil@recoil.org>"
+authors: "Anil Madhavapeddy"
+license: "ISC"
+homepage: "https://tangled.org/anil.recoil.org/ocaml-json-pointer"
+bug-reports: "https://tangled.org/anil.recoil.org/ocaml-json-pointer/issues"
+depends: [
+  "dune" {>= "3.21"}
+  "ocaml" {>= "5.2.0"}
+  "jsont" {>= "0.3.0"}
+  "uri" {>= "4.0.0"}
+  "bytesrw" {>= "0.3.0" & with-test}
+  "mdx" {>= "2.4.1" & with-test}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://tangled.org/anil.recoil.org/ocaml-json-pointer"
+url {
+  src:
+    "https://tangled.org/anil.recoil.org/ocaml-json-pointer/tags/3988887932dc5750bd0f3f1fb25c8b96a8541eea/download/json-pointer-1.0.tbz"
+  checksum: [
+    "md5=154a8d5caa45d40535d97108bea3a683"
+    "sha512=88a34ef7ec9ddb3f88009a7ac854e2e92be5a376a14c1a760a7bddd8e867723b22fee0ae417a29e4a502110d4bd0f28ea669160220f57df48bfb47cfe1af9b6b"
+  ]
+}
+x-maintenance-intent: ["(latest)"]


### PR DESCRIPTION
### `json-pointer.1.0`
RFC 6901 JSON Pointer implementation for jsont
This library provides RFC 6901 JSON Pointer parsing, serialization, and evaluation for jsont values and codecs. It also provides the RFC 6902 JSON Patch operations and RFC 8620 JMAP wildcard evaluation.



---
* Homepage: https://tangled.org/anil.recoil.org/ocaml-json-pointer
* Source repo: git+https://tangled.org/anil.recoil.org/ocaml-json-pointer
* Bug tracker: https://tangled.org/anil.recoil.org/ocaml-json-pointer/issues

---
:camel: Pull-request generated by opam-publish v3.0.1