### PR TITLE
Package libbinaryen.132.0.0

### DIFF
--- a/packages/libbinaryen/libbinaryen.132.0.0/opam
+++ b/packages/libbinaryen/libbinaryen.132.0.0/opam
@@ -1,0 +1,29 @@
+opam-version: "2.0"
+synopsis: "Libbinaryen packaged for OCaml"
+maintainer: "blaine@grain-lang.org"
+authors: "Blaine Bublitz"
+license: "Apache-2.0"
+homepage: "https://github.com/grain-lang/libbinaryen"
+bug-reports: "https://github.com/grain-lang/libbinaryen/issues"
+depends: [
+  "conf-cmake" {build}
+  "dune" {>= "3.0.0"}
+  "dune-configurator" {>= "3.0.0"}
+  "js_of_ocaml-compiler" {with-test & >= "6.3.0" & < "7.0.0"}
+  "ocaml" {>= "4.14"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+depexts: ["gcc-g++"] {os-distribution = "cygwinports"}
+dev-repo: "git+https://github.com/grain-lang/libbinaryen.git"
+url {
+  src:
+    "https://github.com/grain-lang/libbinaryen/releases/download/v132.0.0/libbinaryen-v132.0.0.tar.gz"
+  checksum: [
+    "md5=7f844ff143f591a9d10f7fabdd15716a"
+    "sha512=22a8cf16db927f1b2462b43decaf2230681ca57a9077e339b3259dbd050d615ccb123dd89ed7ff392216a5cd7ecae63bfd39fe2123a90a1e6901fc0237295ec9"
+  ]
+}
+x-maintenance-intent: ["(latest)"]


### PR DESCRIPTION
### `libbinaryen.132.0.0`
Libbinaryen packaged for OCaml



---
* Homepage: https://github.com/grain-lang/libbinaryen
* Source repo: git+https://github.com/grain-lang/libbinaryen.git
* Bug tracker: https://github.com/grain-lang/libbinaryen/issues

---
:camel: Pull-request generated by opam-publish v2.7.1