### PR TITLE
[new release] tiny_httpd (3 packages) (0.22)

### DIFF
--- a/packages/tiny_httpd/tiny_httpd.0.22/opam
+++ b/packages/tiny_httpd/tiny_httpd.0.22/opam
@@ -1,0 +1,53 @@
+opam-version: "2.0"
+synopsis: "Minimal HTTP server using threads"
+maintainer: ["c-cube"]
+authors: ["c-cube"]
+license: "MIT"
+tags: [
+  "http" "thread" "server" "tiny_httpd" "http_of_dir" "simplehttpserver"
+]
+homepage: "https://github.com/c-cube/tiny_httpd/"
+bug-reports: "https://github.com/c-cube/tiny_httpd/issues"
+depends: [
+  "dune" {>= "3.2"}
+  "seq"
+  "base-threads"
+  "result"
+  "hmap"
+  "iostream" {>= "0.2"}
+  "ocaml" {>= "4.13"}
+  "odoc" {with-doc}
+  "logs" {with-test}
+  "conf-libcurl" {with-test}
+  "ptime" {with-test}
+  "qcheck-core" {>= "0.91" & with-test}
+]
+depopts: [
+  "logs"
+  "magic-mime"
+  "mtime" {>= "2.0"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/c-cube/tiny_httpd.git"
+url {
+  src:
+    "https://github.com/c-cube/tiny_httpd/releases/download/v0.22/tiny_httpd-0.22.tbz"
+  checksum: [
+    "sha256=09fb93125c26b99f8714d0060dd3fb972046cde3ff935626d495b25e80543d8e"
+    "sha512=5751a0ac007c8cad11255d08b4915c8a8fb82ad33d28e58809ef1e29dc8c8f2fceb0dd15ecbe1fda5b5db2edbbc9479fa1d0690a4a25949e1d1b375ea13bd1a9"
+  ]
+}
+x-commit-hash: "7fc1f962760bce4efa11975db5079d8fd0e71fdc"

--- a/packages/tiny_httpd_camlzip/tiny_httpd_camlzip.0.22/opam
+++ b/packages/tiny_httpd_camlzip/tiny_httpd_camlzip.0.22/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+synopsis: "Interface to camlzip for tiny_httpd"
+maintainer: ["c-cube"]
+authors: ["c-cube"]
+license: "MIT"
+homepage: "https://github.com/c-cube/tiny_httpd/"
+bug-reports: "https://github.com/c-cube/tiny_httpd/issues"
+depends: [
+  "dune" {>= "3.2"}
+  "tiny_httpd" {= version}
+  "camlzip" {>= "1.06"}
+  "iostream-camlzip" {>= "0.2.1"}
+  "logs" {with-test}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/c-cube/tiny_httpd.git"
+url {
+  src:
+    "https://github.com/c-cube/tiny_httpd/releases/download/v0.22/tiny_httpd-0.22.tbz"
+  checksum: [
+    "sha256=09fb93125c26b99f8714d0060dd3fb972046cde3ff935626d495b25e80543d8e"
+    "sha512=5751a0ac007c8cad11255d08b4915c8a8fb82ad33d28e58809ef1e29dc8c8f2fceb0dd15ecbe1fda5b5db2edbbc9479fa1d0690a4a25949e1d1b375ea13bd1a9"
+  ]
+}
+x-commit-hash: "7fc1f962760bce4efa11975db5079d8fd0e71fdc"

--- a/packages/tiny_httpd_eio/tiny_httpd_eio.0.22/opam
+++ b/packages/tiny_httpd_eio/tiny_httpd_eio.0.22/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+synopsis: "Use eio for tiny_httpd"
+maintainer: ["c-cube"]
+authors: ["c-cube"]
+license: "MIT"
+homepage: "https://github.com/c-cube/tiny_httpd/"
+bug-reports: "https://github.com/c-cube/tiny_httpd/issues"
+depends: [
+  "dune" {>= "3.2"}
+  "tiny_httpd" {= version}
+  "eio" {>= "1.0" & < "2.0"}
+  "base-unix"
+  "logs" {with-test}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/c-cube/tiny_httpd.git"
+url {
+  src:
+    "https://github.com/c-cube/tiny_httpd/releases/download/v0.22/tiny_httpd-0.22.tbz"
+  checksum: [
+    "sha256=09fb93125c26b99f8714d0060dd3fb972046cde3ff935626d495b25e80543d8e"
+    "sha512=5751a0ac007c8cad11255d08b4915c8a8fb82ad33d28e58809ef1e29dc8c8f2fceb0dd15ecbe1fda5b5db2edbbc9479fa1d0690a4a25949e1d1b375ea13bd1a9"
+  ]
+}
+x-commit-hash: "7fc1f962760bce4efa11975db5079d8fd0e71fdc"


### PR DESCRIPTION
Minimal HTTP server using threads

- Project page: <a href="https://github.com/c-cube/tiny_httpd/">https://github.com/c-cube/tiny_httpd/</a>

##### CHANGES:

- mask authorization header by default in responses, too
- fix header bugs related to casing
- forbid duplicates for some sensitive headers
- in dir serving, check paths even for chunked uploads
