### PR TITLE
named-pipe: Fix compilation on 4.11: cmdliner <= "1.0.4"

### DIFF
--- a/packages/named-pipe/named-pipe.0.4.0/opam
+++ b/packages/named-pipe/named-pipe.0.4.0/opam
@@ -22,7 +22,7 @@ depends: [
   "base-bytes"
   "lwt" {>= "2.4.7" & < "5.0.0"}
   "base-unix"
-  "cmdliner"
+  "cmdliner" { <= "1.0.4" }
   "alcotest" {with-test & >= "0.4.0"}
 ]
 synopsis: "Bindings for named pipes"
@@ -39,3 +39,4 @@ url {
   ]
 }
 flags: deprecated
+x-maintenance-intent: ["(none)"]


### PR DESCRIPTION
This package is already deprecated but not being archived by default. I added maintenance-intent: none. For newer compilers it is already counted as unavailable

Error was:

> File "src/pipecat.ml", line 115, characters 8-12:
 115 |   Term.(pure main $ listen $ echo $ path),
               ^^^^
 Error: Unbound value pure