### PR TITLE
Package utcp.0.0.8

### DIFF
--- a/packages/utcp/utcp.0.0.8/opam
+++ b/packages/utcp/utcp.0.0.8/opam
@@ -1,0 +1,67 @@
+opam-version: "2.0"
+synopsis: "An implementation of TCP (Transmission Control Protocol) in OCaml"
+description: """\
+µTCP is an implementation of the Transmission Control
+Protocol (RFC 793) in OCaml. TCP is widely used on the Internet today.
+
+This implementation is based on the research project Network Semantics
+(https://www.cl.cam.ac.uk/~pes20/Netsem/) which developed a rigorous test
+oracle specification and validation for TCP/IP and the Sockets API (also see
+the JACM paper http://www.cl.cam.ac.uk/~pes20/Netsem/paper3.pdf) in HOL4. The
+implementation does not adhere to the specification, since some features of TCP
+that are rarely used are not implemented (such as the urgent flag and urgent
+pointers).
+
+The target of this opam package is the MirageOS (https://mirageos.org) unikernel
+operating system."""
+maintainer: "Robur <team@robur.coop>"
+authors: "Robur <team@robur.coop>"
+license: "ISC"
+homepage: "https://git.robur.coop/robur/utcp"
+bug-reports: "https://github.com/robur-coop/utcp/issues"
+depends: [
+  "ocaml" {>= "4.13.0"}
+  "dune" {>= "2.7.0"}
+  "cstruct" {>= "6.0.1"}
+  "duration" {>= "0.2.0"}
+  "fmt" {>= "0.8.7"}
+  "ipaddr" {>= "5.2.0"}
+  "ipaddr-cstruct" {>= "5.2.0"}
+  "logs" {>= "0.7.0"}
+  "randomconv" {>= "0.2.0"}
+  "mtime" {>= "1.4.0"}
+  "metrics" {>= "0.4.1"}
+  "mirage-crypto-rng" {>= "1.2.0"}
+  "base64" {>= "3.5.1"}
+  "lwt" {>= "5.4.2"}
+  "mirage-sleep" {>= "4.0.0"}
+  "mirage-mtime" {>= "5.0.0"}
+  "tcpip" {>= "9.0.0"}
+  "alcotest" {>= "1.5.0" & with-test}
+  "crowbar" {>= "0.2.1" & with-test}
+  "ohex" {with-test}
+  "bechamel" {with-test}
+  "bechamel-js" {with-test}
+  "cmdliner" {>= "1.1.0" & with-dev-setup}
+  "mirage-net-unix" {>= "2.8.0" & with-dev-setup}
+  "ethernet" {>= "2.2.1" & with-dev-setup}
+  "arp" {>= "4.0.0" & with-dev-setup}
+  "mirage-unix" {>= "5.0.0" & with-dev-setup}
+  "pcap-format" {>= "0.6.0" & with-dev-setup}
+]
+available: arch != "arm32" & arch != "x86_32"
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://git.robur.coop/robur/utcp.git"
+url {
+  src:
+    "https://git.robur.coop/robur/utcp/releases/download/v0.0.8/utcp-0.0.8.tbz"
+  checksum: [
+    "md5=221e1c5779a24a265c9043f65ec79611"
+    "sha512=cc1b07dbfbc43985c25e8068f7664613e4e15e2a7832771d99dca3558f37f8dc839f79b4166f2697b7ac487693a9451a0b7b35ae3747a9565b43e4d31f0f2ae3"
+  ]
+}
+x-maintenance-intent: ["(latest)"]


### PR DESCRIPTION
### `utcp.0.0.8`
An implementation of TCP (Transmission Control Protocol) in OCaml
µTCP is an implementation of the Transmission Control
Protocol (RFC 793) in OCaml. TCP is widely used on the Internet today.

This implementation is based on the research project Network Semantics
(https://www.cl.cam.ac.uk/~pes20/Netsem/) which developed a rigorous test
oracle specification and validation for TCP/IP and the Sockets API (also see
the JACM paper http://www.cl.cam.ac.uk/~pes20/Netsem/paper3.pdf) in HOL4. The
implementation does not adhere to the specification, since some features of TCP
that are rarely used are not implemented (such as the urgent flag and urgent
pointers).

The target of this opam package is the MirageOS (https://mirageos.org) unikernel
operating system.



---
* Homepage: https://git.robur.coop/robur/utcp
* Source repo: git+https://git.robur.coop/robur/utcp.git
* Bug tracker: https://github.com/robur-coop/utcp/issues

---
:camel: Pull-request generated by opam-publish v3.0.1