### PR TITLE
Add Fedora44 support for conf-taglib_c.2

### DIFF
--- a/packages/conf-taglib_c/conf-taglib_c.2/opam
+++ b/packages/conf-taglib_c/conf-taglib_c.2/opam
@@ -16,6 +16,7 @@ depexts: [
   ["taglib-dev" "zlib-dev"] {os-family = "alpine"}
   ["libtag-devel"] {os-family = "suse" | os-family = "opensuse"}
   ["taglib"] {os-family = "arch" | os = "freebsd" | os-distribution = "nixos"}
+  ["taglib-devel"] {os-family = "fedora" & os-version >= "44"}
   ["taglib"] {os = "macos" & os-distribution = "homebrew"}
   ["taglib"] {os = "macos" & os-distribution = "macports"}
 ]


### PR DESCRIPTION
While looking at the CI failures of #30655 I was comparing the `conf-taglib_c.2` errors to the known ones from earlier
https://github.com/ocaml/opam-repository/pull/29161#issuecomment-3703886725
and then discovered that Fedora 44 now ships a v2 (2.2.1-1 to be precise): https://pkgs.org/search/?q=taglib_c.pc

This PR thus adds that. It should eliminate the Fedora 44 failures from #30655