### PR TITLE
Add: bytesrw.0.4.1

### DIFF
--- a/packages/bytesrw/bytesrw.0.4.1/opam
+++ b/packages/bytesrw/bytesrw.0.4.1/opam
@@ -1,0 +1,118 @@
+opam-version: "2.0"
+synopsis: "Composable byte stream readers and writers for OCaml"
+description: """\
+Bytesrw extends the OCaml `Bytes` module with composable, memory
+efficient, byte stream readers and writers compatible with effect
+based concurrency.
+
+Except for byte slice life-times, these abstractions intentionally
+separate away resource management and the specifics of reading and
+writing bytes.
+
+Bytesrw distributed under the ISC license. It has no dependencies.
+
+Optional support for compressed, hashed and encrypted bytes depend, at
+your wish, on the C [`zlib`], [`libzstd`], [`blake3`], [`libmd`],
+[`xxhash`] and  [`mbedtls`] libraries.
+
+[`blake3`]: https://blake3.io
+[`libzstd`]: http://zstd.net
+[`libmd`]: https://www.hadrons.org/software/libmd/
+[`xxhash`]: https://xxhash.com/
+[`zlib`]: https://zlib.net
+[`mbedtls`]: https://www.trustedfirmware.org/projects/mbed-tls
+
+Homepage: <https://erratique.ch/software/bytesrw/>"""
+maintainer: "Daniel Bünzli <daniel.buenzl i@erratique.ch>"
+authors: "The bytesrw programmers"
+license: "ISC"
+tags: [
+  "bytes"
+  "entropy"
+  "streaming"
+  "zstd"
+  "zlib"
+  "gzip"
+  "deflate"
+  "random"
+  "csprng"
+  "sha1"
+  "sha2"
+  "compression"
+  "hashing"
+  "utf"
+  "xxhash"
+  "blake3"
+  "psa"
+  "tls"
+  "websocket"
+  "cryptography"
+  "sha3"
+  "org:erratique"
+]
+homepage: "https://erratique.ch/software/bytesrw"
+doc: "https://erratique.ch/software/bytesrw/doc"
+bug-reports: "https://github.com/dbuenzli/bytesrw/issues"
+depends: [
+  "ocaml" {>= "4.14.0"}
+  "ocamlfind" {build}
+  "ocamlbuild" {build}
+  "topkg" {build & >= "1.1.1"}
+  "conf-pkg-config" {build}
+]
+depopts: [
+  "conf-mbedtls"
+  "conf-xxhash"
+  "conf-zlib"
+  "conf-zstd"
+  "conf-libmd"
+  "conf-libblake3"
+  "cmdliner"
+  "b0"
+]
+conflicts: [
+  "conf-zstd" {< "1.3.8"}
+  "cmdliner" {< "2.0.0"}
+  "b0" {< "0.0.7"}
+]
+build: [
+  [
+    "ocaml"
+    "pkg/pkg.ml"
+    "build"
+    "--dev-pkg"
+    "%{dev}%"
+    "--with-cmdliner"
+    "%{cmdliner:installed}%"
+    "--with-b0"
+    "%{b0:installed}%"
+    "--with-conf-libblake3"
+    "%{conf-libblake3:installed}%"
+    "--with-conf-mbedtls"
+    "%{conf-mbedtls:installed}%"
+    "--with-conf-libmd"
+    "%{conf-libmd:installed}%"
+    "--with-conf-xxhash"
+    "%{conf-xxhash:installed}%"
+    "--with-conf-zlib"
+    "%{conf-zlib:installed}%"
+    "--with-conf-zstd"
+    "%{conf-zstd:installed}%"
+  ]
+  [
+    "cmdliner"
+    "install"
+    "tool-support"
+    "--update-opam-install=%{_:name}%.install"
+    "_build/test/certown.native:certown" {ocaml:native}
+    "_build/test/certown.byte:certown" {!ocaml:native}
+    "_build/cmdliner-install"
+  ] {cmdliner:installed & b0:installed & conf-mbedtls:installed}
+]
+dev-repo: "git+https://erratique.ch/repos/bytesrw.git"
+url {
+  src: "https://erratique.ch/software/bytesrw/releases/bytesrw-0.4.1.tbz"
+  checksum:
+    "sha512=9d4d65ff080a107f2ed35c4f13ac77c20e4920e92dffe84c270f23169d7db130506a450aa83a6c6c621ce80b699191291fb8be227d1fb47fb5fd49ddc150b37e"
+}
+x-maintenance-intent: ["(latest)"]


