### PR TITLE
openai-gym: Schedule for archival

### DIFF
--- a/packages/openai-gym/openai-gym.0.01/opam
+++ b/packages/openai-gym/openai-gym.0.01/opam
@@ -40,3 +40,5 @@ url {
     "md5=e74f45cdf57969d4758b9d40274cb7a4"
   ]
 }
+
+x-maintenance-intent: ["(none)"]


### PR DESCRIPTION
The package is not compilable on 4.11 and not available on newer versions (according to [1]). Also upstream library [2] is archived. I think it is a good idea to archive this

CI error for OCaml 4.11 is:  Library "atdgen" not found. No idea why because opam dependecy is present.

CC @mandel

[1]: https://check.ci.ocaml.org/?comp=4.11&comp=4.14&comp=5.2&comp=5.4&comp=5.5&available=4.11&available=4.14&available=5.2&available=5.4&available=5.5&show-only=bad&show-latest-only=true&packages=openai-gym&maintainers=&logsearch=&logsearch_comp=4.11

[2]: https://github.com/openai/gym