### PR TITLE
[new release] modelkit (4 packages) (0.5.0)

### DIFF
--- a/packages/modelkit-nx/modelkit-nx.0.5.0/opam
+++ b/packages/modelkit-nx/modelkit-nx.0.5.0/opam
@@ -1,0 +1,44 @@
+opam-version: "2.0"
+synopsis: "Checked Nx tensor admission for ModelKit"
+description:
+  "ModelKit Nx converts explicitly typed Nx tensors into immutable ModelKit features, targets, masks, groups, names, and weights with typed validation and allocation reports."
+maintainer: ["Asara developers <devs@asara.io>"]
+authors: ["Asara"]
+license: "Apache-2.0"
+tags: ["data-science" "machine-learning" "adapters" "tensors"]
+homepage: "https://github.com/asara-io/ModelKit"
+bug-reports: "https://github.com/asara-io/ModelKit/issues"
+depends: [
+  "dune" {>= "3.23"}
+  "ocaml" {>= "5.2"}
+  "modelkit" {= version}
+  "nx" {= "1.0.0~alpha3"}
+  "alcotest" {with-test & >= "1.9.0"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/asara-io/ModelKit.git"
+x-maintenance-intent: ["(latest)"]
+available: os != "win32"
+url {
+  src:
+    "https://github.com/asara-io/ModelKit/releases/download/0.5.0/modelkit-0.5.0.tbz"
+  checksum: [
+    "sha256=1fe8fa7c7f904dd098a21a2ca30fd69230750b8cf8aa2ae481b97a16531b47b4"
+    "sha512=c946cd1ac014726f4d21791e14d806a205680e6edfa2f80ed8d3680f24f48ca3c5a2f89d5afa68c11eac4053ead448b6381fb3d06dc8ff129097af6c69b262fb"
+  ]
+}
+x-commit-hash: "0a8876ab1daa76a266632d98dbda7b41f2b629dc"

--- a/packages/modelkit-parallel/modelkit-parallel.0.5.0/opam
+++ b/packages/modelkit-parallel/modelkit-parallel.0.5.0/opam
@@ -1,0 +1,43 @@
+opam-version: "2.0"
+synopsis: "Bounded parallel execution for ModelKit"
+description:
+  "ModelKit Parallel provides an optional Domainslib execution backend for deterministic bounded cross-validation."
+maintainer: ["Asara developers <devs@asara.io>"]
+authors: ["Asara"]
+license: "Apache-2.0"
+tags: ["data-science" "machine-learning" "parallelism"]
+homepage: "https://github.com/asara-io/ModelKit"
+bug-reports: "https://github.com/asara-io/ModelKit/issues"
+depends: [
+  "dune" {>= "3.23"}
+  "ocaml" {>= "5.2"}
+  "modelkit" {= version}
+  "domainslib" {>= "0.5.2"}
+  "alcotest" {with-test & >= "1.9.0"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/asara-io/ModelKit.git"
+x-maintenance-intent: ["(latest)"]
+url {
+  src:
+    "https://github.com/asara-io/ModelKit/releases/download/0.5.0/modelkit-0.5.0.tbz"
+  checksum: [
+    "sha256=1fe8fa7c7f904dd098a21a2ca30fd69230750b8cf8aa2ae481b97a16531b47b4"
+    "sha512=c946cd1ac014726f4d21791e14d806a205680e6edfa2f80ed8d3680f24f48ca3c5a2f89d5afa68c11eac4053ead448b6381fb3d06dc8ff129097af6c69b262fb"
+  ]
+}
+x-commit-hash: "0a8876ab1daa76a266632d98dbda7b41f2b629dc"

--- a/packages/modelkit-talon/modelkit-talon.0.5.0/opam
+++ b/packages/modelkit-talon/modelkit-talon.0.5.0/opam
@@ -1,0 +1,45 @@
+opam-version: "2.0"
+synopsis: "Checked Talon dataframe column admission for ModelKit"
+description:
+  "ModelKit Talon converts explicitly selected, typed Talon dataframe columns into immutable ModelKit features, targets, masks, groups, names, and weights with typed validation and allocation reports."
+maintainer: ["Asara developers <devs@asara.io>"]
+authors: ["Asara"]
+license: "Apache-2.0"
+tags: ["data-science" "machine-learning" "adapters" "dataframes"]
+homepage: "https://github.com/asara-io/ModelKit"
+bug-reports: "https://github.com/asara-io/ModelKit/issues"
+depends: [
+  "dune" {>= "3.23"}
+  "ocaml" {>= "5.2"}
+  "modelkit" {= version}
+  "talon" {= "1.0.0~alpha3"}
+  "nx" {= "1.0.0~alpha3"}
+  "alcotest" {with-test & >= "1.9.0"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/asara-io/ModelKit.git"
+x-maintenance-intent: ["(latest)"]
+available: os != "win32"
+url {
+  src:
+    "https://github.com/asara-io/ModelKit/releases/download/0.5.0/modelkit-0.5.0.tbz"
+  checksum: [
+    "sha256=1fe8fa7c7f904dd098a21a2ca30fd69230750b8cf8aa2ae481b97a16531b47b4"
+    "sha512=c946cd1ac014726f4d21791e14d806a205680e6edfa2f80ed8d3680f24f48ca3c5a2f89d5afa68c11eac4053ead448b6381fb3d06dc8ff129097af6c69b262fb"
+  ]
+}
+x-commit-hash: "0a8876ab1daa76a266632d98dbda7b41f2b629dc"

--- a/packages/modelkit/modelkit.0.5.0/opam
+++ b/packages/modelkit/modelkit.0.5.0/opam
@@ -1,0 +1,43 @@
+opam-version: "2.0"
+synopsis: "Portable classical machine learning workflows for OCaml"
+description:
+  "ModelKit is a native OCaml library for cohesive classical machine learning workflows. It is designed around immutable estimator specifications, leakage-safe pipelines, deterministic evaluation, and portable fitted artifacts."
+maintainer: ["Asara developers <devs@asara.io>"]
+authors: ["Asara"]
+license: "Apache-2.0"
+tags: ["data-science" "machine-learning"]
+homepage: "https://github.com/asara-io/ModelKit"
+bug-reports: "https://github.com/asara-io/ModelKit/issues"
+depends: [
+  "dune" {>= "3.23"}
+  "ocaml" {>= "5.2"}
+  "alcotest" {with-test & >= "1.9.0"}
+  "mdx" {with-test & >= "2.4.0"}
+  "qcheck-core" {with-test & >= "0.90"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/asara-io/ModelKit.git"
+x-maintenance-intent: ["(latest)"]
+url {
+  src:
+    "https://github.com/asara-io/ModelKit/releases/download/0.5.0/modelkit-0.5.0.tbz"
+  checksum: [
+    "sha256=1fe8fa7c7f904dd098a21a2ca30fd69230750b8cf8aa2ae481b97a16531b47b4"
+    "sha512=c946cd1ac014726f4d21791e14d806a205680e6edfa2f80ed8d3680f24f48ca3c5a2f89d5afa68c11eac4053ead448b6381fb3d06dc8ff129097af6c69b262fb"
+  ]
+}
+x-commit-hash: "0a8876ab1daa76a266632d98dbda7b41f2b629dc"


### PR DESCRIPTION
Portable classical machine learning workflows for OCaml

- Project page: <a href="https://github.com/asara-io/ModelKit">https://github.com/asara-io/ModelKit</a>

##### CHANGES:

- Publish the third-party estimator authoring guide, metadata-aware conformance
  checks, component provenance, and explicit fitted-pipeline artifact-support
  reports. A separately built public-only consumer participates unchanged in
  nested composition, metadata routing, parallel cross-validation, and
  randomized search; external codecs remain opt-in reviewed work and unsupported
  encoding returns a typed error.
- Add candidate-boundary search checkpoints with partial evaluation reports,
  bounded data-only serialization, full data/split/configuration identity checks,
  and deterministic resumption across process restarts and execution backends.
- Add successive-halving search over grid or randomized candidates with nested
  training-row budgets, deterministic promotion, class and weight feasibility
  checks, fresh fits, per-round reports, and optional bounded full-data refitting.
- Add typed randomized parameter distributions and search with finite sampling
  without replacement, distribution sampling, and deterministic candidate streams.
- Share named-score, no-refit, and custom multi-metric selection policies across
  grid and randomized search while preserving existing named-refit entry points.
- Add typed supervised pipelines, dense column transformation, feature unions,
  and nested preprocessing chains with fold-local fitting.
- Route requested weights, groups, and callbacks through nested consumers,
  cross-validation, search, and full-data refit with bounded cancellation.
- Add stratified-group K-fold, predefined, leave-one-out, and leave-one-group-out
  splitters with explicit coverage, feasibility, and group-exclusion contracts.
- Add shuffle, stratified-shuffle, holdout, and repeated K-fold splitters, plus
  aligned train/test dataset splitting with explicit counts and fractional sizes.
- Add transformed-target regression with fold-local target fitting, metadata
  requests, checked inverse transforms, and original-space predictions.
- Record producer version 0.5.0 in newly written artifacts while retaining
  compatibility with existing readers and golden artifacts.
