### PR TITLE
[new release] mfetch (0.1.1)

### DIFF
--- a/packages/mfetch/mfetch.0.1.1/opam
+++ b/packages/mfetch/mfetch.0.1.1/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+maintainer:   "Romain Calascibetta <romain.calascibetta@gmail.com>"
+authors:      "Romain Calascibetta <romain.calascibetta@gmail.com>"
+homepage:     "https://git.robur.coop/robur/mfetch"
+bug-reports:  "https://git.robur.coop/robur/mfetch/issues"
+dev-repo:     "git+https://github.com/robur-coop/mfetch.git"
+license:      "AGPL-3.0-or-later"
+synopsis:     "A tool to fetch dependencies of an OCaml project"
+build: [
+  [ "dune" "build" "-p" name "-j" jobs ]
+]
+depends: [
+  "ocaml"             {>= "5.4"}
+  "dune"              {>= "2.8.0"}
+  "httpcats"          {>= "0.3.1"}
+  "ca-certs"
+  "carton-miou"
+  "opam-file-format"  {>= "2.2.0"}
+  "ohex"
+  "tar"
+  "flux"
+  "fluxt"             {>= "0.0.1~beta7"}
+  "logs"
+  "bcfg"
+  "fmt"
+  "fpath"
+  "cmdliner"
+  "progress"
+  "mirage-crypto-rng" {>= "1.2.0"}
+  "alcotest" {with-test}
+]
+url {
+  src:
+    "https://github.com/robur-coop/mfetch/releases/download/v0.1.1/mfetch-0.1.1.tbz"
+  checksum: [
+    "sha256=26433733f8ac9c6b3c4b44e7d1d3c0460d8e4db0d6e2670bc75fbb8749a3de98"
+    "sha512=03a1c15e9f448d162483bc2380ad81fc3f3709e1786a0f3ba27b90fdefc3a63667f9ce9bbf4291a505a4cf0901bc32c32a95e24165d65b5a54b049eabc7c5f44"
+  ]
+}
+x-commit-hash: "51256fe15bbe4bf8f4bb3a76d32566bf5f4009c9"


### PR DESCRIPTION
A tool to fetch dependencies of an OCaml project

- Project page: <a href="https://git.robur.coop/robur/mfetch">https://git.robur.coop/robur/mfetch</a>

##### CHANGES:

- Handle smart version 1 protocol (@dinosaure, fix [robur-coop/mfetch#11][11], [!12][12])

[12]: https://git.robur.coop/robur/mfetch/pulls/12
[11]: https://git.robur.coop/robur/mfetch/issues/11