### PR DESCRIPTION
* Add: `bytesrw.0.4.1` [home](https://erratique.ch/software/bytesrw), [doc](https://erratique.ch/software/bytesrw/doc), [issues](https://github.com/dbuenzli/bytesrw/issues)  
  *Composable byte stream readers and writers for OCaml*


---

#### `bytesrw` v0.4.1 2026-09-12 Zagreb

- Add `Bytes.Writer.make'` which allows to access the writer in the
  write function.

- Fix `Bytesrw_fmt.Slice.pp' ~head:true`, the ellipsis could be
  missing on truncated output. Thanks to Anil Madhavapeddy for the
  report.

- Fix `Bytes.Slice.of_bigbytes_or_eod` on empty ranges. It raised
  `Invalid_argument` instead of returning `eod`. Thanks to Anil
  Madhavapeddy for the report and the fix.

- Fix `Bytes.Reader.empty` ignoring its `pos` and `slice_length`
  optional argument. Indirectly affected the result of
  `Bytes.Reader.{of_bytes,of_string,of_slice,sub}` when those would
  return an empty stream reader. Thanks to Anil Madhavapeddy for the
  report and the fix.

- Fix `Bytes.Writer.limit` filter raising `Invalid_argument` instead
  of a `Stream.Limit` error if the last write is exactly in the
  limit but the next one blows it ([#15](https://github.com/dbuenzli/bytesrw/issues/15)). Thanks to Vladimir N. Silyaev
  and Anil Madhavapeddy for the report and the fix.

- Fix `Bytes.Writer.limit` resulting's writer `Writer.pos` final value.
  Cap it at what is supposed to be seen by the limit.
  Thanks to Anil Madhavapeddy for the report and the fix.

- Fix `Bytesrw_zstd.decompress_writes` position error reporting. 
  The reported positions were in the decompressed stream rather
  than in the compressed stream.

- Fix `Bytesrw_sysrandom` potential unwarranted panics on Linux due to short
  `getrandom` results or `EINTR`. Thanks to Anil Madhavapeddy for the
  report and the fix.

- Fix `Bytesrw_xxhash.Xxhash_128.update` using `Xxhash_64.update`.
  This doesn't change previously generated hashes as libxxahsh 0.8.x
  use the same implementation for both. Thanks to Anil Madhavapeddy
  for the report and the fix.

### `Bytesrw_crypto` 

- Add `Psa.Alg.is_tls12_psk_to_ms` wrongly assumed not to be in
  TF-PSA-Crypto due to a typo. Thanks to Anil Madhavapeddy for the
  report and the fix.

- Fix C binding to `Psa.Alg.is_rsa_oaep` and `Psa.Mac.max_size`, they
  were returning garbage. Thanks to Anil Madhavapeddy for the report
  and the fix.

- Fix `Psa.Key_agreement.raw_output_size` returning garbage due to a
  `Val_long` used instead of `Long_val`. Thanks to Anil Madhavapeddy
  for the report and the fix.

- Fix `Psa.Key_lifetime.from_persistaence_and_location`, the components
  were combined with `logand` instead of `logor`. Thanks to Anil
  Madhavapeddy for the report and the fix.

- Fix `Psa.Aead.decrypt` stub in bytecode, it was calling the `encrypt`
  stub. Thanks to Anil Madhavapeddy for the report and the fix.

- Fix `Psa.Key_type.is_{public_key,key_pair}`. They were implemented
  as `is_assymetric`. Thanks to Anil Madhavapeddy for the report and
  the fix.

- Fix `Psa.Status.message` have a user friendly message for
  `Error.{insufficient_entropy,invalid_padding}`. Thanks to Anil
  Madhavapeddy for the report and the fix.

- Fix `Psa.Alg.pp`, `SHA3-512` was printed as `SHA3-256`. to Anil
  Madhavapeddy for the report and the fix.

- Fix `Psa.Key_type.pp` DH key-pairs where printed as an unknown key type.
  Thanks to Anil Madhavapeddy for the report and the fix.

- Rename inexisting name `Psa.Alg.cbc` to `Psa.Alg.cmac`. Thanks to Anil
  Madhavapeddy for the report and the fix.

### `Bytesrw_tls`

- Fix `Bytesrw_tls` reader and writer, reading and writing beyond slice
  lengths. Thanks to Anil Madhavapeddy for the report and the fix.

- Fix `Bytesrw_tls.X509_certchain.{self_signed,ca_signed}` memory leak.
  Thanks to Anil Madhavapeddy for the report and the fix.

- Fix `Bytesrw_tls.X509_certchain.Private_key.write_pem_file`. The C
  function handling the write was not zeroing a temporary stack
  allocated buffer holding the private key. Thanks to Anil
  Madhavapeddy for the report.

### `Bytesrw_zlib`

- Improve `Bytesrw_zlib` error reporting. Thanks to Anil Madhavapeddy for
  the fix.

- Fix `Bytesrw_zlib.{Deflate,Zlib,Ggzip}.decompress_writes` position error
  reporting. The reported positions were in the decompressed stream rather
  than in the compressed stream. Thanks to Anil Madhavapeddy for the report.

- Fix `Bytesrw_zlib.Gzip.decompress_writes` accepting a truncated last 
  member intead of erroring. Thanks to Anil Madhavapeddy for the report 
  and the fix.

---

Use `b0 -- .opam publish bytesrw.0.4.1` to update the pull request.