### PR TITLE
[new release] ocaml-ai-sdk (2 packages) (0.6.3)

### DIFF
--- a/packages/ai-sdk-react/ai-sdk-react.0.6.3/opam
+++ b/packages/ai-sdk-react/ai-sdk-react.0.6.3/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+synopsis: "Melange bindings for @ai-sdk/react"
+description: "Type-safe OCaml/Melange bindings for Vercel AI SDK)"
+maintainer: ["José Nogueira <jose.nogueira@ahrefs.com>"]
+authors: ["Ahrefs"]
+license: "MIT"
+homepage: "https://github.com/ahrefs/ocaml-ai-sdk"
+doc: "https://github.com/ahrefs/ocaml-ai-sdk"
+bug-reports: "https://github.com/ahrefs/ocaml-ai-sdk/issues"
+depends: [
+  "dune" {>= "3.21"}
+  "ocaml" {>= "4.14"}
+  "melange" {>= "4.0.0"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/ahrefs/ocaml-ai-sdk.git"
+x-maintenance-intent: ["(latest)"]
+url {
+  src:
+    "https://github.com/ahrefs/ocaml-ai-sdk/releases/download/0.6.3/ocaml-ai-sdk-0.6.3.tbz"
+  checksum: [
+    "sha256=0cc0a957784c295877b6bcc4f80c0dba0f6507d3c282e7d6cbd71038050376de"
+    "sha512=f8e082376b4de194a877d0df193892cdaa8139a4789f51eebac651acf8b6d4064b95242e158d86c1a32776d99130d43ed4c1119e2d54e738e93bdba2a6ad9a33"
+  ]
+}
+x-commit-hash: "fe91855a2b1be51e96bff38b68b31b0f67ab13cf"

--- a/packages/ocaml-ai-sdk/ocaml-ai-sdk.0.6.3/opam
+++ b/packages/ocaml-ai-sdk/ocaml-ai-sdk.0.6.3/opam
@@ -1,0 +1,54 @@
+opam-version: "2.0"
+synopsis: "OCaml AI SDK - Provider abstraction for AI models"
+description:
+  "Type-safe, provider-agnostic AI model abstraction inspired by Vercel AI SDK"
+maintainer: ["José Nogueira <jose.nogueira@ahrefs.com>"]
+authors: ["Ahrefs"]
+license: "MIT"
+homepage: "https://github.com/ahrefs/ocaml-ai-sdk"
+doc: "https://github.com/ahrefs/ocaml-ai-sdk"
+bug-reports: "https://github.com/ahrefs/ocaml-ai-sdk/issues"
+depends: [
+  "dune" {>= "3.21"}
+  "ocaml" {>= "4.14"}
+  "lwt" {>= "5.9"}
+  "yojson" {>= "2.2"}
+  "jsonschema" {>= "0.1"}
+  "melange-json-native" {>= "2.0"}
+  "cohttp-lwt-unix" {>= "5.3"}
+  "lwt_ssl" {>= "1.2"}
+  "base64" {>= "1.3"}
+  "ppx_deriving" {>= "5.2"}
+  "lwt_ppx" {>= "5.9"}
+  "re2" {>= "v0.16"}
+  "uuseg" {>= "17.0"}
+  "trace" {>= "0.12"}
+  "cohttp-lwt" {with-test}
+  "alcotest" {with-test}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/ahrefs/ocaml-ai-sdk.git"
+x-maintenance-intent: ["(latest)"]
+url {
+  src:
+    "https://github.com/ahrefs/ocaml-ai-sdk/releases/download/0.6.3/ocaml-ai-sdk-0.6.3.tbz"
+  checksum: [
+    "sha256=0cc0a957784c295877b6bcc4f80c0dba0f6507d3c282e7d6cbd71038050376de"
+    "sha512=f8e082376b4de194a877d0df193892cdaa8139a4789f51eebac651acf8b6d4064b95242e158d86c1a32776d99130d43ed4c1119e2d54e738e93bdba2a6ad9a33"
+  ]
+}
+x-commit-hash: "fe91855a2b1be51e96bff38b68b31b0f67ab13cf"


### PR DESCRIPTION
OCaml AI SDK - Provider abstraction for AI models

- Project page: <a href="https://github.com/ahrefs/ocaml-ai-sdk">https://github.com/ahrefs/ocaml-ai-sdk</a>
- Documentation: <a href="https://github.com/ahrefs/ocaml-ai-sdk">https://github.com/ahrefs/ocaml-ai-sdk</a>

##### CHANGES:


