### PR TITLE
Frama-C/Frama-Clang 0.0.20

### DIFF
--- a/packages/frama-clang/frama-clang.0.0.20/opam
+++ b/packages/frama-clang/frama-clang.0.0.20/opam
@@ -1,0 +1,49 @@
+opam-version: "2.0"
+synopsis: "Frama-C plug-in based on Clang for parsing C++ files"
+description:
+  "This Frama-C plug-in parse C++ files that may contain ACSL++ annotations."
+maintainer: "Virgile.Prevosto@cea.fr"
+authors: "Virgile Prevosto"
+license: "LGPL-2.1-only"
+tags: ["formal specification" "C++" "plugins" "ACSL" "ACSL++"]
+homepage: "https://frama-c.com/frama-clang.html"
+bug-reports: "https://git.frama-c.com/pub/frama-clang/-/issues"
+depends: [
+  "dune" {>= "3.13" & != "3.13.0"}
+  "frama-c" {>= "33.0~" & < "34.0~"}
+  "zarith" {>= "1.5"}
+  "camlp-streams"
+  "conf-libclang" {>= "19" & <= "21"}
+  "conf-cmake"
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "env"
+    "OPAM_LLVM_CONFIG=%{conf-libclang:config}%"
+    "FCIRGEN_JOBS=%{jobs}%"
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--promote-install-files=false"
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+  ["dune" "install" "-p" name "--create-install-files" name]
+]
+dev-repo: "git+https://git.frama-c.com/pub/frama-clang.git"
+url {
+  src:
+    "https://git.frama-c.com/pub/frama-clang/-/archive/0.0.20/frama-clang-0.0.20.tar.bz2"
+  checksum: [
+    "md5=cb1f49d7828013ef6a321c037e9f0c03"
+    "sha512=f848d4d0215a57820d4baf58f1036ed4a0a2573398e27130600094df8f9ea5ef41a87d007d07cb5d57e54520166aee2df54e8a3b276bc57f449a129c62a9c819"
+  ]
+}
+x-ci-accept-failures: ["debian-11" "ubuntu-20.04" "freebsd-14.3"]
+x-maintenance-intent: ["(latest)" "(latest-1)"]


### PR DESCRIPTION
Main changes:

- removed dependency upon `camlp5`
- `framaCIRGen` is now properly registered as a clang tool through `libtooling`
- Compatibility with Clang 21 and Clang 22
- Minimal Clang version is now 13
- Compatibility with Frama-C 33.0 Arsenic