### PR TITLE
mlmpfr: add ci-accept-failures about new GCC 14

### DIFF
--- a/packages/mlmpfr/mlmpfr.4.2.1/opam
+++ b/packages/mlmpfr/mlmpfr.4.2.1/opam
@@ -23,6 +23,8 @@ x-ci-accept-failures: [
 	"debian-13"
 	"debian-testing"
 	"debian-unstable"
+	"debian-12"
+	"ubuntu-22.04"
 	"ubuntu-25.04"
 	"ubuntu-25.10"
 	"ubuntu-26.04"
@@ -34,9 +36,17 @@ x-ci-accept-failures: [
   "opensuse-16.0"
   "centos-10"
   "opensuse-tumbleweed"
+  "centos-9"
 ]
 post-messages: [
   "This version of mlmpfr requires MPFR >= 4.2.1 installed on your system." {failure}
+  "Debian 12 has libmpfr-dev = 4.2.0." {failure &
+    ( os-distribution = "debian" & os-version = "12" )
+  }
+  "Ubuntu 22.04 and Centos 9 has libmpfr-dev = 4.1.0." {failure &
+    ( os-distribution = "ubuntu" & os-version = "22.04"
+    | os-distribution = "centos" & os-version = "9" )
+  }
 ]
 synopsis: "OCaml C bindings for MPFR >= 4.2.1"
 url {

--- a/packages/mlmpfr/mlmpfr.4.2.1/opam
+++ b/packages/mlmpfr/mlmpfr.4.2.1/opam
@@ -18,7 +18,23 @@ depends: [
   "conf-mpfr"
   "odoc" {with-doc}
 ]
-x-ci-accept-failures: ["debian-unstable"]
+x-ci-accept-failures: [
+  "debian-unstable"
+	"debian-13"
+	"debian-testing"
+	"debian-unstable"
+	"ubuntu-25.04"
+	"ubuntu-25.10"
+	"ubuntu-26.04"
+  "alpine-3.23"
+  "archlinux"
+  "fedora-42"
+  "fedora-43"
+  "fedora-44"
+  "opensuse-16.0"
+  "centos-10"
+  "opensuse-tumbleweed"
+]
 post-messages: [
   "This version of mlmpfr requires MPFR >= 4.2.1 installed on your system." {failure}
 ]


### PR DESCRIPTION
Error is:

> implicit declaration of function 'atomic_load_acquire' [-Wimplicit-function-declaration]
   221 |   return atomic_load_acquire(&latch->value) == Latch_released;