### PR TITLE
Add an upper ocaml bound for misuja

### DIFF
--- a/packages/misuja/misuja.0.0.0/opam
+++ b/packages/misuja/misuja.0.0.0/opam
@@ -24,7 +24,7 @@ depexts: [
   ["jack"] {os-distribution = "homebrew" & os = "macos"}
 ]
 synopsis:
-  "A library to drive the MIDI system of the Jack Audio Connection Kit."
+  "A library to drive the MIDI system of the Jack Audio Connection Kit"
 description: """
 Misuja is a low-latency “MIDI communications thread” implemented in C
 which is manipulated with an OCaml API (communicating through

--- a/packages/misuja/misuja.0.0.0/opam
+++ b/packages/misuja/misuja.0.0.0/opam
@@ -9,7 +9,7 @@ build: [make "lib"]
 install: [make "install"]
 remove: [make "uninstall"]
 depends: [
-  "ocaml" {>= "4.03.0"}
+  "ocaml" {>= "4.03.0" & < "5.0.0"}
   "ocamlfind" {build}
   "base-unix"
 ]


### PR DESCRIPTION
Spotted on https://check.ci.ocaml.org/

https://check.ci.ocaml.org/log/1788254620-b4dc6a9d84c79cbc5548726f15b59c93d46d96a9/5.2/bad/misuja.0.0.0
```
#=== ERROR while compiling misuja.0.0.0 =======================================#
# context              2.6.0~beta1 | linux/x86_64 | ocaml-base-compiler.5.2.1 | file:///home/opam/opam-repository
# path                 ~/.opam/5.2/.opam-switch/build/misuja.0.0.0
# command              ~/.opam/opam-init/hooks/sandbox.sh build make lib
# exit-code            2
# env-file             ~/.opam/log/misuja-8-9d98a5.env
# output-file          ~/.opam/log/misuja-8-9d98a5.out
### output ###
# mkdir -p _build/lib
# gcc -I `ocamlc -where` -pthread -pedantic -Wall -Wextra -Wpointer-arith -Wbad-function-cast -pthread -ljack -fPIC -c src/lib/misuja_jack_seq.c -o _build/lib/misuja_jack_seq.o
# src/lib/misuja_jack_seq.c:231:1: warning: missing initializer for field 'compare_ext' of 'struct custom_operations' [-Wmissing-field-initializers]
#   231 | };
#       | ^
# In file included from src/lib/misuja_jack_seq.c:60:
# /home/opam/.opam/5.2/lib/ocaml/caml/custom.h:36:9: note: 'compare_ext' declared here
#    36 |   int (*compare_ext)(value v1, value v2);
#       |         ^~~~~~~~~~~
# src/lib/misuja_jack_seq.c: In function 'ml_jackseq_make':
# src/lib/misuja_jack_seq.c:253:3: warning: 'jack_client_new' is deprecated [-Wdeprecated-declarations]
#   253 |   js->js_client = jack_client_new ( String_val(app_name));
#       |   ^~
# In file included from src/lib/misuja_jack_seq.c:47:
# /usr/include/jack/jack.h:127:17: note: declared here
#   127 | jack_client_t * jack_client_new (const char *client_name) JACK_OPTIONAL_WEAK_DEPRECATED_EXPORT;
#       |                 ^~~~~~~~~~~~~~~
# src/lib/misuja_jack_seq.c:293:19: error: implicit declaration of function 'alloc_custom'; did you mean 'caml_alloc_custom'? [-Wimplicit-function-declaration]
#   293 |   the_sequencer = alloc_custom(
#       |                   ^~~~~~~~~~~~
#       |                   caml_alloc_custom
# src/lib/misuja_jack_seq.c: In function 'ml_jackseq_close':
# src/lib/misuja_jack_seq.c:307:7: warning: variable 'ret' set but not used [-Wunused-but-set-variable]
#   307 |   int ret;
#       |       ^~~
# make: *** [Makefile:10: _build/lib/misuja_jack_seq.o] Error 1
```

The bindings are using `alloc_custom` without the `caml_` prefix - this is no longer possible since the OCaml 5 release.