### PR TITLE
Fix re2 v-bound in ocaml-ai-sdk 0.6, 0.6.1, 0.6.2

### DIFF
--- a/packages/ocaml-ai-sdk/ocaml-ai-sdk.0.6.1/opam
+++ b/packages/ocaml-ai-sdk/ocaml-ai-sdk.0.6.1/opam
@@ -20,7 +20,7 @@ depends: [
   "base64" {>= "1.3"}
   "ppx_deriving" {>= "5.2"}
   "lwt_ppx" {>= "5.9"}
-  "re2" {>= "0.16"}
+  "re2" {>= "v0.16"}
   "uuseg" {>= "17.0"}
   "trace" {>= "0.12"}
   "cohttp-lwt" {with-test}

--- a/packages/ocaml-ai-sdk/ocaml-ai-sdk.0.6.2/opam
+++ b/packages/ocaml-ai-sdk/ocaml-ai-sdk.0.6.2/opam
@@ -20,7 +20,7 @@ depends: [
   "base64" {>= "1.3"}
   "ppx_deriving" {>= "5.2"}
   "lwt_ppx" {>= "5.9"}
-  "re2" {>= "0.16"}
+  "re2" {>= "v0.16"}
   "uuseg" {>= "17.0"}
   "trace" {>= "0.12"}
   "cohttp-lwt" {with-test}

--- a/packages/ocaml-ai-sdk/ocaml-ai-sdk.0.6/opam
+++ b/packages/ocaml-ai-sdk/ocaml-ai-sdk.0.6/opam
@@ -20,7 +20,7 @@ depends: [
   "base64" {>= "1.3"}
   "ppx_deriving" {>= "5.2"}
   "lwt_ppx" {>= "5.9"}
-  "re2" {>= "0.16"}
+  "re2" {>= "v0.16"}
   "uuseg" {>= "17.0"}
   "trace" {>= "0.12"}
   "cohttp-lwt" {with-test}


### PR DESCRIPTION
First batch was fixed here: https://github.com/ocaml/opam-repository/pull/30225

3 versions have been published since with a 4th one coming: https://github.com/ocaml/opam-repository/pull/30681