### PR TITLE
[new release] esgg (20260908)

### DIFF
--- a/packages/esgg/esgg.20260908/opam
+++ b/packages/esgg/esgg.20260908/opam
@@ -1,0 +1,35 @@
+opam-version: "2.0"
+homepage: "https://github.com/ahrefs/esgg"
+synopsis: "Elasticsearch guided (code) generator"
+authors: "Ahrefs Pte Ltd <github@ahrefs.com>"
+maintainer: "Ahrefs Pte Ltd <github@ahrefs.com>"
+dev-repo: "git+https://github.com/ahrefs/esgg.git"
+bug-reports: "https://github.com/ahrefs/esgg/issues"
+license: "GPL-2.0-only"
+tags: ["org:ahrefs"]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "dune" {>= "1.3."}
+  "ocaml" { >= "4.04.0" }
+  "yojson" {>= "2.0.0"}
+  "extlib" {>= "1.7.1"}
+  "atd" {>= "2.0.0"}
+  "easy-format"
+  "jsonm"
+  "ppx_deriving" {>= "4.2"}
+  "mybuild" {>= "4"}
+]
+conflicts: [
+  "dune" {= "1.4.0"}
+]
+url {
+  src:
+    "https://github.com/ahrefs/esgg/releases/download/20260908/esgg-20260908.tar.gz"
+  checksum: [
+    "sha256=31f2a1cddf3b7c64c973e2bd0e5cab167bb985bd52446695bc3cc80b365af84f"
+    "sha512=952ae24790d844a23c30edbd6a3f5c33f50a1eed7192a8f97b2b8bfd565206e93e270303c8643ed7408b9b42abc1d264e228b86cad242dbf75b8b7d6ceed8979"
+  ]
+}

--- a/packages/esgg/esgg.20260908/opam
+++ b/packages/esgg/esgg.20260908/opam
@@ -15,7 +15,7 @@ depends: [
   "dune" {>= "1.3."}
   "ocaml" { >= "4.04.0" }
   "yojson" {>= "2.0.0"}
-  "extlib" {>= "1.7.1"}
+  "extlib" {>= "1.7.7"}
   "atd" {>= "2.0.0" & < "3"}
   "easy-format"
   "jsonm"

--- a/packages/esgg/esgg.20260908/opam
+++ b/packages/esgg/esgg.20260908/opam
@@ -16,7 +16,7 @@ depends: [
   "ocaml" { >= "4.04.0" }
   "yojson" {>= "2.0.0"}
   "extlib" {>= "1.7.1"}
-  "atd" {>= "2.0.0"}
+  "atd" {>= "2.0.0" & < "3"}
   "easy-format"
   "jsonm"
   "ppx_deriving" {>= "4.2"}


### PR DESCRIPTION
New release of esgg (Elasticsearch guided code generator by Ahrefs). Previous release on opam is 20190322. 
Release notes: https://github.com/ahrefs/esgg/releases/tag/20260908