### PR TITLE
ppx_interact.0.2.0 needs OCaml < 5.4

### DIFF
--- a/packages/ppx_interact/ppx_interact.0.2.0/opam
+++ b/packages/ppx_interact/ppx_interact.0.2.0/opam
@@ -8,7 +8,7 @@ homepage: "https://github.com/dariusf/ppx_interact"
 bug-reports: "https://github.com/dariusf/ppx_interact/issues"
 depends: [
   "dune" {>= "3.7"}
-  "ocaml" {>= "4.14"}
+  "ocaml" {>= "4.14" & < "5.4" }
   "cppo" {build}
   "ppxlib" {>= "0.36.0"}
   "linenoise" {>= "1.4.0"}


### PR DESCRIPTION
The library touches Typedtree and doesn't compile. The error is:

> File "runtime/ppx_interact_runtime.ml", line 231, characters 38-42:
  231 |             (get_required_label "loc" args, get_required_label "values" args)
                                             ^^^^
  Error: The value args has type
          (Asttypes.arg_label * Typedtree.apply_arg) list
        but an expression was expected of type
          (Asttypes.arg_label * 'a option) list
        Type
          Typedtree.apply_arg =
            (Typedtree.expression, unit) Typedtree.arg_or_omitted
        is not compatible with type 'a option