### PR TITLE
metapp.0.4.4: update download URL to ocamllibs

### DIFF
--- a/packages/metapp/metapp.0.4.4/opam
+++ b/packages/metapp/metapp.0.4.4/opam
@@ -37,7 +37,7 @@ build: [
 dev-repo: "git+https://github.com/thierry-martinez/metapp.git"
 url {
   src:
-    "https://github.com/thierry-martinez/metapp/releases/download/v0.4.4/metapp.0.4.4.tar.gz"
+    "https://github.com/ocamllibs/metapp/releases/download/v0.4.4/metapp.0.4.4.tar.gz"
   checksum: [
     "sha512=817b33d9006a6849845e29a2b12ad7b7d13e34e38216bd2724df45e8f24356f9d281e2731ecc37a8ab2b5faef844252a04f976adf61d024b7653235e38dfdc46"
   ]


### PR DESCRIPTION
My other opam installation was failing with

```
#=== ERROR while fetching sources for metapp.0.4.4 ============================#
OpamSolution.Fetch_fail("https://github.com/thierry-martinez/metapp/releases/download/v0.4.4/metapp.0.4.4.tar.gz (code 404 while downloading https://github.com/thierry-martinez/metapp/releases/download/v0.4.4/metapp.0.4.4.tar.gz)")
```

I pinned it to ocamllibs/metapp instead which worked.