### PR TITLE
Add an ocaml.5.0 upper bound for odbc.3.0

### DIFF
--- a/packages/odbc/odbc.3.0/opam
+++ b/packages/odbc/odbc.3.0/opam
@@ -11,7 +11,10 @@ build: [
 remove: [
   ["ocamlfind" "remove" "odbc"]
 ]
-depends: ["ocaml" "ocamlfind"]
+depends: [
+  "ocaml" {< "5.0.0"}
+  "ocamlfind"
+]
 depexts: [
   ["unixodbc-dev"] {os-family = "debian"}
   ["unixodbc"] {os = "macos" & os-distribution = "homebrew"}


### PR DESCRIPTION
Also spotted on https://check.ci.ocaml.org/

https://check.ci.ocaml.org/log/1788254620-b4dc6a9d84c79cbc5548726f15b59c93d46d96a9/5.2/bad/odbc.3.0
```
#=== ERROR while compiling odbc.3.0 ===========================================#
# context              2.5.2 | linux/x86_64 | ocaml-base-compiler.5.2.1 | file:///home/opam/opam-repository
# path                 ~/.opam/5.2/.opam-switch/build/odbc.3.0
# command              ~/.opam/opam-init/hooks/sandbox.sh build make
# exit-code            2
# env-file             ~/.opam/log/odbc-8-954aca.env
# output-file          ~/.opam/log/odbc-8-954aca.out
### output ###
# rm -f .depend
# ocamldep  ocamlodbc.ml ocamlodbc_lowlevel.ml odbc.ml ocamlodbc.mli odbc.mli > .depend
# for d in unixodbc openingres; do \
#   make BASE=$d library; \
# done
# make[1]: Entering directory '/home/opam/.opam/5.2/.opam-switch/build/odbc.3.0'
# ocamlc.opt -verbose -pp 'grep -v DEBUG'  -c odbc.mli
# + grep -v DEBUG 'odbc.mli' > /opam-tmp/ocamlpp20ae38
# ocamlc.opt -verbose -pp 'grep -v DEBUG'  -c odbc.ml
# + grep -v DEBUG 'odbc.ml' > /opam-tmp/ocamlppbf74d4
# ocamlc.opt -verbose -a -o odbc.cma odbc.cmo
# ocamlopt.opt -pp 'grep -v DEBUG'  -c odbc.ml
# ocamlopt.opt -a -o odbc.cmxa odbc.cmx
# ======== Compiling 'unixodbc' ========
# make BASE=unixodbc ocamlmklib
# make[2]: Entering directory '/home/opam/.opam/5.2/.opam-switch/build/odbc.3.0'
# LC_ALL=C sed -e 's/ocamlodbc_/ocamlodbc_unixodbc_/' ocaml_odbc_c.c > odbc_unixodbc_c.c
# gcc -c -fPIC -pthread -g -O2 -D unixODBC   -I /home/opam/.opam/5.2/lib/ocaml -D unixODBC   odbc_unixodbc_c.c
# In file included from odbc_unixodbc_c.c:47:
# odbc_unixodbc_c.c: In function 'ocamlodbc_unixodbc_initDB_c':
# /home/opam/.opam/5.2/lib/ocaml/caml/mlvalues.h:332:23: warning: initialization discards 'const' qualifier from pointer target type [-Wdiscarded-qualifiers]
#   332 | #define String_val(x) ((const char *) Bp_val(x))
#       |                       ^
# odbc_unixodbc_c.c:178:20: note: in expansion of macro 'String_val'
#   178 |   char *nom_base = String_val(v_nom_base);
#       |                    ^~~~~~~~~~
# /home/opam/.opam/5.2/lib/ocaml/caml/mlvalues.h:332:23: warning: initialization discards 'const' qualifier from pointer target type [-Wdiscarded-qualifiers]
#   332 | #define String_val(x) ((const char *) Bp_val(x))
#       |                       ^
# odbc_unixodbc_c.c:179:20: note: in expansion of macro 'String_val'
#   179 |   char *nom_user = String_val(v_nom_user);
#       |                    ^~~~~~~~~~
# /home/opam/.opam/5.2/lib/ocaml/caml/mlvalues.h:332:23: warning: initialization discards 'const' qualifier from pointer target type [-Wdiscarded-qualifiers]
#   332 | #define String_val(x) ((const char *) Bp_val(x))
#       |                       ^
# odbc_unixodbc_c.c:180:20: note: in expansion of macro 'String_val'
#   180 |   char *password = String_val(v_password);
#       |                    ^~~~~~~~~~
# odbc_unixodbc_c.c:192:9: error: implicit declaration of function 'alloc_tuple'; did you mean 'caml_alloc_tuple'? [-Wimplicit-function-declaration]
#   192 |   res = alloc_tuple(3);
#       |         ^~~~~~~~~~~
#       |         caml_alloc_tuple
```
The reason is the same as in the other one: using runtime functions without the `caml_` prefix, which isn't possible anymore since OCaml 5.0.

There are plenty of other things to address here, which I probably won't unless there are actual interested users:
- opam lint failures about missing 'homepage', 'bug-reports', 'dev-repo', 'license'
- support for platforms other than Debian and macOS-homebrew based on https://pkgs.org/search/?q=odbc.pc