### PR TITLE
[new release] x509 (1.2.0)

### DIFF
--- a/packages/x509/x509.1.2.0/opam
+++ b/packages/x509/x509.1.2.0/opam
@@ -1,0 +1,60 @@
+opam-version: "2.0"
+maintainer: [
+  "Hannes Mehnert <hannes@mehnert.org>"
+]
+authors: [
+  "Hannes Mehnert <hannes@mehnert.org>"
+  "David Kaloper <dk505@cam.ac.uk>"
+]
+license: "BSD-2-Clause"
+tags: "org:mirage"
+homepage: "https://github.com/mirleft/ocaml-x509"
+doc: "https://mirleft.github.io/ocaml-x509/doc"
+bug-reports: "https://github.com/mirleft/ocaml-x509/issues"
+depends: [
+  "ocaml" {>= "4.13.0"}
+  "dune" {>= "2.0"}
+  "asn1-combinators" {>= "0.3.1"}
+  "ptime"
+  "base64" {>= "3.3.0"}
+  "mirage-crypto" {>= "1.0.0"}
+  "mirage-crypto-pk"
+  "mirage-crypto-ec" {>= "0.10.7"}
+  "mirage-crypto-rng"
+  "mirage-crypto-rng" {with-test & >= "1.2.0"}
+  "fmt" {>= "0.8.7"}
+  "alcotest" {with-test}
+  "gmap" {>= "0.3.0"}
+  "domain-name" {>= "0.3.0"}
+  "logs"
+  "kdf" {>= "1.0.0"}
+  "ohex" {>= "0.2.0"}
+  "ipaddr" {>= "5.2.0"}
+]
+conflicts: [ "result" {< "1.5"} ]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/mirleft/ocaml-x509.git"
+synopsis: "Public Key Infrastructure (RFC 5280, PKCS) purely in OCaml"
+description: """
+X.509 is a public key infrastructure used mostly on the Internet.  It consists
+of certificates which include public keys and identifiers, signed by an
+authority. Authorities must be exchanged over a second channel to establish the
+trust relationship. This library implements most parts of RFC5280 and RFC6125.
+The Public Key Cryptography Standards (PKCS) defines encoding and decoding
+(in ASN.1 DER and PEM format), which is also implemented by this library -
+namely PKCS 1, PKCS 5, PKCS 7, PKCS 8, PKCS 9, PKCS 10, and PKCS 12.
+"""
+x-maintenance-intent: [ "(latest)" ]
+url {
+  src:
+    "https://github.com/mirleft/ocaml-x509/releases/download/v1.2.0/x509-1.2.0.tbz"
+  checksum: [
+    "sha256=483f529096a1fcedc3f9827b826819d6a294f97aba08f903eb6bf89fb0f61674"
+    "sha512=64fc696920d08bf05d445871354eed1465173fdc94b6eab2f069ff126fe1218dc5aa660b560a7bd47956ae6a03b68ccfe765f80777cdc9482f0efe25336fa2b4"
+  ]
+}
+x-commit-hash: "6157b3c68ece98b1701cba683a973bb140ca9a67"


### PR DESCRIPTION
Public Key Infrastructure (RFC 5280, PKCS) purely in OCaml

- Project page: <a href="https://github.com/mirleft/ocaml-x509">https://github.com/mirleft/ocaml-x509</a>
- Documentation: <a href="https://mirleft.github.io/ocaml-x509/doc">https://mirleft.github.io/ocaml-x509/doc</a>

##### CHANGES:

* BREAKING: Distinguished_name: separate equality from matching. Introduce
  `matches` which compares the data, and treats ignores the tag UTF8 and
  Printable - and redefine `equal` which now compares the tags. The function
  `matches` is used for Validation.issuer_matches_subject and build_paths.
  (mirleft/ocaml-x509#192 @torinnd)
* BREAKING: Distinguished_name: preserve string encoding by using typed
  attribute values (mirleft/ocaml-x509#188 @torinnd)
* BREAKING: Certificate.hostnames: adapt to RFC 9525 Section 1 and only use
  SubjectAlternativeName values for validation (mirleft/ocaml-x509#190 @hannesm)
* BUGFIX: Signing_request.sign_certificate: use the subject of the certificate
  passed in as _issuer_ of the certificate that is returned. (mirleft/ocaml-x509#184 @torinnd)
* BUGFIX: Distinguished_name.common_name: fix the lookup, adapt the
  documentation to be exact - it is from the most specific RDN (mirleft/ocaml-x509#187 @torinnd)
* BUGFIX: Name constraints: treat permitted name subtress as union per name
  form, previously some valid chains were not accepted (mirleft/ocaml-x509#185 @torinnd)
* Tests: remove certificates, generate them on the fly (mirleft/ocaml-x509#189 @hannesm)

This work was partially funded by Tarides