### PR TITLE
Package binaryen.0.40.0

### DIFF
--- a/packages/binaryen/binaryen.0.40.0/opam
+++ b/packages/binaryen/binaryen.0.40.0/opam
@@ -1,0 +1,28 @@
+opam-version: "2.0"
+synopsis: "OCaml bindings for Binaryen"
+maintainer: "oscar@grain-lang.org"
+authors: "Oscar Spencer"
+license: " Apache-2.0"
+homepage: "https://github.com/grain-lang/binaryen.ml"
+bug-reports: "https://github.com/grain-lang/binaryen.ml/issues"
+depends: [
+  "ocaml" {>= "4.14.0"}
+  "dune" {>= "3.0.0"}
+  "dune-configurator" {>= "3.0.0"}
+  "js_of_ocaml-compiler" {>= "6.4.0" & < "7.0.0"}
+  "libbinaryen" {>= "130.0.0" & < "131.0.0"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+]
+dev-repo: "git+https://github.com/grain-lang/binaryen.ml.git"
+url {
+  src:
+    "https://github.com/grain-lang/binaryen.ml/releases/download/v0.40.0/binaryen-archive-v0.40.0.tar.gz"
+  checksum: [
+    "md5=fd5826bad93c758c0f9930c1b837f2bc"
+    "sha512=4b83b599f8656f6cf0b9631e97976aa688db4774f43b51e2dbd40e7705f71dad33b95a19c8433aaaaf1e75cb522d2700acf12d4883330169147a4db318aa466c"
+  ]
+}
+x-maintenance-intent: ["0.(latest)"]


### PR DESCRIPTION
### `binaryen.0.40.0`
OCaml bindings for Binaryen



---
* Homepage: https://github.com/grain-lang/binaryen.ml
* Source repo: git+https://github.com/grain-lang/binaryen.ml.git
* Bug tracker: https://github.com/grain-lang/binaryen.ml/issues

---
:camel: Pull-request generated by opam-publish v2.7.1