### PR TITLE
Package binaryen.0.39.0

### DIFF
--- a/packages/binaryen/binaryen.0.39.0/opam
+++ b/packages/binaryen/binaryen.0.39.0/opam
@@ -1,0 +1,28 @@
+opam-version: "2.0"
+synopsis: "OCaml bindings for Binaryen"
+maintainer: "oscar@grain-lang.org"
+authors: "Oscar Spencer"
+license: " Apache-2.0"
+homepage: "https://github.com/grain-lang/binaryen.ml"
+bug-reports: "https://github.com/grain-lang/binaryen.ml/issues"
+depends: [
+  "ocaml" {>= "4.14.0"}
+  "dune" {>= "3.0.0"}
+  "dune-configurator" {>= "3.0.0"}
+  "js_of_ocaml-compiler" {>= "6.4.0" & < "7.0.0"}
+  "libbinaryen" {>= "129.0.0" & < "130.0.0"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+dev-repo: "git+https://github.com/grain-lang/binaryen.ml.git"
+url {
+  src:
+    "https://github.com/grain-lang/binaryen.ml/releases/download/v0.39.0/binaryen-archive-v0.39.0.tar.gz"
+  checksum: [
+    "md5=fab62c8b8311825effd981c14f9428aa"
+    "sha512=05dd691675d6a5becd84b0e9fab934eed3a2d40a65fbac8b1db046f06f4a9d82bf0d775b223c81f50043d1bcd912f10692123b0c3d076fc4ab240c58835656cf"
+  ]
+}
+x-maintenance-intent: ["0.(latest)"]


### PR DESCRIPTION
### `binaryen.0.39.0`
OCaml bindings for Binaryen



---
* Homepage: https://github.com/grain-lang/binaryen.ml
* Source repo: git+https://github.com/grain-lang/binaryen.ml.git
* Bug tracker: https://github.com/grain-lang/binaryen.ml/issues

---
:camel: Pull-request generated by opam-publish v2.7.1