### PR TITLE
Fix ppx_yojson_conv{,_lib} v-bounds in oxbow 0.1.0 and 0.1.1

### DIFF
--- a/packages/oxbow/oxbow.0.1.0/opam
+++ b/packages/oxbow/oxbow.0.1.0/opam
@@ -29,8 +29,8 @@ depends: [
   "landmarks" {>= "1.7"}
   "landmarks-ppx" {>= "1.7"}
   "logs" {>= "0.10"}
-  "ppx_yojson_conv" {>= "0.17"}
-  "ppx_yojson_conv_lib" {>= "0.17"}
+  "ppx_yojson_conv" {>= "v0.17"}
+  "ppx_yojson_conv_lib" {>= "v0.17"}
   "re" {>= "1.12"}
   "wayland" {>= "2.3"}
   "xkbcommon" {>= "0.1"}

--- a/packages/oxbow/oxbow.0.1.1/opam
+++ b/packages/oxbow/oxbow.0.1.1/opam
@@ -28,8 +28,8 @@ depends: [
   "landmarks" {>= "1.7"}
   "landmarks-ppx" {>= "1.7"}
   "logs" {>= "0.10"}
-  "ppx_yojson_conv" {>= "0.17"}
-  "ppx_yojson_conv_lib" {>= "0.17"}
+  "ppx_yojson_conv" {>= "v0.17"}
+  "ppx_yojson_conv_lib" {>= "v0.17"}
   "re" {>= "1.12"}
   "wayland" {>= "2.3"}
   "xkbcommon" {>= "0.1"}


### PR DESCRIPTION
This fixes `ppx_yojson_conv` and  `ppx_yojson_conv_lib` `v`-bounds for `oxbow`.

CC: @3L0C 

This is a common trip-wise - a real foot gun IMO: Some packages (a minority) use a version scheme starting with a `v`.
As a result, the bounds instead compare characters `v` and `0`, which is typically not the intention... :grimacing: 
Please consider fixing this upstream. :pray: 