### PR TITLE
Add: brr.0.0.9

### DIFF
--- a/packages/brr/brr.0.0.9/opam
+++ b/packages/brr/brr.0.0.9/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+synopsis: "Browser programming toolkit for OCaml"
+description: """\
+Brr is a toolkit for programming browsers in OCaml with the
+[`js_of_ocaml`][jsoo] compiler. It provides:
+
+* Interfaces to a selection of browser APIs.
+* An OCaml console developer tool for live interaction 
+  with programs running in web pages.
+* A JavaScript FFI for idiomatic OCaml programming.
+
+Brr is distributed under the ISC license. It depends on the
+`js_of_ocaml` compiler and runtime – but not on its libraries or
+syntax extension.
+
+[jsoo]: https://ocsigen.org/js_of_ocaml
+
+Homepage: <https://erratique.ch/software/brr>"""
+maintainer: "Daniel Bünzli <daniel.buenzl i@erratique.ch>"
+authors: "The brr programmers"
+license: ["ISC" "BSD-3-Clause"]
+tags: ["reactive" "declarative" "frp" "front-end" "browser" "org:erratique"]
+homepage: "https://erratique.ch/software/brr"
+doc: "https://erratique.ch/software/brr/doc/"
+bug-reports: "https://github.com/dbuenzli/brr/issues"
+depends: [
+  "ocaml" {>= "4.08.0"}
+  "ocamlfind" {build}
+  "ocamlbuild" {build}
+  "topkg" {build & >= "1.1.0"}
+  "js_of_ocaml-compiler" {>= "6.0.1"}
+  "js_of_ocaml-toplevel" {>= "6.0.1"}
+]
+build: ["ocaml" "pkg/pkg.ml" "build" "--dev-pkg" "%{dev}%"]
+dev-repo: "git+https://erratique.ch/repos/brr.git"
+url {
+  src: "https://erratique.ch/software/brr/releases/brr-0.0.9.tbz"
+  checksum:
+    "sha512=45cdf73c6a23c8fc4609a32ae2196d4790e5bdba34ca0b784bff9c0b70dab233eb336f1c11dc3002451042ff4cf25b643098ad0d011f14c3d6175842113bed21"
+}
+x-maintenance-intent: ["(latest)"]


### PR DESCRIPTION
* Add: `brr.0.0.9` [home](https://erratique.ch/software/brr), [doc](https://erratique.ch/software/brr/doc/), [issues](https://github.com/dbuenzli/brr/issues)  
  *Browser programming toolkit for OCaml*


---

#### `brr` v0.0.9 2026-09-08 Zagreb

- Add `El.dialog`.
- Add `At.{role,popover,popoveraction,popovertargetaction`}.
- Add `El.{show,hide,toggle}_popover`.
- Replace deprecated and unsupported `Gpu.Adapter.request_adapter_info` 
  by `Gpu.Adapter.info`.
  Thanks to Jack Nørskov Jørgensen for the patch ([#82](https://github.com/dbuenzli/brr/issues/82)).
- Fix `Fetch.Request.method'`.
  Thanks to Puneeth Chaganti for the patch ([#83](https://github.com/dbuenzli/brr/issues/83)).
- Fix binding to `Audio.Buffer.duration_s`.
  Thanks to Raoul Hidalgo Charman ([#85](https://github.com/dbuenzli/brr/issues/85)).

---

Use `b0 -- .opam publish brr.0.0.9` to update the pull request.